### PR TITLE
Override admin set policies

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -1,0 +1,238 @@
+# Overriding actor to allow admins to override admin set embargo permissions
+module Hyrax
+  module Actors
+    class InterpretVisibilityActor < AbstractActor
+      class Intention
+        def initialize(attributes)
+          @attributes = attributes
+        end
+
+        # returns a copy of attributes with the necessary params removed
+        # If the lease or embargo is valid, or if they selected something besides lease
+        # or embargo, remove all the params.
+        def sanitize_params
+          if valid_lease?
+            sanitize_lease_params
+          elsif valid_embargo?
+            sanitize_embargo_params
+          elsif !wants_lease? && !wants_embargo?
+            sanitize_unrestricted_params
+          else
+            @attributes
+          end
+        end
+
+        def wants_lease?
+          visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
+        end
+
+        def wants_embargo?
+          visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+        end
+
+        def valid_lease?
+          wants_lease? && @attributes[:lease_expiration_date].present?
+        end
+
+        def valid_embargo?
+          wants_embargo? && @attributes[:embargo_release_date].present?
+        end
+
+        def lease_params
+          [:lease_expiration_date,
+           :visibility_during_lease,
+           :visibility_after_lease].map { |key| @attributes[key] }
+        end
+
+        def embargo_params
+          [:embargo_release_date,
+           :visibility_during_embargo,
+           :visibility_after_embargo].map { |key| @attributes[key] }
+        end
+
+        private
+
+        def sanitize_unrestricted_params
+          @attributes.except(:lease_expiration_date,
+                             :visibility_during_lease,
+                             :visibility_after_lease,
+                             :embargo_release_date,
+                             :visibility_during_embargo,
+                             :visibility_after_embargo)
+        end
+
+        def sanitize_embargo_params
+          @attributes.except(:visibility,
+                             :lease_expiration_date,
+                             :visibility_during_lease,
+                             :visibility_after_lease)
+        end
+
+        def sanitize_lease_params
+          @attributes.except(:visibility,
+                             :embargo_release_date,
+                             :visibility_during_embargo,
+                             :visibility_after_embargo)
+        end
+
+        def visibility
+          @attributes[:visibility]
+        end
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        intention = Intention.new(env.attributes)
+        attributes = intention.sanitize_params
+        new_env = Environment.new(env.curation_concern, env.current_ability, attributes)
+        validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
+            next_actor.create(new_env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        intention = Intention.new(env.attributes)
+        attributes = intention.sanitize_params
+        new_env = Environment.new(env.curation_concern, env.current_ability, attributes)
+        validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
+            next_actor.update(new_env)
+      end
+
+      private
+
+      # Validate against selected AdminSet's PermissionTemplate (if any)
+      def validate(env, intention, attributes)
+        # If AdminSet was selected, look for its PermissionTemplate
+        # IMPORTANT: the schema for permission_templates table has changed in master!!!!!
+        # admin_set_id is now source_id
+        template = Hyrax::PermissionTemplate.find_by!(admin_set_id: attributes[:admin_set_id]) if attributes[:admin_set_id].present?
+
+        validate_lease(env, intention, template) &&
+            validate_release_type(env, intention, template) &&
+            validate_visibility(env, attributes, template) &&
+            validate_embargo(env, intention, attributes, template)
+      end
+
+      def apply_visibility(env, intention)
+        result = apply_lease(env, intention) && apply_embargo(env, intention)
+        env.curation_concern.visibility = env.attributes[:visibility] if env.attributes[:visibility]
+        result
+      end
+
+      # Validate that a lease is allowed by AdminSet's PermissionTemplate
+      def validate_lease(env, intention, template)
+        return true unless intention.wants_lease?
+
+        # Leases are only allowable if a template doesn't require a release period or have any specific visibility requirement
+        # (Note: permission template release/visibility options do not support leases)
+        unless template.present? && (template.release_period.present? || template.visibility.present?)
+          return true if intention.valid_lease?
+          env.curation_concern.errors.add(:visibility, 'When setting visibility to "lease" you must also specify lease expiration date.')
+          return false
+        end
+
+        env.curation_concern.errors.add(:visibility, 'Lease option is not allowed by permission template for selected AdminSet.')
+        false
+      end
+
+      # Validate the selected release settings against template, checking for when embargoes/leases are not allowed
+      def validate_release_type(env, intention, template)
+        # It's valid as long as embargo is not specified when a template requires no release delays
+        return true unless intention.wants_embargo? && template.present? && template.release_no_delay?
+
+        env.curation_concern.errors.add(:visibility, 'Visibility specified does not match permission template "no release delay" requirement for selected AdminSet.')
+        false
+      end
+
+      # Validate visibility complies with AdminSet template requirements
+      def validate_visibility(env, attributes, template)
+        # NOTE: For embargo/lease, attributes[:visibility] will be nil (see sanitize_params), so visibility will be validated as part of embargo/lease
+        return true if attributes[:visibility].blank?
+
+        # Validate against template's visibility requirements
+        return true if validate_template_visibility(attributes[:visibility], template)
+
+        env.curation_concern.errors.add(:visibility, 'Visibility specified does not match permission template visibility requirement for selected AdminSet.')
+        false
+      end
+
+      # When specified, validate embargo is a future date that complies with AdminSet template requirements (if any)
+      def validate_embargo(env, intention, attributes, template)
+        return true unless intention.wants_embargo?
+
+        embargo_release_date = parse_date(attributes[:embargo_release_date])
+
+        # When embargo required, date must be in future AND matches any template requirements
+        return true if valid_future_date?(env, embargo_release_date) &&
+            valid_template_embargo_date?(env, embargo_release_date, template) &&
+            valid_template_visibility_after_embargo?(env, attributes, template)
+
+        env.curation_concern.errors.add(:visibility, 'When setting visibility to "embargo" you must also specify embargo release date.') if embargo_release_date.blank?
+        false
+      end
+
+      # Validate an date attribute is in the future
+      def valid_future_date?(env, date, attribute_name: :embargo_release_date)
+        return true if date.present? && date.future?
+
+        env.curation_concern.errors.add(attribute_name, "Must be a future date.")
+        false
+      end
+
+      # Validate an embargo date against permission template restrictions
+      def valid_template_embargo_date?(env, date, template)
+        # Added this to allow admins to override embargo settings in admin set
+        return true if env.current_ability.admin?
+
+        return true if template.blank?
+
+        # Validate against template's release_date requirements
+        return true if template.valid_release_date?(date)
+
+        env.curation_concern.errors.add(:embargo_release_date, "Release date specified does not match permission template release requirements for selected AdminSet.")
+        false
+      end
+
+      # Validate the post-embargo visibility against permission template requirements (if any)
+      def valid_template_visibility_after_embargo?(env, attributes, template)
+        # Validate against template's visibility requirements
+        return true if validate_template_visibility(attributes[:visibility_after_embargo], template)
+
+        env.curation_concern.errors.add(:visibility_after_embargo, "Visibility after embargo does not match permission template visibility requirements for selected AdminSet.")
+        false
+      end
+
+      # Validate that a given visibility value satisfies template requirements
+      def validate_template_visibility(visibility, template)
+        return true if template.blank?
+
+        template.valid_visibility?(visibility)
+      end
+
+      # Parse date from string. Returns nil if date_string is not a valid date
+      def parse_date(date_string)
+        datetime = Time.zone.parse(date_string) if date_string.present?
+        return datetime.to_date unless datetime.nil?
+        nil
+      end
+
+      # If they want a lease, we can assume it's valid
+      def apply_lease(env, intention)
+        return true unless intention.wants_lease?
+        env.curation_concern.apply_lease(*intention.lease_params)
+        return unless env.curation_concern.lease
+        env.curation_concern.lease.save # see https://github.com/samvera/hydra-head/issues/226
+      end
+
+      # If they want an embargo, we can assume it's valid
+      def apply_embargo(env, intention)
+        return true unless intention.wants_embargo?
+        env.curation_concern.apply_embargo(*intention.embargo_params)
+        return unless env.curation_concern.embargo
+        env.curation_concern.embargo.save # see https://github.com/samvera/hydra-head/issues/226
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_form_permission_embargo.html.erb
+++ b/app/views/hyrax/base/_form_permission_embargo.html.erb
@@ -1,0 +1,12 @@
+<%# Overriding partial from gem to fix problem with editing embargos and switching admin sets %>
+<div class="form-inline">
+  <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+  <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+  <%= f.input :embargo_release_date, wrapper: :inline, input_html: { value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker' } %>
+  <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+  <%# Added here and in PR #2810 on github %>
+  <% if defined? f.object.admin_set_id %>
+    <%= f.hidden_field :admin_set_id, value: f.object.admin_set_id %>
+  <% end %>
+  <%# end of changes %>
+</div>

--- a/app/views/hyrax/base/_form_relationships.html.erb
+++ b/app/views/hyrax/base/_form_relationships.html.erb
@@ -17,7 +17,7 @@
               input_html: { class: 'form-control' } %>
   <% else %>
   <%= f.input :admin_set_id, as: :hidden,
-              input_html: { class: 'form-control', value: admin_set_id },
+              input_html: { class: 'form-control', value: admin_set_id[1] },
               readonly: true %>
   <% end%>
 <% end %>

--- a/app/views/hyrax/base/_form_relationships.html.erb
+++ b/app/views/hyrax/base/_form_relationships.html.erb
@@ -1,22 +1,25 @@
 <%# Overriding partial in hyrax gem in order to auto-select an admin set %>
 <% if Flipflop.assign_admin_set? %>
+  <% if f.object.model.title.blank? %>
+    <% admin_set_id = AdminSetSelectService.select(f.object.model.class.to_s,
+                                                   params[:affiliation],
+                                                   Hyrax::AdminSetOptionsPresenter
+                                                       .new(Hyrax::AdminSetService.new(controller)).select_options)
+    %>
+  <% else %>
+    <% admin_set_id = f.object.model.admin_set_id %>
+  <% end %>
   <% if current_user.admin? %>
   <%= f.input :admin_set_id, as: :select,
-              selected: AdminSetSelectService.select(f.object.model.class.to_s, params[:affiliation],
-                                                     Hyrax::AdminSetOptionsPresenter
-                                                         .new(Hyrax::AdminSetService.new(controller)).select_options),
+              selected: admin_set_id,
               include_blank: true,
               collection: Hyrax::AdminSetOptionsPresenter.new(Hyrax::AdminSetService.new(controller)).select_options,
               input_html: { class: 'form-control' } %>
-    <% else %>
-    <%= f.input :admin_set_id, as: :hidden,
-                input_html: { class: 'form-control',
-                              value: AdminSetSelectService.select(f.object.model.class.to_s, params[:affiliation],
-                                                                  Hyrax::AdminSetOptionsPresenter
-                                                                      .new(Hyrax::AdminSetService.new(controller))
-                                                                      .select_options)[1] },
-                readonly: true %>
-    <% end%>
+  <% else %>
+  <%= f.input :admin_set_id, as: :hidden,
+              input_html: { class: 'form-control', value: admin_set_id },
+              readonly: true %>
+  <% end%>
 <% end %>
 
 <%= render 'form_in_works', f: f %>

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set 'js: true'
+RSpec.feature 'Edit a work', js: false do
+  context 'a logged in user' do
+    let(:admin_user) do
+      User.find_by_user_key('admin@example.com')
+    end
+
+    let(:admin_set) do
+      AdminSet.create(title: ['article admin set'],
+                      description: ['some description'],
+                      edit_users: [admin_user.user_key])
+    end
+
+    let(:other_admin_set) do
+      AdminSet.create(title: ['other admin set'],
+                      description: ['some description'],
+                      edit_users: [admin_user.user_key])
+    end
+
+    let(:permission_template) do
+      Hyrax::PermissionTemplate.create!(admin_set_id: admin_set.id)
+    end
+
+    let(:other_permission_template) do
+      Hyrax::PermissionTemplate.create!(admin_set_id: other_admin_set.id)
+    end
+
+    let(:workflow) do
+      Sipity::Workflow.create(name: 'test', allows_access_grant: true, active: true,
+                              permission_template_id: permission_template.id)
+    end
+
+    let(:other_workflow) do
+      Sipity::Workflow.create(name: 'test2', allows_access_grant: true, active: true,
+                              permission_template_id: other_permission_template.id)
+    end
+
+    before do
+      Hyrax::PermissionTemplateAccess.create(permission_template: permission_template,
+                                             agent_type: 'user',
+                                             agent_id: admin_user.user_key,
+                                             access: 'deposit')
+      Hyrax::PermissionTemplateAccess.create(permission_template: other_permission_template,
+                                             agent_type: 'user',
+                                             agent_id: admin_user.user_key,
+                                             access: 'deposit')
+      Sipity::WorkflowAction.create(id: 4, name: 'show', workflow_id: workflow.id)
+      Sipity::WorkflowAction.create(id: 5, name: 'show', workflow_id: other_workflow.id)
+      DefaultAdminSet.delete_all
+      DefaultAdminSet.create(work_type_name: 'Article', admin_set_id: admin_set.id)
+    end
+
+    scenario 'as an admin' do
+      login_as admin_user
+
+      visit new_hyrax_article_path
+      expect(page).to have_content 'Add New Article'
+
+      fill_in 'Title', with: 'Test Article work'
+      fill_in 'Creator', with: 'Test Default Creator'
+      fill_in 'Keyword', with: 'Test Default Keyword'
+      select 'In Copyright', :from => 'article_rights_statement'
+      choose 'article_visibility_open'
+      check 'agreement'
+
+      click_link 'Files' # switch tab
+      within '//span[@id=addfiles]' do
+        attach_file('files[]', File.join(Rails.root, '/spec/fixtures/files/test.txt'))
+      end
+
+      click_link 'Relationships'
+      expect(page).to have_content 'Add as member of administrative set'
+      find('#article_admin_set_id').text eq 'article admin set'
+      find('#article_admin_set_id').select 'other admin set'
+
+      click_button 'Save'
+      expect(page).to have_content 'Your files are being processed by Hyrax'
+
+      visit '/dashboard/my/works/'
+      expect(page).to have_content 'Test Article work'
+
+      first('.document-title', text: 'Test Article work').click
+      expect(page).to have_content 'Test Default Keyword'
+      expect(page).to have_content 'In Administrative Set: other admin set'
+      expect(page).to have_selector(:link, 'Delete')
+
+      click_link 'Edit'
+      # Make sure that default admin set selector does not overwrite saved value
+      find('#article_admin_set_id').text eq 'other admin set'
+    end
+  end
+end

--- a/spec/features/set_embargo_spec.rb
+++ b/spec/features/set_embargo_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set 'js: true'
+RSpec.feature 'Edit embargo', js: false do
+  context 'a logged in user' do
+    let(:user) do
+      User.new(email: 'test@example.com',guest: false) { |u| u.save!(validate: false)}
+    end
+
+    let(:admin_user) do
+      User.find_by_user_key('admin@example.com')
+    end
+
+    let(:admin_set) do
+      AdminSet.create(title: ['article admin set'],
+                      description: ['some description'],
+                      edit_users: [user.user_key])
+    end
+
+    let(:permission_template) do
+      Hyrax::PermissionTemplate.create!(admin_set_id: admin_set.id, release_period: '6mos')
+    end
+
+    let(:workflow) do
+      Sipity::Workflow.create(name: 'test', allows_access_grant: true, active: true,
+                              permission_template_id: permission_template.id)
+    end
+
+    before do
+      Hyrax::PermissionTemplateAccess.create(permission_template: permission_template,
+                                             agent_type: 'user',
+                                             agent_id: user.user_key,
+                                             access: 'deposit')
+      Hyrax::PermissionTemplateAccess.create(permission_template: permission_template,
+                                             agent_type: 'user',
+                                             agent_id: admin_user.user_key,
+                                             access: 'deposit')
+      Sipity::WorkflowAction.create(id: 4, name: 'show', workflow_id: workflow.id)
+      DefaultAdminSet.create(work_type_name: 'Article', admin_set_id: admin_set.id)
+    end
+
+    scenario 'as a non-admin with an invalid release date' do
+      login_as user
+
+      visit new_hyrax_article_path
+      expect(page).to have_content 'Add New Article'
+
+      fill_in 'Title', with: 'Test Article work'
+      fill_in 'Creator', with: 'Test Default Creator'
+      fill_in 'Keyword', with: 'Test Default Keyword'
+      select 'In Copyright', :from => 'article_rights_statement'
+      choose 'article_visibility_embargo'
+      check 'agreement'
+
+      click_link 'Files' # switch tab
+      within '//span[@id=addfiles]' do
+        attach_file('files[]', File.join(Rails.root, '/spec/fixtures/files/test.txt'))
+      end
+
+      click_link 'Relationships'
+      expect(page).to_not have_content 'Add as member of administrative set'
+
+      fill_in 'article_embargo_release_date', with: DateTime.now+7.months
+      click_button 'Save'
+      expect(page).to have_content 'Embargo release date Release date specified does not match permission template release requirements for selected AdminSet'
+
+      # Hyrax empties the form
+      fill_in 'Title', with: 'Test Article work'
+      fill_in 'Creator', with: 'Test Default Creator'
+      fill_in 'Keyword', with: 'Test Default Keyword'
+      select 'In Copyright', :from => 'article_rights_statement'
+      choose 'article_visibility_embargo'
+      check 'agreement'
+
+      click_link 'Files' # switch tab
+      within '//span[@id=addfiles]' do
+        attach_file('files[]', File.join(Rails.root, '/spec/fixtures/files/test.txt'))
+      end
+
+      fill_in 'article_embargo_release_date', with: DateTime.now+5.months
+      click_button 'Save'
+      expect(page).to have_content 'Your files are being processed by Hyrax'
+
+      visit '/dashboard/my/works/'
+      expect(page).to have_content 'Test Article work'
+
+      first('.document-title', text: 'Test Article work').click
+      expect(page).to have_content 'Unauthorized The page you have tried to access is private'
+    end
+
+    scenario 'as an admin with an invalid release date' do
+      login_as admin_user
+
+      visit new_hyrax_article_path
+      expect(page).to have_content 'Add New Article'
+
+      fill_in 'Title', with: 'Test Article work'
+      fill_in 'Creator', with: 'Test Default Creator'
+      fill_in 'Keyword', with: 'Test Default Keyword'
+      select 'In Copyright', :from => 'article_rights_statement'
+      choose 'article_visibility_embargo'
+      check 'agreement'
+
+      click_link 'Files' # switch tab
+      within '//span[@id=addfiles]' do
+        attach_file('files[]', File.join(Rails.root, '/spec/fixtures/files/test.txt'))
+      end
+
+      click_link 'Relationships'
+      expect(page).to have_content 'Add as member of administrative set'
+      find('#article_admin_set_id').text eq 'article admin set'
+
+      click_button 'Save'
+      expect(page).to have_content 'Your files are being processed by Hyrax'
+
+      visit '/dashboard/my/works/'
+      expect(page).to have_content 'Test Article work'
+
+      first('.document-title', text: 'Test Article work').click
+      expect(page).to have_content 'Test Default Keyword'
+      expect(page).to have_content 'In Administrative Set: article admin set'
+      expect(page).to have_selector(:link, 'Delete')
+      expect(page).to have_content 'Embargo release date '+(DateTime.now+1.day).humanize
+
+      click_link 'Edit'
+      fill_in 'article_embargo_release_date', with: DateTime.now+7.months
+      click_button 'Save'
+      expect(page).to have_content 'Test Default Keyword'
+      expect(page).to have_content 'In Administrative Set: article admin set'
+      expect(page).to have_content 'Embargo release date '+(DateTime.now+7.months).humanize
+    end
+  end
+end


### PR DESCRIPTION
I added a conditional checking if the current user is an admin in the interpret_visibility_actor file to allow the embargo release date restrictions from admin sets to be ignored.  I also found an error in the logic in the form_relationships file which reset the admin set to the default for the given work type even if an administrator had selected a different admin set.  I fixed that error here because I needed it working in order to test the override abilities.