### PR TITLE
Update production db config in database.yml for qa

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -83,6 +83,7 @@ test:
 #
 production:
   <<: *default
-  database: hyrax_production
+  database: hyrax
   username: hyrax
   password: <%= ENV['HYRAX_DATABASE_PASSWORD'] %>
+  url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
The database connection is a little different on QA, and we need to provide the correct db name and host in each environment.

Also need to add `DATABASE_URL: 'postgresql://localhost:5432'` variable to config/local_env.yml locally and `DATABASE_URL: 'postgresql://hamilton.libint.unc.edu:5432'` on QA.