### PR TITLE
Hyc-228 - Sign-in order and worktype visibility

### DIFF
--- a/app/assets/javascripts/unc_custom.js
+++ b/app/assets/javascripts/unc_custom.js
@@ -34,7 +34,7 @@ $(function() {
 
 
     // Only show student paper options in modal when clicking "Student Papers" link on homepage
-    (function visibleForms() {
+    function visibleForms() {
         var all_work_types = $('form.new-work-select .select-worktype');
 
         $('#student-papers-work-types').on('click', function() {
@@ -48,5 +48,11 @@ $(function() {
         $('.all-unc-work-types').on('click', function() {
             all_work_types.removeClass('hidden');
         });
-    })();
+    }
+    visibleForms();
+
+    // Make sure that form visibility gets set after page changes
+    $(document).on('turbolinks:load', function() {
+      visibleForms();
+    });
 });

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,13 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
 
+  # [hyc-override] Overriding default after_sign_in_path_for which only forwared to the dashboard
+  protected
+    def after_sign_in_path_for(resource)
+      direct_to = stored_location_for(resource) || request.env['omniauth.origin'] || root_path
+      Rails.logger.debug "After sign in, direct to: #{direct_to}"
+      direct_to
+    end
 
   protect_from_forgery with: :exception
   skip_after_action :discard_flash_if_xhr

--- a/app/controllers/masters_papers_controller.rb
+++ b/app/controllers/masters_papers_controller.rb
@@ -1,5 +1,7 @@
 class MastersPapersController < ApplicationController
 
+  before_action :authenticate_user!
+
   layout 'hyrax/dashboard'
 
   def department

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -1,9 +1,11 @@
+require 'cgi'
 # [devise-override] Overriding sessions controller to trigger shibboleth logout
 class OmniauthController < Devise::SessionsController
   def new
     # Rails.logger.debug "SessionsController#new: request.referer = #{request.referer}"
     if Rails.env.production? && (ENV['DATABASE_AUTH'] == 'false')
-      shib_login_url = ENV['SSO_LOGIN_PATH'] + "?target=#{user_shibboleth_omniauth_authorize_path}"
+      origin_param = CGI.escape("&origin=#{request.referer}")
+      shib_login_url = ENV['SSO_LOGIN_PATH'] + "?target=#{user_shibboleth_omniauth_authorize_path}#{origin_param}"
       redirect_to shib_login_url
     else
       super

--- a/app/presenters/hyrax/homepage_presenter.rb
+++ b/app/presenters/hyrax/homepage_presenter.rb
@@ -1,0 +1,45 @@
+module Hyrax
+  class HomepagePresenter
+    class_attribute :create_work_presenter_class
+    self.create_work_presenter_class = Hyrax::UnrestrictedSelectTypeListPresenter
+    attr_reader :current_ability, :collections
+
+    def initialize(current_ability, collections)
+      @current_ability = current_ability
+      @collections = collections
+    end
+
+    # @return [Boolean] If the current user is a guest and the display_share_button_when_not_logged_in?
+    #   is activated, then return true. Otherwise return true if the signed in
+    #   user has permission to create at least one kind of work.
+    def display_share_button?
+      (user_unregistered? && Hyrax.config.display_share_button_when_not_logged_in?) ||
+        current_ability.can_create_any_work?
+    end
+
+    # A presenter for selecting a work type to create
+    # this is needed here because the selector is in the header on every page
+    def create_work_presenter
+      @create_work_presenter ||= create_work_presenter_class.new(current_ability.current_user)
+    end
+
+    def create_many_work_types?
+      create_work_presenter.many?
+    end
+
+    def draw_select_work_modal?
+      display_share_button? && create_many_work_types?
+    end
+
+    def first_work_type
+      create_work_presenter.first_model
+    end
+
+    private
+
+      def user_unregistered?
+        current_ability.current_user.new_record? ||
+          current_ability.current_user.guest?
+      end
+  end
+end

--- a/app/presenters/hyrax/unrestricted_select_type_list_presenter.rb
+++ b/app/presenters/hyrax/unrestricted_select_type_list_presenter.rb
@@ -1,0 +1,8 @@
+module Hyrax
+  class UnrestrictedSelectTypeListPresenter < Hyrax::SelectTypeListPresenter
+    def authorized_models
+      Rails.logger.info "Getting unrestricted models"
+      @authorized_models ||= Hyrax::UnrestrictedClassificationQuery.new(@current_user).authorized_models
+    end
+  end
+end

--- a/app/services/hyrax/unrestricted_classification_query.rb
+++ b/app/services/hyrax/unrestricted_classification_query.rb
@@ -1,0 +1,8 @@
+module Hyrax
+  class UnrestrictedClassificationQuery < Hyrax::QuickClassificationQuery
+    # @return [Array] a list of all the requested concerns
+    def authorized_models
+      normalized_model_names.select
+    end
+  end
+end

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -6,7 +6,7 @@
           <%= link_to t(:'hyrax.links.collections'), main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}) %></li>
         <li <%= 'class=active' if current_page?(hyrax.root_path) %>>
           <%= link_to t(:'hyrax.links.departments'), main_app.facet_catalog_path(id: 'affiliation_sim') %></li>
-          <li>
+          <li data-turbolinks="false">
             <% if user_signed_in? %>
               <%= link_to '#', class: 'all-unc-work-types',
                              data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -7,17 +7,10 @@
         <li <%= 'class=active' if current_page?(hyrax.root_path) %>>
           <%= link_to t(:'hyrax.links.departments'), main_app.facet_catalog_path(id: 'affiliation_sim') %></li>
           <li data-turbolinks="false">
-            <% if user_signed_in? %>
-              <%= link_to '#', class: 'all-unc-work-types',
-                             data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-                <i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
-                <%= t('hyrax.links.deposit') %>
-              <% end %>
-            <% else %>
-              <%= link_to main_app.new_user_session_path do %>
-                <i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
-                <%= t('hyrax.links.deposit') %>
-              <% end %>
+            <%= link_to '#', class: 'all-unc-work-types',
+                           data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
+              <i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
+              <%= t('hyrax.links.deposit') %>
             <% end %>
           </li>
       </ul><!-- /.nav -->

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -22,7 +22,7 @@
       </ul>
     </li><!-- /.btn-group -->
   <% else %>
-    <li>
+    <li data-turbolinks="false">
       <%= link_to main_app.new_user_session_path do %>
         <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
       <% end %>

--- a/app/views/hyrax/homepage/_unc_deposit.html.erb
+++ b/app/views/hyrax/homepage/_unc_deposit.html.erb
@@ -7,16 +7,9 @@
     <% end %>
   </div>
   <div class="col-sm-3 col-xs-6 unc-block" data-turbolinks="false">
-    <% if user_signed_in? %>
-      <%= link_to '#', id: 'student-papers-work-types',  data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-        <i class="fa fa-graduation-cap fa-5x" aria-hidden="true"></i>
-        <div><%= t('hyrax.deposit.student_paper') %></div>
-      <% end %>
-    <% else %>
-      <%= link_to main_app.new_user_session_path do %>
-        <i class="fa fa-graduation-cap fa-5x" aria-hidden="true"></i>
-        <div><%= t('hyrax.deposit.student_paper') %></div>
-      <% end %>
+    <%= link_to '#', id: 'student-papers-work-types',  data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
+      <i class="fa fa-graduation-cap fa-5x" aria-hidden="true"></i>
+      <div><%= t('hyrax.deposit.student_paper') %></div>
     <% end %>
   </div>
   <div class="col-sm-3 col-xs-6 unc-block">
@@ -26,16 +19,9 @@
     <% end %>
   </div>
   <div class="col-sm-3 col-xs-6 unc-block" data-turbolinks="false">
-    <% if user_signed_in? %>
-      <%= link_to  '#', class: 'all-unc-work-types', data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-        <i class="fa fa-upload fa-5x" aria-hidden="true"></i>
-        <div><%= t('hyrax.deposit.other') %></div>
-      <% end %>
-    <% else %>
-      <%= link_to main_app.new_user_session_path do %>
-        <i class="fa fa-upload fa-5x" aria-hidden="true"></i>
-        <div><%= t('hyrax.deposit.other') %></div>
-      <% end %>
+    <%= link_to  '#', class: 'all-unc-work-types', data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
+      <i class="fa fa-upload fa-5x" aria-hidden="true"></i>
+      <div><%= t('hyrax.deposit.other') %></div>
     <% end %>
   </div>
 </div>

--- a/app/views/hyrax/homepage/_unc_deposit.html.erb
+++ b/app/views/hyrax/homepage/_unc_deposit.html.erb
@@ -6,7 +6,7 @@
       <div><%= t('hyrax.deposit.article') %></div>
     <% end %>
   </div>
-  <div class="col-sm-3 col-xs-6 unc-block">
+  <div class="col-sm-3 col-xs-6 unc-block" data-turbolinks="false">
     <% if user_signed_in? %>
       <%= link_to '#', id: 'student-papers-work-types',  data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
         <i class="fa fa-graduation-cap fa-5x" aria-hidden="true"></i>
@@ -25,7 +25,7 @@
       <div><%= t('hyrax.deposit.dataset') %></div>
     <% end %>
   </div>
-  <div class="col-sm-3 col-xs-6 unc-block">
+  <div class="col-sm-3 col-xs-6 unc-block" data-turbolinks="false">
     <% if user_signed_in? %>
       <%= link_to  '#', class: 'all-unc-work-types', data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
         <i class="fa fa-upload fa-5x" aria-hidden="true"></i>

--- a/app/views/hyrax/homepage/_unc_masthead.html.erb
+++ b/app/views/hyrax/homepage/_unc_masthead.html.erb
@@ -10,7 +10,7 @@
     <ul class="list-unstyled pull-right">
       <li><div><%= link_to t('hyrax.links.browse_collections'), main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}) %></div></li>
       <li><div><%= link_to t(:'hyrax.links.departments'), main_app.facet_catalog_path(id: 'affiliation_sim') %></div></li>
-      <li><div><i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
+      <li><div data-turbolinks="false"><i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
         <% if user_signed_in? %>
           <%= link_to t('hyrax.links.deposit'), '#', class: 'all-unc-work-types',
                       data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } %>

--- a/app/views/hyrax/homepage/_unc_masthead.html.erb
+++ b/app/views/hyrax/homepage/_unc_masthead.html.erb
@@ -11,12 +11,8 @@
       <li><div><%= link_to t('hyrax.links.browse_collections'), main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}) %></div></li>
       <li><div><%= link_to t(:'hyrax.links.departments'), main_app.facet_catalog_path(id: 'affiliation_sim') %></div></li>
       <li><div data-turbolinks="false"><i class="fa fa-arrow-circle-up" aria-hidden="true"></i>
-        <% if user_signed_in? %>
-          <%= link_to t('hyrax.links.deposit'), '#', class: 'all-unc-work-types',
-                      data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } %>
-        <% else %>
-          <%= link_to t('hyrax.links.deposit'), main_app.new_user_session_path %>
-        <% end %>
+        <%= link_to t('hyrax.links.deposit'), '#', class: 'all-unc-work-types',
+                    data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } %>
       </div></li>
     </ul>
   </div>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -38,4 +38,4 @@
   <%#= render 'home_content' %>
 </div>
 -->
-<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter %>

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -8,7 +8,7 @@
       </div>
       <div class="modal-body">
         <% create_work_presenter.each do |row_presenter| %>
-          <% unless row_presenter.concern.to_s == 'Dissertation' && !current_user.admin? %>
+          <% if row_presenter.concern.to_s != 'Dissertation' || (current_user && current_user.admin?) %>
           <div class="select-worktype">
             <label>
               <% if row_presenter.concern.to_s == 'MastersPaper' %>

--- a/spec/controllers/masters_papers_controller_spec.rb
+++ b/spec/controllers/masters_papers_controller_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 RSpec.describe MastersPapersController, type: :controller do
 
   describe "GET #department" do
+    let(:user) do
+      User.new(email: 'test@example.com', guest: false, uid: 'test@example.com') { |u| u.save!(validate: false)}
+    end
+    
+    before do
+      sign_in user
+    end
+    
     it "returns http success" do
       get :department
       expect(response).to have_http_status(:success)

--- a/spec/presenters/hyrax/unrestricted_select_type_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/unrestricted_select_type_list_presenter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+# Note: test app generates multiple work types (concerns) now
+RSpec.describe Hyrax::UnrestrictedSelectTypeListPresenter do
+  let(:instance) { described_class.new(user) }
+  let(:user) { nil }
+
+  describe "#many?" do
+    subject { instance.many? }
+
+    context 'without a logged in user' do
+      it { is_expected.to be true }
+
+      context "if user is nil" do
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'with a logged in user' do
+      let(:user) do
+        User.new(email: 'test@example.com', guest: false, uid: 'test@example.com') { |u| u.save!(validate: false)}
+      end
+
+      it { is_expected.to be true }
+      context "if authorized_models returns only one" do
+        before do
+          allow(instance).to receive(:authorized_models).and_return([double])
+        end
+        it { is_expected.to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Users forwarded to the page they requested or were on when they are prompted to log in to shibboleth.
* Modals for selecting worktype to deposit display options prior to logging in
* After selecting a worktype, the user will be prompted to log in and then sent to form
* Fixes issue where student papers modal displayed the full set of worktypes after visiting any page other than the front page.

This involved disabling turbolinks for login links, overriding hyrax default post-sign-in page, and passing `origin` parameter to shibboleth.