### PR TITLE
Hyc-225 - Requests/Tombstones for all workflows

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -15,9 +15,6 @@
           <input class="btn btn-danger" type="submit" value="Tombstone">
         <% end %>
       <% end %>
-    <% elsif @presenter.workflow.actions.present? &&
-        !@presenter.workflow.actions.select{|action| action[0] == 'request_deletion'}.blank? %>
-      <button class="btn btn-danger" data-toggle="modal" data-target="#deletion-request-modal">Request Deletion</button>
     <% end %>
     <%# Changes end here %>
     <% if presenter.member_presenters.size > 1 %>
@@ -43,6 +40,10 @@
         </ul>
       </div>
     <% end %>
+  <% end %>
+  <% if @presenter.workflow.actions.present? &&
+      !@presenter.workflow.actions.select{|action| action[0] == 'request_deletion'}.blank? %>
+    <button class="btn btn-danger" data-toggle="modal" data-target="#deletion-request-modal">Request Deletion</button>
   <% end %>
   <% if presenter.work_featurable? %>
     <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),

--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -28,7 +28,9 @@
                     "methods": [
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
-                }, {"name": "request_deletion",
+                }, {
+                    "name": "request_deletion",
+                    "_comment" : "This action is suppressed from normal rendering with other review/approval actions",
                     "from_states": [{"names": ["deposited"], "roles": ["approving", "depositing"]}],
                     "transition_to": "pending_deletion",
                     "notifications": [

--- a/config/workflows/honors_thesis_deposit_workflow.json
+++ b/config/workflows/honors_thesis_deposit_workflow.json
@@ -83,7 +83,9 @@
                     "methods": [
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
-                }, {"name": "request_deletion",
+                }, {
+                    "name": "request_deletion",
+                    "_comment" : "This action is suppressed from default rendering with other review/approval actions",
                     "from_states": [{"names": ["deposited"], "roles": ["approving", "depositing"]}],
                     "transition_to": "pending_deletion",
                     "notifications": [

--- a/config/workflows/honors_thesis_deposit_workflow.json
+++ b/config/workflows/honors_thesis_deposit_workflow.json
@@ -69,6 +69,62 @@
                         { "names": ["pending_review", "deposited"], "roles": ["approving"] },
                         { "names": ["changes_required"], "roles": ["depositing"] }
                     ]
+                }, {
+                    "name": "tombstone",
+                    "from_states": [{"names": ["deposited"], "roles": ["approving"]}],
+                    "transition_to": "tombstoned",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DeletionApprovalNotification",
+                            "to": ["depositing"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::MetadataOnlyRecord"
+                    ]
+                }, {"name": "request_deletion",
+                    "from_states": [{"names": ["deposited"], "roles": ["approving", "depositing"]}],
+                    "transition_to": "pending_deletion",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingDeletionNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
+                    ]
+                }, {
+                    "name": "approve_deletion",
+                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "transition_to": "tombstoned",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DeletionApprovalNotification",
+                            "to": ["depositing"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::MetadataOnlyRecord"
+                    ]
+                }, {
+                    "name": "republish",
+                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "transition_to": "deposited",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DeletionRequestRejectionNotification",
+                            "to": ["depositing"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::GrantEditToDepositor",
+                        "Hyrax::Workflow::ActivateObject"
+                    ]
                 }
             ]
         }

--- a/config/workflows/mediated_deposit_workflow.json
+++ b/config/workflows/mediated_deposit_workflow.json
@@ -68,6 +68,62 @@
                         { "names": ["pending_review", "deposited"], "roles": ["approving"] },
                         { "names": ["changes_required"], "roles": ["depositing"] }
                     ]
+                }, {
+                    "name": "tombstone",
+                    "from_states": [{"names": ["deposited"], "roles": ["approving"]}],
+                    "transition_to": "tombstoned",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DeletionApprovalNotification",
+                            "to": ["depositing"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::MetadataOnlyRecord"
+                    ]
+                }, {"name": "request_deletion",
+                    "from_states": [{"names": ["deposited"], "roles": ["approving", "depositing"]}],
+                    "transition_to": "pending_deletion",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingDeletionNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
+                    ]
+                }, {
+                    "name": "approve_deletion",
+                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "transition_to": "tombstoned",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DeletionApprovalNotification",
+                            "to": ["depositing"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::MetadataOnlyRecord"
+                    ]
+                }, {
+                    "name": "republish",
+                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "transition_to": "deposited",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DeletionRequestRejectionNotification",
+                            "to": ["depositing"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::GrantEditToDepositor",
+                        "Hyrax::Workflow::ActivateObject"
+                    ]
                 }
             ]
         }

--- a/config/workflows/mediated_deposit_workflow.json
+++ b/config/workflows/mediated_deposit_workflow.json
@@ -82,7 +82,9 @@
                     "methods": [
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
-                }, {"name": "request_deletion",
+                }, {
+                    "name": "request_deletion",
+                    "_comment" : "This action is suppressed from normal rendering with other review/approval actions",
                     "from_states": [{"names": ["deposited"], "roles": ["approving", "depositing"]}],
                     "transition_to": "pending_deletion",
                     "notifications": [


### PR DESCRIPTION
* Adds requests to delete items to all workflows
* Adds tombstone option to all workflows for admins
* `Request Deletion` button available for users after edit options are removed by workflow

To deploy the workflow changes, `scl enable rh-ruby24 -- rails hyrax:workflow:load` must be run