### PR TITLE
Change branding image storage location

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -153,6 +153,9 @@ Hyrax.config do |config|
   # config.derivatives_path = Rails.root.join('tmp', 'derivatives')
   config.derivatives_path = ENV['DERIVATIVE_STORAGE']
 
+  # Store banner images in data storage directory
+  config.branding_path = ENV['DATA_STORAGE']+'/branding'
+
   # Should schema.org microdata be displayed?
   # config.display_microdata = true
 


### PR DESCRIPTION
* We do not want uploaded files to live inside the application directory on qa or prod