### PR TITLE
Restrict access for tombstones and tombstone requests.

### DIFF
--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -26,6 +26,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {
@@ -41,11 +42,12 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor"
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
+                        "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {
                     "name": "approve_deletion",
-                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "from_states": [{"names": ["deposited", "pending_deletion"], "roles": ["approving"]}],
                     "transition_to": "tombstoned",
                     "notifications": [
                         {
@@ -55,6 +57,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {

--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -25,9 +25,10 @@
                             "to": ["depositing", "managing"]
                         }
                     ],
+                    "_comment" : "MetadataOnlyRecord must be called before RevokeEditFromDepositor",
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "request_deletion",
@@ -42,8 +43,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "approve_deletion",
@@ -57,8 +58,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "republish",

--- a/config/workflows/honors_thesis_deposit_workflow.json
+++ b/config/workflows/honors_thesis_deposit_workflow.json
@@ -80,9 +80,10 @@
                             "to": ["depositing", "managing"]
                         }
                     ],
+                    "_comment" : "MetadataOnlyRecord must be called before RevokeEditFromDepositor",
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "request_deletion",
@@ -97,8 +98,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "approve_deletion",
@@ -112,8 +113,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "republish",

--- a/config/workflows/honors_thesis_deposit_workflow.json
+++ b/config/workflows/honors_thesis_deposit_workflow.json
@@ -81,6 +81,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {
@@ -96,11 +97,12 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor"
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
+                        "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {
                     "name": "approve_deletion",
-                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "from_states": [{"names": ["deposited", "pending_deletion"], "roles": ["approving"]}],
                     "transition_to": "tombstoned",
                     "notifications": [
                         {
@@ -110,6 +112,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {

--- a/config/workflows/mediated_deposit_workflow.json
+++ b/config/workflows/mediated_deposit_workflow.json
@@ -80,6 +80,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {
@@ -95,11 +96,12 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor"
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
+                        "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {
                     "name": "approve_deletion",
-                    "from_states": [{"names": ["pending_deletion"], "roles": ["approving"]}],
+                    "from_states": [{"names": ["deposited", "pending_deletion"], "roles": ["approving"]}],
                     "transition_to": "tombstoned",
                     "notifications": [
                         {
@@ -109,6 +111,7 @@
                         }
                     ],
                     "methods": [
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
                         "Hyrax::Workflow::MetadataOnlyRecord"
                     ]
                 }, {

--- a/config/workflows/mediated_deposit_workflow.json
+++ b/config/workflows/mediated_deposit_workflow.json
@@ -79,9 +79,10 @@
                             "to": ["depositing", "managing"]
                         }
                     ],
+                    "_comment" : "MetadataOnlyRecord must be called before RevokeEditFromDepositor",
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "request_deletion",
@@ -96,8 +97,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "approve_deletion",
@@ -111,8 +112,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::RevokeEditFromDepositor",
-                        "Hyrax::Workflow::MetadataOnlyRecord"
+                        "Hyrax::Workflow::MetadataOnlyRecord",
+                        "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
                     "name": "republish",


### PR DESCRIPTION
1. Revoke edit status if admin tombstones a record.
2. Prevents direct downloads of "Pending Deletion" records.
https://jira.lib.unc.edu/browse/HYC-239

