### PR TITLE
Show file page thumbnails for public works that haven't been withdrawn

### DIFF
--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,5 +1,5 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% if current_user&.admin? || (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) ) %>
   <h2><%= t('.header') %></h2>
   <%  array_of_ids = presenter.list_of_item_ids_to_display %>
   <%  members = presenter.member_presenters_for(array_of_ids) %>

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,5 +1,5 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || (!@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) && Hyrax.config.display_media_download_link?) %>
+<% if current_user&.admin? || (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])  && Hyrax.config.display_media_download_link?) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
@@ -13,7 +13,7 @@
                   target: :_blank,
                   id: "file_download" %>
     </div>
-<% elsif !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
     <div>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
@@ -21,4 +21,14 @@
         Your browser does not support the audio tag.
       </audio>
     </div>
+<% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+  <%# Display nothing %>
+<% else %>
+  <div>
+    <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
+      <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
+      <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
+      Your browser does not support the audio tag.
+    </audio>
+  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -13,7 +13,8 @@
                   target: :_blank,
                   id: "file_download" %>
     </div>
-<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif (presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])) ||
+    !@presenter.respond_to?('workflow') %>
     <div>
       <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
@@ -23,12 +24,4 @@
     </div>
 <% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
   <%# Display nothing %>
-<% else %>
-  <div>
-    <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
-      <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
-      <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
-      Your browser does not support the audio tag.
-    </audio>
-  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || (!@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) && Hyrax.config.display_media_download_link?) %>
+<% if current_user&.admin? ||
+    (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])  && Hyrax.config.display_media_download_link?) %>
   <div class="no-preview">
     <%= t('hyrax.works.show.no_preview') %>
       <p /><%= link_to t('hyrax.file_set.show.download'),

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -13,7 +13,8 @@
                   target: :_blank,
                   id: "file_download" %>
     </div>
-<% elsif @presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])) ||
+    !@presenter.respond_to?('workflow') %>
     <div>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",
@@ -22,11 +23,4 @@
     </div>
 <% elsif @presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
   <%# Display nothing %>
-<% else %>
-  <div>
-    <%= image_tag thumbnail_url(file_set),
-                  class: "representative-media",
-                  alt: "",
-                  role: "presentation" %>
-  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,5 +1,5 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || (!@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) &&
+<% if current_user&.admin? || (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])  &&
     Hyrax.config.display_media_download_link? && can?(:download, file_set.id)) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
@@ -13,11 +13,20 @@
                   target: :_blank,
                   id: "file_download" %>
     </div>
-<% elsif !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif @presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
     <div>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
     </div>
+<% elsif @presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+  <%# Display nothing %>
+<% else %>
+  <div>
+    <%= image_tag thumbnail_url(file_set),
+                  class: "representative-media",
+                  alt: "",
+                  role: "presentation" %>
+  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -13,7 +13,8 @@
                   id: "file_download",
                   data: { label: file_set.id } %>
     </div>
-<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif (presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])) ||
+    !@presenter.respond_to?('workflow') %>
     <div>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",
@@ -22,11 +23,4 @@
     </div>
 <% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
   <%# Display nothing %>
-<% else %>
-  <div>
-    <%= image_tag thumbnail_url(file_set),
-                  class: "representative-media",
-                  alt: "",
-                  role: "presentation" %>
-  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || (!@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) && Hyrax.config.display_media_download_link?) %>
+<% if current_user&.admin? ||
+    (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])  && Hyrax.config.display_media_download_link?) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),
@@ -12,11 +13,20 @@
                   id: "file_download",
                   data: { label: file_set.id } %>
     </div>
-<% elsif !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
     <div>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
     </div>
+<% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+  <%# Display nothing %>
+<% else %>
+  <div>
+    <%= image_tag thumbnail_url(file_set),
+                  class: "representative-media",
+                  alt: "",
+                  role: "presentation" %>
+  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -13,7 +13,8 @@
                   id: "file_download",
                   data: { label: file_set.id } %>
     </div>
-<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif (presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])) ||
+    !@presenter.respond_to?('workflow') %>
     <div>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",
@@ -22,11 +23,4 @@
     </div>
 <% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
   <%# Display nothing %>
-<% else %>
-  <div>
-    <%= image_tag thumbnail_url(file_set),
-                  class: "representative-media",
-                  alt: "",
-                  role: "presentation" %>
-  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || (!@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) && Hyrax.config.display_media_download_link?) %>
+<% if current_user&.admin? ||
+    (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])  && Hyrax.config.display_media_download_link?) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <%= image_tag thumbnail_url(file_set),
@@ -12,11 +13,20 @@
                   id: "file_download",
                   data: { label: file_set.id } %>
     </div>
-<% elsif !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
     <div>
       <%= image_tag thumbnail_url(file_set),
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
     </div>
+<% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+  <%# Display nothing %>
+<% else %>
+  <div>
+    <%= image_tag thumbnail_url(file_set),
+                  class: "representative-media",
+                  alt: "",
+                  role: "presentation" %>
+  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -14,7 +14,8 @@
                   target: :_blank,
                   id: "file_download" %>
     </div>
-<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif (presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion'])) ||
+    !@presenter.respond_to?('workflow') %>
     <div>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
@@ -24,12 +25,4 @@
     </div>
 <% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
   <%# Display nothing %>
-<% else %>
-  <div>
-    <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
-      <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
-      <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
-      Your browser does not support the video tag.
-    </video>
-  </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] Overriding to hide tombstoned files %>
-<% if (current_user&.admin?) || (!@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) && Hyrax.config.display_media_download_link?) %>
+<% if current_user&.admin? ||
+    (@presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) && Hyrax.config.display_media_download_link?) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
@@ -13,7 +14,7 @@
                   target: :_blank,
                   id: "file_download" %>
     </div>
-<% elsif !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+<% elsif presenter.respond_to?('workflow') && !@presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
     <div>
       <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
         <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
@@ -21,4 +22,14 @@
         Your browser does not support the video tag.
       </video>
     </div>
+<% elsif presenter.respond_to?('workflow') && @presenter.workflow.in_workflow_state?(['withdrawn', 'pending deletion']) %>
+  <%# Display nothing %>
+<% else %>
+  <div>
+    <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+      <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+      <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+      Your browser does not support the video tag.
+    </video>
+  </div>
 <% end %>


### PR DESCRIPTION
State doesn't persist onto file pages, and only seems to exist in the context of a workflow. This should show/hide files correctly. The only exception is the file owner can still see thumbnails with a direct link to the files page, which is maybe okay.