### PR TITLE
Remove url field from solr doc. Not used in any form

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -268,10 +268,6 @@ class SolrDocument
     self[Solrizer.solr_name('translator')]
   end
 
-  def url
-    self[Solrizer.solr_name('url')]
-  end
-
   def use
     self[Solrizer.solr_name('use')]
   end

--- a/app/presenters/hyrax/honors_thesis_presenter.rb
+++ b/app/presenters/hyrax/honors_thesis_presenter.rb
@@ -5,6 +5,6 @@ module Hyrax
     delegate :abstract, :academic_concentration, :access, :advisor, :affiliation, :affiliation_label,
              :alternative_title, :award, :date_issued, :dcmi_type, :degree, :degree_granting_institution,
              :deposit_record, :doi, :extent, :geographic_subject, :graduation_year, :language_label, :license_label,
-             :note, :orcid, :rights_statement_label, :url, :use, to: :solr_document
+             :note, :orcid, :rights_statement_label, :use, to: :solr_document
   end
 end


### PR DESCRIPTION
Small addition to the normalizing label names pull request. This is another place where 'url' field needs to be removed