### PR TITLE
Allow users to search for users to share with

### DIFF
--- a/app/controllers/hyrax/users_controller.rb
+++ b/app/controllers/hyrax/users_controller.rb
@@ -1,9 +1,11 @@
 # [hyc-override] Overriding users controller to restrict user profiles to admins
+# [hyc-override] Overriding to restrict index to authenticated users. Needed to search for users for sharing
 module Hyrax
   class UsersController < ApplicationController
     include Blacklight::SearchContext
     prepend_before_action :find_user, only: [:show]
-    before_action :ensure_admin! # [hyc-override] Overriding to restrict user profiles to admins
+    before_action :ensure_admin!, except: [:index] # [hyc-override] Overriding to restrict user profiles to admins
+    before_action :authenticate_user! # [hyc-override] Overriding to restrict index to authenticated users. Needed to search for users
 
     helper Hyrax::TrophyHelper
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-350 
Allow authenticated users to see user list. Needed for depositors to search for users to share with.