### PR TITLE
Remove deprecated human_readable_type method

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,8 +8,6 @@ class Article < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Scholarly Article or Book Chapter'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -8,8 +8,6 @@ class Artwork < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Artwork'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -8,8 +8,6 @@ class DataSet < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Dataset'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/dissertation.rb
+++ b/app/models/dissertation.rb
@@ -8,8 +8,6 @@ class Dissertation < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Dissertation or Thesis'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/general.rb
+++ b/app/models/general.rb
@@ -8,8 +8,6 @@ class General < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'General'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/honors_thesis.rb
+++ b/app/models/honors_thesis.rb
@@ -8,8 +8,6 @@ class HonorsThesis < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Undergraduate Honors Thesis'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -8,8 +8,6 @@ class Journal < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Scholarly Journal, Newsletter or Book'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/masters_paper.rb
+++ b/app/models/masters_paper.rb
@@ -8,8 +8,6 @@ class MastersPaper < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = "Master's Paper"
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/multimed.rb
+++ b/app/models/multimed.rb
@@ -8,8 +8,6 @@ class Multimed < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Multimedia'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/app/models/scholarly_work.rb
+++ b/app/models/scholarly_work.rb
@@ -8,8 +8,6 @@ class ScholarlyWork < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.human_readable_type = 'Poster, Presentation or Paper'
-
   property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
     index.as :stored_searchable
   end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,4 +1,16 @@
 en:
+  activefedora:
+    models:
+      article: 'Scholarly Article or Book Chapter'
+      artwork: 'Artwork'
+      data_set: 'Dataset'
+      dissertation: 'Dissertation or Thesis'
+      general: 'General'
+      honors_thesis: 'Undergraduate Honors Thesis'
+      journal: 'Scholarly Journal, Newsletter or Book'
+      masters_paper: "Master's Paper"
+      multimed: 'Multimedia'
+      scholarly_work: 'Poster, Presentation or Paper'
   blacklight:
     search:
       fields:


### PR DESCRIPTION
This will remove deprecation warnings from the logs like: 
```DEPRECATION WARNING: human_readable_type= is deprecated and will be removed from a future release (human_readable_type is deprecated. Set the i18n key for activefedora.models.#{model_name.i18n_key} instead. This will be removed in Hyrax 3). (called from <class:Artwork> at /hyrax/app/models/artwork.rb:11)```