### PR TITLE
Hide panel from non-admins if the workflow action is withdraw

### DIFF
--- a/app/presenters/hyrax/workflow_presenter.rb
+++ b/app/presenters/hyrax/workflow_presenter.rb
@@ -21,7 +21,7 @@ module Hyrax
 
     # Returns an array of tuples (key, label) appropriate for a radio group
     def actions
-      return [] unless sipity_entity && current_ability
+      return [] unless sipity_entity && current_ability && (current_ability.current_user.admin? || state != 'pending_deletion')
       actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(entity: sipity_entity, user: current_ability.current_user)
       actions.map { |action| [action.name, action_label(action)] }
     end


### PR DESCRIPTION
Hide panel from non-admins if the workflow action is to withdraw/delete the work.
https://jira.lib.unc.edu/browse/HYC-447