### PR TITLE
HYC-470 - Migration recoverability

### DIFF
--- a/lib/tasks/migrate/migrate.rake
+++ b/lib/tasks/migrate/migrate.rake
@@ -11,7 +11,7 @@ namespace :migrate do
   require 'tasks/migration_helper'
 
   desc 'batch migrate records from FOXML file'
-  task :works, [:collection, :configuration_file, :mapping_file] => :environment do |t, args|
+  task :works, [:collection, :configuration_file, :output_dir] => :environment do |t, args|
     1.upto(1) do |index|
       puts "round: #{index}"
 
@@ -54,7 +54,7 @@ namespace :migrate do
                                            @binary_hash,
                                            @premis_hash,
                                            @deposit_record_hash,
-                                           args[:mapping_file],
+                                           args[:output_dir],
                                            @depositor).ingest_records
       else
         puts 'The default admin set or specified depositor does not exist'

--- a/lib/tasks/migrate/services/id_mapper.rb
+++ b/lib/tasks/migrate/services/id_mapper.rb
@@ -13,7 +13,7 @@ module Migrate
         end
       end
 
-      def load
+      def mappings
         CSV.read(@filename, { headers: true })
       end
 

--- a/lib/tasks/migrate/services/id_mapper.rb
+++ b/lib/tasks/migrate/services/id_mapper.rb
@@ -13,6 +13,10 @@ module Migrate
         end
       end
 
+      def load
+        CSV.read(@filename, { headers: true })
+      end
+
       private
 
         def create_csv(col_1_name, col_2_name)

--- a/lib/tasks/migrate/services/id_mapper.rb
+++ b/lib/tasks/migrate/services/id_mapper.rb
@@ -7,9 +7,9 @@ module Migrate
         create_csv
       end
 
-      def add_row(data)
+      def add_row(key, value)
         CSV.open(@filename, 'a+') do |csv|
-          csv << [data[0], data[1]]
+          csv << [key, value]
         end
       end
 

--- a/lib/tasks/migrate/services/id_mapper.rb
+++ b/lib/tasks/migrate/services/id_mapper.rb
@@ -2,9 +2,9 @@ module Migrate
   module Services
     class IdMapper
 
-      def initialize(filename)
+      def initialize(filename, col_1_name, col_2_name)
         @filename = filename
-        create_csv
+        create_csv(col_1_name, col_2_name)
       end
 
       def add_row(key, value)
@@ -15,11 +15,11 @@ module Migrate
 
       private
 
-        def create_csv
+        def create_csv(col_1_name, col_2_name)
           if !File.exist?(@filename)
             @filename = File.new(@filename, 'w')
             CSV.open(@filename, 'a+') do |csv|
-              csv << ['old', 'new']
+              csv << [col_1_name, col_2_name]
             end
           end
         end

--- a/lib/tasks/migrate/services/ingest_service.rb
+++ b/lib/tasks/migrate/services/ingest_service.rb
@@ -6,7 +6,7 @@ module Migrate
 
     class IngestService
 
-      def initialize(config, object_hash, binary_hash, premis_hash, deposit_record_hash, mapping_file, depositor)
+      def initialize(config, object_hash, binary_hash, premis_hash, deposit_record_hash, output_dir, depositor)
         @collection_ids_file = config['collection_list']
         @object_hash = object_hash
         @binary_hash = binary_hash
@@ -14,13 +14,12 @@ module Migrate
         @deposit_record_hash = deposit_record_hash
         @work_type = config['work_type']
         @child_work_type = config['child_work_type']
-        @mapping_file = mapping_file
         @depositor = depositor
         @tmp_file_location = config['tmp_file_location']
         @config = config
         
         # Create file and hash mapping new and old ids
-        @id_mapper = Migrate::Services::IdMapper.new(@mapping_file)
+        @id_mapper = Migrate::Services::IdMapper.new(File.join(output_dir, 'mapping.csv'), 'old', 'new')
         @mappings = Hash.new
         # Store parent-child relationships
         @parent_hash = Hash.new

--- a/lib/tasks/migrate/services/progress_tracker.rb
+++ b/lib/tasks/migrate/services/progress_tracker.rb
@@ -15,8 +15,8 @@ module Migrate
         end
       end
 
-      def load_completed
-        IO.readlines(@filename).to_set
+      def completed_set
+        IO.readlines(@filename).map { |entry| entry.chomp }.to_set
       end
 
       private

--- a/lib/tasks/migrate/services/progress_tracker.rb
+++ b/lib/tasks/migrate/services/progress_tracker.rb
@@ -1,0 +1,31 @@
+require 'set'
+
+module Migrate
+  module Services
+    class ProgressTracker
+
+      def initialize(filename)
+        @filename = filename
+        create_log
+      end
+
+      def add_entry(entry)
+        File.open(@filename, 'a+') do |file|
+          file.puts(entry)
+        end
+      end
+
+      def load_completed
+        IO.readlines(@filename).to_set
+      end
+
+      private
+
+        def create_log
+          if !File.exist?(@filename)
+            FileUtils.touch(@filename)
+          end
+        end
+    end
+  end
+end

--- a/spec/tasks/migrate_rake_spec.rb
+++ b/spec/tasks/migrate_rake_spec.rb
@@ -20,6 +20,8 @@ describe "rake migrate:works", type: :task do
     Sipity::Workflow.create(name: 'test', allows_access_grant: true, active: true,
                             permission_template_id: permission_template.id)
   end
+  
+  let(:output_dir) { Dir.mktmpdir }
 
   before do
     Hyrax::Application.load_tasks if Rake::Task.tasks.empty?
@@ -30,6 +32,10 @@ describe "rake migrate:works", type: :task do
                                            access: 'deposit')
     Sipity::WorkflowAction.create(id: 4, name: 'show', workflow_id: workflow.id)
   end
+  
+  after do
+    FileUtils.remove_entry_secure output_dir
+  end
 
   it "preloads the Rails environment" do
     expect(Rake::Task['migrate:works'].prerequisites).to include "environment"
@@ -38,7 +44,7 @@ describe "rake migrate:works", type: :task do
   it "creates a new work" do
     expect { Rake::Task['migrate:works'].invoke('collection1',
                                                       'spec/fixtures/migration/migration_config.yml',
-                                                      'spec/fixtures/migration/mapping.csv',
+                                                      output_dir.to_s,
                                                       'RAILS_ENV=test') }
         .to change{ Article.count }.by(1)
     new_article = Article.all[-1]
@@ -55,6 +61,5 @@ describe "rake migrate:works", type: :task do
     expect(new_article['rights_statement_label']).to eq 'In Copyright'
     expect(new_article['admin_set_id']).to eq admin_set.id
     expect(new_article.visibility).to eq 'restricted'
-    File.delete('spec/fixtures/migration/mapping.csv')
   end
 end


### PR DESCRIPTION
Resolves: https://jira.lib.unc.edu/browse/HYC-487

* Changed third parameter for the migrate script to be an output folder instead of the mappings file (which is now added to the output folder, along with other files)
* Track the progress of objects successfully migrated. If the script is resumed, these objects will be skipped.
* Track the progress of parents which have their children attached. If the script is resumed, these objects will be skipped.
* Store the parent to child mapping in a CSV file, reload at the end when 
* Fix the new id recorded for honors thesis object
* Record the amount of time taken to update the children per object