### PR TITLE
Store parent-child mappings in separate files for each collection

### DIFF
--- a/lib/tasks/migrate/migrate.rake
+++ b/lib/tasks/migrate/migrate.rake
@@ -53,7 +53,8 @@ namespace :migrate do
       if !collection_config['child_work_type'].blank?
         Migrate::Services::ChildWorkParser.new(@object_hash,
                                                collection_config,
-                                               args[:output_dir]).find_children
+                                               args[:output_dir],
+                                               args[:collection]).find_children
       end
 
       Migrate::Services::IngestService.new(collection_config,
@@ -62,7 +63,8 @@ namespace :migrate do
                                          @premis_hash,
                                          @deposit_record_hash,
                                          args[:output_dir],
-                                         @depositor).ingest_records
+                                         @depositor,
+                                         args[:collection]).ingest_records
     else
       puts 'The default admin set or specified depositor does not exist'
     end

--- a/lib/tasks/migrate/services/child_work_parser.rb
+++ b/lib/tasks/migrate/services/child_work_parser.rb
@@ -2,13 +2,13 @@ module Migrate
   module Services
     class ChildWorkParser
 
-      def initialize(object_hash, config, output_dir)
+      def initialize(object_hash, config, output_dir, collection)
         @object_hash = object_hash
         @collection_uuids = MigrationHelper.get_collection_uuids(config['collection_list'])
 
 
         # Store parent-child relationships
-        @parent_child_mapper = Migrate::Services::IdMapper.new(File.join(output_dir, 'parent_child.csv'), 'parent', 'children')
+        @parent_child_mapper = Migrate::Services::IdMapper.new(File.join(output_dir, "#{collection}_parent_child.csv"), 'parent', 'children')
         # Progress tracker for objects migrated
         @object_progress = Migrate::Services::ProgressTracker.new(File.join(output_dir, 'object_progress.log'))
       end

--- a/lib/tasks/migrate/services/ingest_service.rb
+++ b/lib/tasks/migrate/services/ingest_service.rb
@@ -7,7 +7,7 @@ module Migrate
 
     class IngestService
 
-      def initialize(config, object_hash, binary_hash, premis_hash, deposit_record_hash, output_dir, depositor)
+      def initialize(config, object_hash, binary_hash, premis_hash, deposit_record_hash, output_dir, depositor, collection)
         @collection_ids_file = config['collection_list']
         @object_hash = object_hash
         @binary_hash = binary_hash
@@ -38,7 +38,7 @@ module Migrate
         # Create file and hash mapping new and old ids
         @id_mapper = Migrate::Services::IdMapper.new(File.join(@output_dir, 'old_to_new.csv'), 'old', 'new')
         # Store parent-child relationships
-        @parent_child_mapper = Migrate::Services::IdMapper.new(File.join(@output_dir, 'parent_child.csv'), 'parent', 'children')
+        @parent_child_mapper = Migrate::Services::IdMapper.new(File.join(@output_dir, "#{collection}_parent_child.csv"), 'parent', 'children')
         # Progress tracker for objects migrated
         @object_progress = Migrate::Services::ProgressTracker.new(File.join(@output_dir, 'object_progress.log'))
       end


### PR DESCRIPTION
the rake task tries to redo previous parent-child relationships and fails when there is a work type mismatch