### PR TITLE
Proquest ingest update

### DIFF
--- a/config/authorities/proquest_departments.yml
+++ b/config/authorities/proquest_departments.yml
@@ -75,7 +75,7 @@ terms:
   - id: 'Dentistry: Endodontics'
     term: Department of Endodontics
   - id: Ecology
-    term: Curriculum for the Environment and Ecology
+    term: Curriculum in Environment and Ecology
   - id: Economics
     term: Department of Economics
   - id: Education
@@ -93,7 +93,7 @@ terms:
   - id: English
     term: Department of English and Comparative Literature, English
   - id: Environment &amp; Ecology
-    term: Curriculum for the Environment and Ecology
+    term: Curriculum in Environment and Ecology
   - id: Environmental Sciences &amp; Engineering
     term: Department of Environmental Sciences and Engineering
   - id: Environmental Sciences and Engineering
@@ -242,3 +242,13 @@ terms:
     term: Department of Statistics and Operations Research
   - id: Toxicology
     term: Curriculum in Toxicology
+  - id: Clinical Rehabilitation and Mental Health Counseling
+    term: Division of Clinical Rehabilitation and Mental Health Counseling
+  - id: English and Comparative Literature
+    term: Department of English and Comparative Literature
+  - id: Education (Educational Leadership )
+    term: Educational Leadership Graduate Program
+  - id: Dentistry (Oral and Craniofacial Biomedicine)
+    term: Oral and Craniofacial Biomedicine PhD Program
+  - id: Global Studies
+    term: Curriculum in Global Studies

--- a/lib/tasks/proquest_ingest.rake
+++ b/lib/tasks/proquest_ingest.rake
@@ -41,7 +41,7 @@ namespace :proquest do
       unzipped_package_dir = extract_proquest_files(package)
 
       if unzipped_package_dir.blank?
-        puts "[#{Time.now}] skipping zip file"
+        puts "[#{Time.now}] error: skipping zip file"
         next
       end
 
@@ -50,14 +50,14 @@ namespace :proquest do
       if metadata_file.count == 1
         metadata_file = metadata_file.first.to_s
       else
-        puts "[#{Time.now}] #{unzipped_package_dir} has more than 1 xml file"
+        puts "[#{Time.now}] error: #{unzipped_package_dir} has more than 1 xml file"
         next
       end
       pdf_file = Dir.glob("#{unzipped_package_dir}/*.pdf")
       if pdf_file.count == 1
         pdf_file = pdf_file.first.to_s
       else
-        puts "[#{Time.now}] #{unzipped_package_dir} has more than 1 pdf file"
+        puts "[#{Time.now}] error: #{unzipped_package_dir} has more than 1 pdf file"
         next
       end
 

--- a/lib/tasks/proquest_ingest.rake
+++ b/lib/tasks/proquest_ingest.rake
@@ -8,6 +8,7 @@ namespace :proquest do
 
   desc 'batch migrate generic files from FOXML file'
   task :ingest, [:configuration_file] => :environment do |t, args|
+    puts "[#{Time.now}] starting proquest ingest"
 
     config = YAML.load_file(args[:configuration_file])
     
@@ -28,28 +29,35 @@ namespace :proquest do
                              deposited_by: @depositor_onyen }
 
     migrate_proquest_packages(config['package_dir'])
+
+    puts "[#{Time.now}] completed proquest ingest"
   end
 
   def migrate_proquest_packages(metadata_dir)
     proquest_packages = Dir.glob("#{metadata_dir}/*.zip")
     proquest_packages.each do |package|
-      puts "Unpacking #{package}"
+      puts "[#{Time. now}] Unpacking #{package}"
       @file_last_modified = ''
       unzipped_package_dir = extract_proquest_files(package)
+
+      if unzipped_package_dir.blank?
+        puts "[#{Time.now}] skipping zip file"
+        next
+      end
 
       # get all files in unzipped directory (should be 1 pdf and 1 xml)
       metadata_file = Dir.glob("#{unzipped_package_dir}/*_DATA.xml")
       if metadata_file.count == 1
         metadata_file = metadata_file.first.to_s
       else
-        puts "#{unzipped_package_dir} has more than 1 xml file"
+        puts "[#{Time.now}] #{unzipped_package_dir} has more than 1 xml file"
         next
       end
       pdf_file = Dir.glob("#{unzipped_package_dir}/*.pdf")
       if pdf_file.count == 1
         pdf_file = pdf_file.first.to_s
       else
-        puts "#{unzipped_package_dir} has more than 1 pdf file"
+        puts "[#{Time.now}] #{unzipped_package_dir} has more than 1 pdf file"
         next
       end
 
@@ -62,7 +70,7 @@ namespace :proquest do
         # only use xml file for metadata extraction
         metadata_fields = proquest_metadata(metadata_file)
 
-        puts "Number of files: #{metadata_fields[:files].count.to_s}"
+        puts "[#{Time.now}] Number of files: #{metadata_fields[:files].count.to_s}"
 
         # create deposit record
         deposit_record = DepositRecord.new(@deposit_record_hash)
@@ -103,17 +111,21 @@ namespace :proquest do
     fname = file.split('.zip')[0].split('/')[-1]
     dirname = @temp+'/'+fname
     FileUtils::mkdir_p dirname
-    Zip::File.open(file) do |zip_file|
-      zip_file.each do |f|
-        if f.name.match(/DATA.xml/)
-          @file_last_modified = Date.strptime(zip_file.get_entry(f).as_json['time'].split('T')[0],"%Y-%m-%d")
+    begin
+      Zip::File.open(file) do |zip_file|
+        zip_file.each do |f|
+          if f.name.match(/DATA.xml/)
+            @file_last_modified = Date.strptime(zip_file.get_entry(f).as_json['time'].split('T')[0],"%Y-%m-%d")
+          end
+          fpath = File.join(dirname, f.name)
+          zip_file.extract(f, fpath) unless File.exist?(fpath)
         end
-        fpath = File.join(dirname, f.name)
-        puts fpath
-        zip_file.extract(f, fpath) unless File.exist?(fpath)
       end
+      dirname
+    rescue => e
+      puts "[#{Time.now}] zip file error: #{e.message}"
+      nil
     end
-    dirname
   end
 
   def ingest_proquest_files(resource: nil, files: [], metadata: nil, zip_dir_files: nil)
@@ -121,7 +133,7 @@ namespace :proquest do
 
     files.each do |f|
       file_path = zip_dir_files.find { |e| e.match(f.to_s) }
-      puts "trying...#{f.to_s}"
+      puts "[#{Time.now}] trying...#{f.to_s}"
       if !file_path.nil? && File.file?(file_path)
         file_set = ingest_proquest_file(parent: resource, resource: metadata, f: file_path)
         ordered_members << file_set if file_set
@@ -132,7 +144,7 @@ namespace :proquest do
   end
 
   def ingest_proquest_file(parent: nil, resource: nil, f: nil)
-    puts "ingesting... #{f.to_s}"
+    puts "[#{Time.now}] ingesting... #{f.to_s}"
     fileset_metadata = file_record(resource)
 
     if fileset_metadata['embargo_release_date'].blank?

--- a/spec/features/create_artwork_spec.rb
+++ b/spec/features/create_artwork_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature 'Create an Artwork', js: false do
 
       check 'agreement'
 
-      expect(page).to have_selector('#article_dcmi_type')
+      expect(page).to have_selector('#artwork_dcmi_type')
       expect(page).to have_selector("input[value='http://purl.org/dc/dcmitype/Image']")
 
       find('label[for=addFiles]').click do


### PR DESCRIPTION
* Updates department and degree mappings for proquest records
  * Some departments were not in existing authority
  * One department was mapped to the wrong key
  * It looks like the proquest abbreviation for the doctor of education degree changed from E.D.D. to D.E., so we now have both in the mapping
  * Will store non-mapping departments in fedora in the future for easier remediation
* Adds log statements to help identify new records and log zip file errors
* Fixes artwork feature test