### PR TITLE
hyc-970 ruby 26 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - bundle exec rake test_setup RAILS_ENV=test
 before_install:
   - gem update --system
-  - gem install bundler:1.16.6
+  - gem install bundler:2.0.1
 jdk:
   - oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - bundle exec rake test_setup RAILS_ENV=test
 before_install:
   - gem update --system
-  - gem install bundler:2.0.1
+  - gem install bundler:2.1.4
 jdk:
   - oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
   - redis-server
   - postgresql
 rvm:
-  - 2.4.1
+  - 2.6.2
 before_script:
   - curl -o /home/travis/fits-1.0.5.zip https://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip | cat
   - unzip /home/travis/fits-1.0.5.zip -d /home/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - bundle exec rake test_setup RAILS_ENV=test
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install bundler:1.16.6
 jdk:
   - oraclejdk8
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ group :test do
   gem 'shoulda-matchers', '~> 3.1.2'
   gem 'capybara', '~> 2.17.0'
   gem 'rspec-mocks'
-  gem 'webmock'
+  gem 'webmock', '~> 3.5.0'
   gem 'factory_bot_rails', '~> 5.0.1'
   gem 'simplecov', '~> 0.17.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -887,4 +887,4 @@ DEPENDENCIES
   webmock (~> 3.5.0)
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    hashdiff (0.3.7)
+    hashdiff (1.0.1)
     hashie (3.5.7)
     hiredis (0.6.3)
     htmlentities (4.3.4)
@@ -524,7 +524,7 @@ GEM
     noid-rails (3.0.1)
       actionpack (>= 5.0.0, < 6)
       noid (~> 0.9)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -556,7 +556,7 @@ GEM
     pg (0.21.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     pul_uv_rails (2.0.1)
     puma (3.12.4)
     qa (2.2.0)
@@ -705,7 +705,7 @@ GEM
       oauth2
     ruby-progressbar (1.10.1)
     rubyzip (1.3.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.7.3)
@@ -822,7 +822,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.4.2)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -884,7 +884,7 @@ DEPENDENCIES
   turbolinks (~> 5.0.1)
   uglifier (~> 3.2.0)
   web-console (~> 3.5.1)
-  webmock
+  webmock (~> 3.5.0)
 
 BUNDLED WITH
    1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -887,4 +887,4 @@ DEPENDENCIES
   webmock (~> 3.5.0)
 
 BUNDLED WITH
-   1.16.6
+   2.0.1


### PR DESCRIPTION
* https://jira.lib.unc.edu/browse/HYC-970
* updated travis-ci config file
* upgraded webmock gem so tests would run with ruby26