### PR TITLE
Pass checksum to longleaf registration job instead of Hydra::PCDM::File object

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -31,7 +31,7 @@ module Hyrax
         repository_file = related_file
         Hyrax::VersioningService.create(repository_file, user)
         # [hyc-override] Invoke longleaf registration
-        RegisterToLongleafJob.new.perform(repository_file)
+        RegisterToLongleafJob.perform_later(repository_file.checksum.value)
         pathhint = io.uploaded_file.uploader.path if io.uploaded_file # in case next worker is on same filesystem
         CharacterizeJob.perform_later(file_set, repository_file.id, pathhint || io.path)
       end

--- a/app/jobs/register_to_longleaf_job.rb
+++ b/app/jobs/register_to_longleaf_job.rb
@@ -4,13 +4,12 @@ require 'open3'
 class RegisterToLongleafJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
-  def perform(repository_file)
+  def perform(checksum)
     if ENV["LONGLEAF_BASE_COMMAND"].blank?
       Rails.logger.error("LONGLEAF_BASE_COMMAND is not set, skipping registration of file to Longleaf.")
       return
     end
-    
-    checksum = repository_file.checksum.value
+
     # Calculate the path to the file in fedora, assuming modeshape behavior of hashing based on sha1
     binary_path = File.join(ENV["LONGLEAF_STORAGE_PATH"], checksum.scan(/.{2}/)[0..2].join('/'), checksum)
     
@@ -20,11 +19,12 @@ class RegisterToLongleafJob < Hyrax::ApplicationJob
 
     start = Time.now
     stdout,stderr,status = Open3.capture3(register_cmd)
-    
+
     if status.success?
       Rails.logger.info("Successfully registered #{binary_path}")
     else
       Rails.logger.error("Failed to register #{binary_path} to Longleaf: #{stdout} #{stderr}")
+      raise "#{stdout} #{stderr}"
     end
     
     Rails.logger.debug("Longleaf registration completed in #{Time.now - start}")

--- a/spec/jobs/register_to_longleaf_job_spec.rb
+++ b/spec/jobs/register_to_longleaf_job_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RegisterToLongleafJob, type: :job do
     end
     
     it 'calls registration script with the expected parameters' do
-      job.perform(repository_file)
+      job.perform(repository_file.checksum.value)
       
       arguments = File.read(output_path)
       


### PR DESCRIPTION
* https://jira.lib.unc.edu/browse/HYC-1061
* passing the Hyrda::PCDM::File object to the job was causing errors