### PR TITLE
HYC-1111 - Fix honors reviewer notification

### DIFF
--- a/app/jobs/assign_permissions_to_work_job.rb
+++ b/app/jobs/assign_permissions_to_work_job.rb
@@ -14,7 +14,7 @@ class AssignPermissionsToWorkJob < Hyrax::ApplicationJob
 
     if recipients[:to].count > 0
       depositor = User.find_by_user_key(work.depositor)
-      Hyrax::Workflow::PendingReviewNotification.send_notification(entity: entity,
+      Hyrax::Workflow::HonorsDepartmentReviewerDepositNotification.send_notification(entity: entity,
                                                                    comment: '',
                                                                    user: depositor,
                                                                    recipients: recipients)

--- a/config/workflows/honors_thesis_deposit_workflow.json
+++ b/config/workflows/honors_thesis_deposit_workflow.json
@@ -15,11 +15,6 @@
                             "notification_type": "email",
                             "name": "Hyrax::Workflow::HonorsMediatedDepositNotification",
                             "to": []
-                        },
-                        {
-                            "notification_type": "email",
-                            "name": "Hyrax::Workflow::HonorsDepartmentReviewerDepositNotification",
-                            "to": ["viewing"]
                         }
                     ],
                     "methods": [

--- a/spec/features/create_work_in_honors_thesis_workflow_spec.rb
+++ b/spec/features/create_work_in_honors_thesis_workflow_spec.rb
@@ -167,7 +167,7 @@ RSpec.feature 'Create and review a work in the honors thesis workflow', js: fals
       # Reviewer is not yet in reviewing group and does not get a notification
       expect(admin_user.mailbox.inbox.count).to eq 0
       expect(admin_user2.mailbox.inbox.count).to eq 0
-      expect(department_contact1.mailbox.inbox.count).to eq 1
+      expect(department_contact1.mailbox.inbox.count).to eq 0
       expect(department_contact2.mailbox.inbox.count).to eq 0
       expect(user.mailbox.inbox.count).to eq 1
       expect(reviewer.mailbox.inbox.count).to eq 0
@@ -291,7 +291,7 @@ RSpec.feature 'Create and review a work in the honors thesis workflow', js: fals
       # User and admin set owner get notification for 'depositing' role
       expect(admin_user.mailbox.inbox.count).to eq 1
       expect(admin_user2.mailbox.inbox.count).to eq 0
-      expect(department_contact1.mailbox.inbox.count).to eq 1
+      expect(department_contact1.mailbox.inbox.count).to eq 0
       expect(department_contact2.mailbox.inbox.count).to eq 0
       expect(user.mailbox.inbox.count).to eq 2
       expect(reviewer.mailbox.inbox.count).to eq 1
@@ -316,7 +316,7 @@ RSpec.feature 'Create and review a work in the honors thesis workflow', js: fals
       # User gets notification for deletion requests
       expect(admin_user.mailbox.inbox.count).to eq 2
       expect(admin_user2.mailbox.inbox.count).to eq 1
-      expect(department_contact1.mailbox.inbox.count).to eq 1
+      expect(department_contact1.mailbox.inbox.count).to eq 0
       expect(department_contact2.mailbox.inbox.count).to eq 0
       expect(user.mailbox.inbox.count).to eq 3
       expect(reviewer.mailbox.inbox.count).to eq 1
@@ -362,7 +362,7 @@ RSpec.feature 'Create and review a work in the honors thesis workflow', js: fals
       # User gets deposit notification
       expect(admin_user.mailbox.inbox.count).to eq 2
       expect(admin_user2.mailbox.inbox.count).to eq 1
-      expect(department_contact1.mailbox.inbox.count).to eq 2
+      expect(department_contact1.mailbox.inbox.count).to eq 0
       expect(department_contact2.mailbox.inbox.count).to eq 1
       expect(user.mailbox.inbox.count).to eq 4
       expect(reviewer.mailbox.inbox.count).to eq 1


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1111

Use honors reviewer notification for post-permission assignment notification. Remove direct notification call from workflow