### PR TITLE
Require affiliation for honors thesis creator in partial

### DIFF
--- a/app/forms/hyrax/honors_thesis_form.rb
+++ b/app/forms/hyrax/honors_thesis_form.rb
@@ -12,7 +12,7 @@ module Hyrax
 
     self.terms -= [:contributor, :description, :identifier, :publisher, :source, :date_created]
 
-    self.required_fields = [:title, :creator, :abstract, :advisor, :affiliation, :degree, :date_issued,
+    self.required_fields = [:title, :creator, :abstract, :advisor, :degree, :date_issued,
                             :graduation_year]
 
     self.single_value_fields = [:title, :license]
@@ -33,7 +33,6 @@ module Hyrax
     def license
       super.first || ""
     end
-
 
     delegate :advisors_attributes=, to: :model
     delegate :creators_attributes=, to: :model

--- a/app/views/records/edit_fields/_person.html.erb
+++ b/app/views/records/edit_fields/_person.html.erb
@@ -21,7 +21,7 @@
       </div>
 
       <div class="person col-sm-12 <%= person_term %>-affiliation">
-        <% is_required = (person_term == 'advisor' && f.object_name == 'honors_thesis') ? false : f.object.required?(:affiliation) %>
+        <% is_required = person_term == 'creator' && f.object_name == 'honors_thesis' %>
         <%= person.input :affiliation, as: :select,
                          label: "UNC affiliation (#{person_term_display})",
                          collection: DepartmentsService.select_all_options.sort,

--- a/spec/forms/hyrax/honors_thesis_form_spec.rb
+++ b/spec/forms/hyrax/honors_thesis_form_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Hyrax::HonorsThesisForm do
   describe "#required_fields" do
     subject { form.required_fields }
 
-    it do  is_expected.to match_array [:title, :abstract, :advisor, :affiliation, :creator, :date_issued, :degree,
+    # :affiliation requirement enforced in partial
+    it do  is_expected.to match_array [:title, :abstract, :advisor, :creator, :date_issued, :degree,
                                        :graduation_year]
     end
   end


### PR DESCRIPTION
Require affiliation for honors thesis creator in partial, since it's really part of creator sub form. It's the only required affiliation. It gives a log warning if set in the honors thesis form.
https://jira.lib.unc.edu/browse/HYC-1126