### PR TITLE
Replace dashes in dept names with underscore for email notifications

### DIFF
--- a/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
+++ b/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
@@ -3,8 +3,8 @@ module Hyrax::Workflow::AssignReviewerByAffiliation
   def self.call(target:, **)
     target.creators.each do |creator|
       creator['affiliation'].each do |affiliation|
-        # Replace spaces and dashes. PostGres doesn't seem to do well with dashes
-        department = affiliation.strip.to_s.downcase.gsub(/\s|–/, '_')
+        # Replace spaces, dashes and commas. PostGres doesn't seem to do well with dashes and commas
+        department = affiliation.strip.to_s.downcase.gsub(/\s|–|,/, '_')
         reviewer = find_reviewer_for(department: department)
         permission_template_id = Hyrax::PermissionTemplate.find_by_source_id(target.admin_set_id).id
 

--- a/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
+++ b/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
@@ -3,7 +3,8 @@ module Hyrax::Workflow::AssignReviewerByAffiliation
   def self.call(target:, **)
     target.creators.each do |creator|
       creator['affiliation'].each do |affiliation|
-        department = affiliation.strip.to_s.downcase.gsub(' ', '_')
+        # Replace spaces and dashes. PostGres doesn't seem to do well with dashes
+        department = affiliation.strip.to_s.downcase.gsub(/\s|–/, '_')
         reviewer = find_reviewer_for(department: department)
         permission_template_id = Hyrax::PermissionTemplate.find_by_source_id(target.admin_set_id).id
 


### PR DESCRIPTION
Replace dashes in dept names with underscore for email notifications, as PostGres doesn't seem to do well with dashes.
https://jira.lib.unc.edu/browse/HYC-1150