### PR TITLE
Make sure file paths are decoded

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -65,7 +65,7 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
 
   # [hyc-override] add virus checking method
   def virus_check!(uploaded_file)
-    file_path = uploaded_file.file.to_s
+    file_path = URI.unescape(uploaded_file.file.to_s)
     scan_results = Hyc::VirusScanner.hyc_infected?(file_path)
     return if scan_results.instance_of? ClamAV::SuccessResponse
     if scan_results.instance_of? ClamAV::VirusResponse

--- a/spec/fixtures/files/odd_chars_+.txt
+++ b/spec/fixtures/files/odd_chars_+.txt
@@ -1,0 +1,1 @@
+Why the plus sign?

--- a/spec/lib/hyc/virus_scanner_spec.rb
+++ b/spec/lib/hyc/virus_scanner_spec.rb
@@ -57,4 +57,29 @@ RSpec.describe Hyc::VirusScanner do
       expect(scanner).to be_infected
     end
   end
+
+  context 'when a file name has special characters' do
+    src_path = Pathname.new('spec/fixtures/files/odd_chars_+.txt').realpath.to_s
+
+    if Dir.pwd.include? 'runner'
+      let(:file) { Tempfile.new.path }
+    else
+      let(:file) { src_path }
+    end
+
+    before do
+      if Dir.pwd.include? 'runner'
+        FileUtils.rm(file)
+        FileUtils.cp(src_path, file)
+      end
+    end
+
+    it 'can perform a custom virus hy-c custom scan' do
+      expect(scanner.hyc_infected?).to be_a ClamAV::SuccessResponse
+    end
+
+    it 'does not have a virus normal hyrax scan' do
+      expect(scanner).not_to be_infected
+    end
+  end
 end


### PR DESCRIPTION
* Make sure file paths are decoded
* Add test in virus_scanner_spec.rb, as this is where encoded paths fail

https://jira.lib.unc.edu/browse/HYC-1181