### PR TITLE
Allow Vagrant IP address to display web console in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,9 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Allow Vagrant IP address to display web console in development mode
+  # NOTE: When we upgrade to Web Console 4.x this will change to
+  # config.web_console.permissions = ['10.0.2.2']
+  config.web_console.whitelisted_ips = ['10.0.2.2']
 end


### PR DESCRIPTION
Added a "raise" to a footer to verify the change

![image](https://user-images.githubusercontent.com/45948126/141197902-ce208e47-db02-4bc0-ad63-9e223432c634.png)
