### PR TITLE
Update to Rubygems version on server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Update rubygems
       run: |
-        gem update --system
+        gem update --system 3.0.3.1
         gem install bundler:2.1.4
 
     # Run Rubocop as soon as gems are installed, so we fail early if there are issues


### PR DESCRIPTION
- Latest Rubygems update breaks CI, use specific version to fix CI, can investigate when / if we want to upgrade in future.