### PR TITLE
If we are not on a branch, and are on a tag, use tag name

### DIFF
--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -1,5 +1,11 @@
 GIT_SHA = `git rev-parse HEAD`.chomp
-BRANCH = `git rev-parse --abbrev-ref HEAD`.chomp
+branch_name = `git rev-parse --abbrev-ref HEAD`.chomp
+git_tag_name = `git describe --tags`.chomp
+BRANCH = if branch_name == 'HEAD'
+           git_tag_name
+         else
+           branch_name
+         end
 Rails.logger.debug("in initializer: #{Rails.env}")
 LAST_DEPLOYED = if Rails.env.production?
                   # on cdr-test this returns /net/deploy/ir/test/releases/DEPLOY_DATE


### PR DESCRIPTION
On cdr-test without this fix after deploying v1.0.0
![image](https://user-images.githubusercontent.com/45948126/145263001-d1fe0fb5-250a-468e-b5b1-ebd075ff5990.png)

With change - 
![image](https://user-images.githubusercontent.com/45948126/145264435-4e8ba33e-9f42-442b-a1e4-8aa51174acbd.png)
