### PR TITLE
Use same log formatting for all environments

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,17 @@ module Hyrax
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.log_formatter = proc do |severity, time, progname, msg|
+      "#{time} - #{severity}: #{msg}\n"
+    end
+    log_path = ENV["LOGS_PATH"] || "log/#{Rails.env}.log"
+    logger = ActiveSupport::Logger.new(log_path)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+
+    # Prepend all log lines with the following tags.
+    config.log_tags = [:request_id]
     config.before_configuration do
       if ENV.has_key?('LOCAL_ENV_PATH')
         env_file = ENV['LOCAL_ENV_PATH'].to_s

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
   # NOTE: When we upgrade to Web Console 4.x this will change to
   # config.web_console.permissions = ['10.0.2.2']
   config.web_console.whitelisted_ips = ['10.0.2.2']
+  
+  config.log_level = :debug
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,15 +47,6 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :warn
-  config.log_formatter = proc do |severity, time, progname, msg|
-    "#{time} - #{severity}: #{msg}\n"
-  end
-  logger = ActiveSupport::Logger.new(ENV["LOGS_PATH"])
-  logger.formatter = config.log_formatter
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :inline
+  config.log_level = :debug
 end


### PR DESCRIPTION
Use the same log formatter in test and development environments to ensure log tagging is working correctly, and in order to create new tagged logs in future.

Test - before
```
ActiveFedora: loading fedora config from /hyrax/config/fedora.yml
ActiveFedora: loading solr config from /hyrax/config/solr.yml
  [1m[35m (0.2ms)[0m  [1m[31mROLLBACK[0m
  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
  [1m[35m (0.1ms)[0m  [1m[31mROLLBACK[0m
  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
  [1m[35m (0.2ms)[0m  [1m[31mROLLBACK[0m
```

Test - after
```
2021-12-13 16:39:59 +0000 - INFO: ActiveFedora: loading fedora config from /hyrax/config/fedora.yml
2021-12-13 16:39:59 +0000 - INFO: ActiveFedora: loading solr config from /hyrax/config/solr.yml
2021-12-13 16:39:59 +0000 - DEBUG:   [1m[35m (0.1ms)[0m  [1m[31mROLLBACK[0m
2021-12-13 16:39:59 +0000 - DEBUG:   [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
2021-12-13 16:39:59 +0000 - DEBUG:   [1m[35m (0.1ms)[0m  [1m[31mROLLBACK[0m
2021-12-13 16:39:59 +0000 - DEBUG:   [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
2021-12-13 16:39:59 +0000 - DEBUG:   [1m[35m (0.2ms)[0m  [1m[31mROLLBACK[0m
```