### PR TITLE
Allow authority to find http or https

### DIFF
--- a/app/lib/qa/authorities/local/file_based_authority.rb
+++ b/app/lib/qa/authorities/local/file_based_authority.rb
@@ -20,6 +20,8 @@ module Qa::Authorities
     end
 
     def find(id)
+      # If an id includes https, translate it to http
+      id["https"] = "http" if id.include?("https")
       terms.find { |term| term[:id] == id } || {}
     end
 

--- a/app/lib/qa/authorities/local/file_based_authority.rb
+++ b/app/lib/qa/authorities/local/file_based_authority.rb
@@ -21,7 +21,7 @@ module Qa::Authorities
 
     def find(id)
       # If an id includes https, translate it to http
-      id["https"] = "http" if id.include?("https")
+      id["https://"] = "http://" if id.start_with?("https://")
       terms.find { |term| term[:id] == id } || {}
     end
 

--- a/spec/lib/qa/authorities/local/file_based_authority_spec.rb
+++ b/spec/lib/qa/authorities/local/file_based_authority_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::Local::FileBasedAuthority do
+  let(:licenses) { Qa::Authorities::Local.subauthority_for("licenses") }
+
+  describe "#all" do
+    it "returns an array of hashes" do
+      expect(licenses.all).to be_instance_of(Array)
+      expect(licenses.all.first).to be_instance_of(HashWithIndifferentAccess)
+    end
+
+    it "has the expected keys in those hashes" do
+      expect(licenses.all.first.keys).to match_array(['id', 'label', 'active'])
+    end
+  end
+
+  describe "#search" do
+    context "with an empty query string" do
+      let(:expected) { [] }
+      it "returns no results" do
+        expect(licenses.search("")).to eq(expected)
+      end
+    end
+
+    context "with at least one matching entry" do
+      let(:expected) do
+        [{"id"=>"http://creativecommons.org/licenses/by-nc/3.0/us/",
+          "label"=>"Attribution-NonCommercial 3.0 United States",
+          "active"=>"all"},
+         {"id"=>"http://creativecommons.org/licenses/by-nc/4.0/",
+          "label"=>"Attribution-NonCommercial 4.0 International",
+          "active"=>"all"},
+         {"id"=>"http://creativecommons.org/licenses/by-nc-nd/3.0/us/",
+          "label"=>"Attribution-NonCommercial-NoDerivs 3.0 United States",
+          "active"=>"all"},
+         {"id"=>"http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+          "label"=>"Attribution-NonCommercial-ShareAlike 3.0 United States",
+          "active"=>"all"}]
+      end
+      it "returns only entries matching the query term" do
+        expect(licenses.search("NonCommercial")).to eq(expected)
+      end
+      it "is case insensitive" do
+        expect(licenses.search("NonCoMMercial")).to eq(expected)
+      end
+    end
+
+    context "with no matching entries" do
+      let(:expected) { [] }
+      it "returns an empty array" do
+        expect(licenses.search("penguins")).to eq(expected)
+      end
+    end
+  end
+
+  describe "#find" do
+    context "with https in an identifier" do
+      it "returns the full term record" do
+        record = licenses.find("https://creativecommons.org/licenses/by/3.0/us/")
+        expect(record).to be_a HashWithIndifferentAccess
+        expect(record).to eq('id' => "http://creativecommons.org/licenses/by/3.0/us/", 'term' => "Attribution 3.0 United States", 'active' => 'data')
+      end
+    end
+    context "source is a list" do
+      it "has indifferent access" do
+        record = licenses.find("http://creativecommons.org/licenses/by/3.0/us/")
+        expect(record).to be_a HashWithIndifferentAccess
+      end
+    end
+    context "term does not exist" do
+      let(:id) { "NonID" }
+      let(:expected) { {} }
+      it "returns an empty hash" do
+        expect(licenses.find(id)).to eq(expected)
+      end
+    end
+    context "on a sub-authority" do
+      it "returns the full term record" do
+        record = licenses.find("http://creativecommons.org/licenses/by/3.0/us/")
+        expect(record).to be_a HashWithIndifferentAccess
+        expect(record).to eq('id' => "http://creativecommons.org/licenses/by/3.0/us/", 'term' => "Attribution 3.0 United States", 'active' => 'data')
+      end
+    end
+  end
+end

--- a/spec/lib/qa/authorities/local/file_based_authority_spec.rb
+++ b/spec/lib/qa/authorities/local/file_based_authority_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Qa::Authorities::Local::FileBasedAuthority do
   let(:licenses) { Qa::Authorities::Local.subauthority_for("licenses") }
+  # TODO: Add more example file based authorities to make sure this isn't only relevant for licenses.
+  # We can't be quite as agnostic as the original test:
+  # See https://github.com/samvera/questioning_authority/blob/eafe9fe652d1a7efd37e0d7f2737b2d64876c601/spec/lib/authorities/local/file_based_authority_spec.rb
 
   describe "#all" do
     it "returns an array of hashes" do

--- a/spec/services/cdr_license_service_spec.rb
+++ b/spec/services/cdr_license_service_spec.rb
@@ -46,5 +46,9 @@ RSpec.describe Hyrax::CdrLicenseService do
     it "resolves for ids of active terms" do
       expect(service.label('http://creativecommons.org/licenses/by-sa/3.0/us/')).to eq('Attribution-ShareAlike 3.0 United States')
     end
+
+    it "resolves to the same label for http or https ids" do
+      expect(service.label('https://creativecommons.org/licenses/by-sa/3.0/us/')).to eq('Attribution-ShareAlike 3.0 United States')
+    end
   end
 end


### PR DESCRIPTION
Connected to https://jira.lib.unc.edu/browse/HYC-1319

Connected to https://jira.lib.unc.edu/browse/HYC-1280

Sage provides the URIs for licenses with "https", which we only realized when I tried to find the label for them. 

I talked to Anna and Rebekah about being agnostic about mapping URIs to the same authority record whether they use "http" and "https" at the beginning, and they were fine with that. 

We will still only store / return records with "http" as the id, but "#find" will return the record for ids starting with either http or https.

This PR also adds a test for one of our overrides - Qa::Authorities::Local::FileBasedAuthority - this override does not appear to have been tested specifically previously.