### PR TITLE
HYC-1345: Increase error handling for background jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
       DOI_PREFIX: '10.17615'
       EMAIL_FROM_ADDRESS: 'hyraxapp@example.com'
       FCREPO_TEST_PORT: 8080
-      FITS_LOCATION: '/home/travis/fits-1.0.5/fits.sh'
       HYRAX_DATABASE_PASSWORD: 'password'
       HYRAX_HOST: 'https://example.com'
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
@@ -107,12 +106,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install unzip imagemagick ghostscript libpq-dev
-
-    - name: Install FITS
-      run: |
-        curl -o $HOME/fits-1.0.5.zip https://projects.iq.harvard.edu/files/fits/files/fits-1.0.5.zip | cat
-        unzip $HOME/fits-1.0.5.zip -d $HOME
-        chmod u=u+x $HOME/fits-1.0.5/fits.sh
 
     - name: Setup test database
       env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Style/SlicingWithRange:
   Enabled: false
 
 # Section to keep long term
-
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Style/SymbolArray:
   Enabled: false

--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -21,13 +21,17 @@ module Hyrax
       # @note Instead of calling this method, use IngestJob to avoid synchronous execution cost
       # @see IngestJob
       # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
+
+      # [hyc-override] - Raise an error if the file_set cannot save, then rescue and log the error, finally return false after logging
+      # Returning false after the save should maintain the method's API while allowing us to see errors more readily
       def ingest_file(io)
         # Skip versioning because versions will be minted by VersionCommitter as necessary during save_characterize_and_record_committer.
         Hydra::Works::AddFileToFileSet.call(file_set,
                                             io,
                                             relation,
                                             versioning: false)
-        return false unless file_set.save
+
+        file_set.save!
 
         repository_file = related_file
         Hyrax::VersioningService.create(repository_file, user)
@@ -35,6 +39,9 @@ module Hyrax
         RegisterToLongleafJob.perform_later(repository_file.checksum.value)
         pathhint = io.uploaded_file.uploader.path if io.uploaded_file # in case next worker is on same filesystem
         CharacterizeJob.perform_later(file_set, repository_file.id, pathhint || io.path)
+      rescue ActiveFedora::RecordInvalid => error
+        Rails.logger.error("Could not save FileSet with id: #{file_set.id} after adding file due to error: #{error}")
+        false
       end
 
       # Reverts file and spawns async job to characterize and create derivatives.

--- a/app/lib/hyc/virus_scanner.rb
+++ b/app/lib/hyc/virus_scanner.rb
@@ -4,7 +4,8 @@ module Hyc
     # Hyrax requires an infected? method and that this method return a boolean
     def infected?
       results = hyc_infected?
-      return results if results.instance_of? ClamAV::ErrorResponse
+
+      raise(StandardError, "ClamAV::ErrorResponse: #{results.error_str}") if results.instance_of? ClamAV::ErrorResponse
 
       results.instance_of? ClamAV::VirusResponse
     end

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::FileActor do
+  let(:file_set) { FactoryBot.create(:file_set) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:actor) { described_class.new(file_set, :original_file, user) }
+  let(:file_path) { File.join(fixture_path, 'files', 'image.png') }
+  let(:file) { File.new(file_path) }
+  let(:job_wrapper) { JobIoWrapper.create_with_varied_file_handling!(file_set: file_set, user: user, file: file, relation: 'some_string') }
+
+  before do
+    allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { false }
+    allow(RegisterToLongleafJob).to receive(:perform_later).and_return(nil)
+  end
+
+  it 'can be instantiated' do
+    expect(actor).to be_instance_of(described_class)
+  end
+
+  it 'can ingest a file' do
+    expect(CharacterizeJob).to receive(:perform_later)
+    actor.ingest_file(job_wrapper)
+  end
+
+  context 'with a file_set that fails validation' do
+    before do
+      # one of the FileSet validations is whether the file has a virus - mock that it does
+      allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { true }
+    end
+
+    it 'logs an error' do
+      allow(Rails.logger).to receive(:error)
+
+      actor.ingest_file(job_wrapper)
+
+      expect(Rails.logger).to have_received(:error).with(("Could not save FileSet with id: #{file_set.id} after adding file due to error: Validation failed: Failed to verify uploaded file is not a virus"))
+    end
+  end
+end

--- a/spec/lib/hyc/virus_scanner_spec.rb
+++ b/spec/lib/hyc/virus_scanner_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Hyc::VirusScanner do
     end
   end
 
+  context 'when it cannot find the file' do
+    let(:file) { 'not/a/file.txt' }
+
+    it 'raises an error' do
+      expect { scanner.infected? }.to raise_error(ClamAV::Util::UnknownPathException)
+    end
+  end
+
   context 'when a file is infected' do
     src_path = Pathname.new('spec/fixtures/files/virus.txt').realpath.to_s
     if Dir.pwd.include? 'runner'

--- a/spec/services/tasks/onescience_ingest_service_spec.rb
+++ b/spec/services/tasks/onescience_ingest_service_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe Tasks::OnescienceIngestService do
     end
 
     before do
+      allow(CharacterizeJob).to receive(:perform_later)
+      allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { false }
       AdminSet.delete_all
       Hyrax::PermissionTemplateAccess.delete_all
       Hyrax::PermissionTemplate.delete_all

--- a/spec/services/tasks/proquest_ingest_service_spec.rb
+++ b/spec/services/tasks/proquest_ingest_service_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Tasks::ProquestIngestService do
   end
 
   before do
+    allow(CharacterizeJob).to receive(:perform_later)
+    allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { false }
     allow(Date).to receive(:today).and_return(Date.parse('2019-09-12'))
     AdminSet.delete_all
     Sipity::WorkflowState.create(workflow_id: workflow.id, name: 'deposited')


### PR DESCRIPTION
- Raise and then rescue error when can't save file_set
- Raise error when we get a ClamAV error
- Remove fits from CI, wasn't working anyway, mocking in tests 
- Allow to rescue with `error` rather than `e`