### PR TITLE
HYC-1396: Update tests for security upgrades

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.6.7']
+        ruby-version: ['2.6.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
     - name: Update rubygems
       run: |
         gem update --system 3.0.3.1
-        gem install bundler:2.1.4
+        gem install bundler:2.2.18
 
     # Run Rubocop as soon as gems are installed, so we fail early if there are issues
     - name: Run RuboCop


### PR DESCRIPTION
- Upgrading to bundler 2.2.18 did not result in any changes to the Gemfile.lock 
- Once the upgrade to bundler has been done on all the deployed servers, we can update the `BUNDLED WITH` in the Gemfile.lock (run `bundler update --bundler`). Bundler doesn't usually complain if you bundle with a newer version than is in the lockfile, but does if it's an older version. 