### PR TITLE
Fix typo and use delimiter for packed CSV field

### DIFF
--- a/app/jobs/list_unmappable_affiliations_job.rb
+++ b/app/jobs/list_unmappable_affiliations_job.rb
@@ -2,6 +2,6 @@ class ListUnmappableAffiliationsJob < Hyrax::ApplicationJob
   queue_as :long_running_jobs
 
   def perform
-    HycCrawlerService.create_csv_of_umappable_affiliations
+    HycCrawlerService.create_csv_of_unmappable_affiliations
   end
 end

--- a/app/services/hyc_crawler_service.rb
+++ b/app/services/hyc_crawler_service.rb
@@ -47,7 +47,7 @@ module HycCrawlerService
       crawl_for_affiliations do |document_id, url, affiliations|
         unmappable_affiliations = unmappable_affiliations(affiliations)
         Rails.logger.debug("Saving object info to csv. url: #{url}") unless unmappable_affiliations.empty?
-        csv << [document_id, url, unmappable_affiliations] unless unmappable_affiliations.empty?
+        csv << [document_id, url, unmappable_affiliations.join(' || ')] unless unmappable_affiliations.empty?
       end
     end
   end

--- a/app/services/hyc_crawler_service.rb
+++ b/app/services/hyc_crawler_service.rb
@@ -34,14 +34,14 @@ module HycCrawlerService
   def self.csv_file_path
     csv_directory = Rails.root.join(ENV['DATA_STORAGE'], 'reports')
     FileUtils.mkdir_p(csv_directory)
-    Rails.root.join(ENV['DATA_STORAGE'], 'reports', 'umappable_affiliations.csv')
+    Rails.root.join(ENV['DATA_STORAGE'], 'reports', 'unmappable_affiliations.csv')
   end
 
   def self.csv_headers
     ['object_id', 'url', 'affiliations']
   end
 
-  def self.create_csv_of_umappable_affiliations
+  def self.create_csv_of_unmappable_affiliations
     CSV.open(csv_file_path, 'a+') do |csv|
       csv << csv_headers
       crawl_for_affiliations do |document_id, url, affiliations|

--- a/spec/jobs/list_unmappable_affiliations_spec.rb
+++ b/spec/jobs/list_unmappable_affiliations_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'active_fedora/cleaner'
 
 RSpec.describe ListUnmappableAffiliationsJob, type: :job do
-  let(:csv_path) { "#{ENV['DATA_STORAGE']}/reports/umappable_affiliations.csv" }
+  let(:csv_path) { "#{ENV['DATA_STORAGE']}/reports/unmappable_affiliations.csv" }
   after do
     FileUtils.remove_entry(csv_path) if File.exist?(csv_path)
   end


### PR DESCRIPTION
Typo also needs to be fixed in hyrax-vagrant code - https://gitlab.lib.unc.edu/cdr/vagrant-rails/-/merge_requests/126 