### PR TITLE
HYC-1390: Create job and service to remediate affiliations

### DIFF
--- a/app/jobs/remediate_affiliations_job.rb
+++ b/app/jobs/remediate_affiliations_job.rb
@@ -1,0 +1,9 @@
+class RemediateAffiliationsJob < Hyrax::ApplicationJob
+  queue_as :long_running_jobs
+
+  def perform
+    csv_path = Rails.root.join(ENV['DATA_STORAGE'], 'reports', 'unmappable_affiliations.csv').to_s
+    service = AffiliationRemediationService.new(csv_path)
+    service.remediate_all_affiliations
+  end
+end

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -1,0 +1,86 @@
+class AffiliationRemediationService
+  def initialize(id_csv_path)
+    @id_csv_path = id_csv_path
+  end
+
+  def person_fields
+    [:advisors, :arrangers, :composers, :contributors, :creators, :project_directors,
+     :researchers, :reviewers, :translators]
+  end
+
+  def remediate_all_affiliations
+    id_list.each do |id|
+      object = object_by_id(id)
+      next unless object
+
+      update_affiliations(object)
+      Rails.logger.info("Updated affiliations for object id: #{object.id}")
+    end
+  end
+
+  def update_affiliations(object)
+    person_fields.each do |person_field|
+      next unless object.attributes.keys.member?(person_field.to_s)
+
+      people_objects = object.try(person_field)
+      new_attributes = []
+      next if people_objects.blank?
+
+      people_objects.each do |person|
+        new_attributes << map_person_attributes(person.attributes)
+      end
+      object[person_field.to_s] = nil
+      object.save!
+      object.update("#{person_field}_attributes" => new_attributes)
+      object.save!
+    end
+  end
+
+  def id_list
+    @id_list ||= begin
+      csv = CSV.parse(File.read(@id_csv_path), headers: true)
+      csv.map { |row| row['object_id'] }
+    end
+  end
+
+  def object_by_id(identifier)
+    ActiveFedora::Base.find(identifier)
+  rescue ActiveFedora::ObjectNotFoundError
+    Rails.logger.warn("Object not found. Object identifier: #{identifier}")
+    nil
+  end
+
+  def affiliation_map
+    @affiliation_map ||= begin
+      csv_path = 'spec/fixtures/files/umappable-affiliations-mapped-final.csv'
+      csv = CSV.parse(File.read(csv_path), headers: true)
+      csv.map { |row| { original_affiliation: row['original_affiliation'], new_affiliation: row['new_affiliation'] } }
+    end
+  end
+
+  def map_to_new_affiliation(unmappable_affiliation)
+    target_hash = affiliation_map.find { |affil| affil[:original_affiliation] == unmappable_affiliation }
+    target_hash.try(:[], :new_affiliation)
+  end
+
+  def map_person_attributes(attributes)
+    # Do a json round trip to force any ActiveTriples into an array
+    attributes_hash = JSON.parse(attributes.to_json)
+    attributes_hash.delete('id')
+    original_affiliation = attributes_hash['affiliation'].first
+    new_affiliation = []
+    if mappable_affiliation?(original_affiliation)
+      new_affiliation << original_affiliation
+    elsif map_to_new_affiliation(original_affiliation)
+      new_affiliation << map_to_new_affiliation(original_affiliation)
+    end
+    attributes_hash.delete('affiliation')
+    attributes_hash['affiliation'] = new_affiliation
+    attributes_hash
+  end
+
+  def mappable_affiliation?(affiliation)
+    mapping = DepartmentsService.label(affiliation)
+    mapping ? true : false
+  end
+end

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -63,7 +63,14 @@ class AffiliationRemediationService
 
   def map_to_new_affiliation(unmappable_affiliation)
     target_hash = affiliation_map.find { |affil| affil[:original_affiliation] == unmappable_affiliation }
-    target_hash.try(:[], :new_affiliation)
+    new_affiliation = target_hash.try(:[], :new_affiliation)
+    return nil if new_affiliation.nil?
+
+    if new_affiliation.include?('|')
+      new_affiliation.split('|')
+    else
+      new_affiliation
+    end
   end
 
   def map_person_attributes(attributes)
@@ -78,7 +85,7 @@ class AffiliationRemediationService
       new_affiliation << map_to_new_affiliation(original_affiliation)
     end
     attributes_hash.delete('affiliation')
-    attributes_hash['affiliation'] = new_affiliation
+    attributes_hash['affiliation'] = new_affiliation.flatten
     attributes_hash
   end
 

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -20,10 +20,7 @@ class AffiliationRemediationService
 
   def update_affiliations(object)
     person_fields.each do |person_field|
-      next unless object.attributes.keys.member?(person_field.to_s)
-
-      people_objects = object.try(person_field)
-      next if people_objects.blank?
+      next unless needs_updated_people?(object, person_field)
 
       update_affiliation_by_person_field(object, person_field)
     end
@@ -88,5 +85,13 @@ class AffiliationRemediationService
   def mappable_affiliation?(affiliation)
     mapping = DepartmentsService.label(affiliation)
     mapping ? true : false
+  end
+
+  def needs_updated_people?(object, person_field)
+    return false unless object.attributes.keys.member?(person_field.to_s)
+
+    return false if object.try(person_field).blank?
+
+    true
   end
 end

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -23,17 +23,23 @@ class AffiliationRemediationService
       next unless object.attributes.keys.member?(person_field.to_s)
 
       people_objects = object.try(person_field)
-      new_attributes = []
       next if people_objects.blank?
 
-      people_objects.each do |person|
-        new_attributes << map_person_attributes(person.attributes)
-      end
-      object[person_field.to_s] = nil
-      object.save!
-      object.update("#{person_field}_attributes" => new_attributes)
-      object.save!
+      update_affiliation_by_person_field(object, person_field)
     end
+  end
+
+  def update_affiliation_by_person_field(object, person_field)
+    people_objects = object.try(person_field)
+
+    new_attributes = []
+    people_objects.each do |person|
+      new_attributes << map_person_attributes(person.attributes)
+    end
+    object[person_field.to_s] = nil
+    object.save!
+    object.update("#{person_field}_attributes" => new_attributes)
+    object.save!
   end
 
   def id_list

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -96,6 +96,8 @@ class AffiliationRemediationService
 
   def mappable_affiliation?(affiliation)
     # No need to check service for empty strings
+    return false unless affiliation
+
     return false if affiliation.empty?
 
     mapping = DepartmentsService.label(affiliation)

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -81,6 +81,9 @@ class AffiliationRemediationService
     new_affiliation = []
     if mappable_affiliation?(original_affiliation)
       new_affiliation << original_affiliation
+    elsif map_to_new_affiliation(original_affiliation) == 'n/a'
+      attributes_hash.delete('other_affiliation')
+      attributes_hash['other_affiliation'] = [original_affiliation]
     elsif map_to_new_affiliation(original_affiliation)
       new_affiliation << map_to_new_affiliation(original_affiliation)
     end

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -83,14 +83,14 @@ class AffiliationRemediationService
     new_affiliation = []
     if mappable_affiliation?(original_affiliation)
       new_affiliation << original_affiliation
-      Rails.logger.debug("Keeping original affiliation: #{original_affiliation}")
+      Rails.logger.info("Keeping original affiliation: #{original_affiliation}")
     elsif map_to_new_affiliation(original_affiliation) == 'n/a'
       attributes_hash.delete('other_affiliation')
       attributes_hash['other_affiliation'] = [original_affiliation]
-      Rails.logger.debug("Moved affiliation #{original_affiliation} to other_affiliation")
+      Rails.logger.info("Moved affiliation #{original_affiliation} to other_affiliation")
     elsif map_to_new_affiliation(original_affiliation)
       new_affiliation << map_to_new_affiliation(original_affiliation)
-      Rails.logger.debug("Mapped affiliation from: #{original_affiliation} to: #{new_affiliation.flatten}")
+      Rails.logger.info("Mapped affiliation from: #{original_affiliation} to: #{new_affiliation.flatten}")
     end
     attributes_hash.delete('affiliation')
     attributes_hash['affiliation'] = new_affiliation.flatten

--- a/app/services/affiliation_remediation_service.rb
+++ b/app/services/affiliation_remediation_service.rb
@@ -84,8 +84,10 @@ class AffiliationRemediationService
     elsif map_to_new_affiliation(original_affiliation) == 'n/a'
       attributes_hash.delete('other_affiliation')
       attributes_hash['other_affiliation'] = [original_affiliation]
+      Rails.logger.debug("Moved affiliation #{original_affiliation} to other_affiliation")
     elsif map_to_new_affiliation(original_affiliation)
       new_affiliation << map_to_new_affiliation(original_affiliation)
+      Rails.logger.debug("Mapped affiliation #{original_affiliation} to #{new_affiliation}")
     end
     attributes_hash.delete('affiliation')
     attributes_hash['affiliation'] = new_affiliation.flatten
@@ -93,6 +95,9 @@ class AffiliationRemediationService
   end
 
   def mappable_affiliation?(affiliation)
+    # No need to check service for empty strings
+    return false if affiliation.empty?
+
     mapping = DepartmentsService.label(affiliation)
     mapping ? true : false
   end

--- a/app/services/departments_service.rb
+++ b/app/services/departments_service.rb
@@ -19,7 +19,6 @@ module DepartmentsService
     authority.find(id).fetch('term')
   rescue StandardError
     Rails.logger.warn "DepartmentsService: cannot find '#{id}'"
-    puts "DepartmentsService: cannot find '#{id}'" # for migration log
     nil
   end
 

--- a/lib/tasks/list_affiliations.rake
+++ b/lib/tasks/list_affiliations.rake
@@ -2,3 +2,8 @@ desc 'Create a csv that affiliations that do not map to solr and their associate
 task list_affiliations: :environment do
   ListUnmappableAffiliationsJob.perform_later
 end
+
+desc 'Remediate affiliations that were previously found'
+task remediate_affiliations: :environment do
+  RemediateAffiliations.perform_later
+end

--- a/lib/tasks/list_affiliations.rake
+++ b/lib/tasks/list_affiliations.rake
@@ -5,5 +5,5 @@ end
 
 desc 'Remediate affiliations that were previously found'
 task remediate_affiliations: :environment do
-  RemediateAffiliations.perform_later
+  RemediateAffiliationsJob.perform_later
 end

--- a/spec/fixtures/files/short_unmappable_affiliations.csv
+++ b/spec/fixtures/files/short_unmappable_affiliations.csv
@@ -1,0 +1,9 @@
+object_id,url,affiliations
+76537342x,https://cdr.lib.unc.edu/concern/articles/76537342x,University of North Carolina at Chapel Hill. Library || University of North Carolina at Chapel Hill. Library
+1544br378,https://cdr.lib.unc.edu/concern/articles/1544br378,University of North Carolina at Chapel Hill. Library
+th83m3811,https://cdr.lib.unc.edu/concern/articles/th83m3811,Department of Economics and Curriculum for the Environment and Ecology; University of North Carolina at Chapel Hill
+4655n73p,https://cdr.lib.unc.edu/concern/articles/s4655n73p,Marsico Lung Institute
+q237j1933,https://cdr.lib.unc.edu/concern/dissertations/q237j1933,Health Informatics
+0z709523j,https://cdr.lib.unc.edu/concern/dissertations/0z709523j,Carolina-Duke Joint Program in German Studies
+8p58pp87q,https://cdr.lib.unc.edu/concern/dissertations/8p58pp87q,Health Informatics
+r494vv549,https://cdr.lib.unc.edu/concern/dissertations/r494vv549,Cell Biology and Physiology

--- a/spec/fixtures/files/umappable-affiliations-mapped-final.csv
+++ b/spec/fixtures/files/umappable-affiliations-mapped-final.csv
@@ -1,0 +1,5176 @@
+original_affiliation,new_affiliation,move_to_other_affiliation?
+University of North Carolina at Chapel Hill. Library,University of North Carolina at Chapel Hill. University Libraries,False
+Department of Economics and Curriculum for the Environment and Ecology; University of North Carolina at Chapel Hill,Department of Economics,False
+Marsico Lung Institute,Marsico Lung Institute/UNC Cystic Fibrosis Center,False
+ineberger Comprehensive Cancer Center,UNC Lineberger Comprehensive Cancer Center,False
+Department of Biochemistry and Molecular Pharmacology,n/a,True
+Cincinnati Childrens Hospital Medical Center,n/a,True
+Colorado School of Public Health,n/a,True
+University of Washington,n/a,True
+Department of Otolaryngology and Head and Neck Surgery,n/a,True
+Division of Pulmonary and Critical Care Medicine,n/a,True
+Center for Health Promotion and Disease Prevention,n/a,True
+Center for Functional GI and Motility Disorders,n/a,True
+"n        From the Epidemiology Branch, National Institute of Environmental Health Sciences, National Institutes of Health, Department of Health and Human Services, Research Triangle Park, NC (HK and SJL); the Departments of Nutrition and Epidemiology (JS) and the Department of Epidemiology (GH and KMR), School of Public Health, the University of North Carolina at Chapel Hill, NC); and the Department of Op",n/a,True
+Department of Biological Psychology; VU University Amsterdam; Amsterdam The Netherlands,n/a,True
+Department of Medical Epidemiology and Biostatistics; Karolinska Institute; Stockholm Sweden,n/a,True
+Department of Psychology and Neuroscience; University of Colorado at Boulder; Boulder Colorado,n/a,True
+"MRC Social Genetic & Developmental Psychiatry Centre; Institute of Psychiatry, King's College London; London United Kingdom",n/a,True
+Stanley Center for Psychiatric Research; Broad Institute of MIT and Harvard; Cambridge Massachusetts,n/a,True
+"The University of Queensland, Queensland Brain Institute; Brisbane Australia",n/a,True
+"National Hospice and Palliative Care Organization, Alexandria, VA",n/a,True
+"RTI International, Research Triangle Park, NC",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC",University of North Carolina at Chapel Hill,False
+"Chatham Social Health Council, Pittsboro, North Carolina",n/a,True
+"Department of Health Behavior and Health Education, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Health Behavior,False
+"Department of Health Behavior and Health Education, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, Orange County Health Department, United Voices of Efland, Hillsborough, North Carolina",Department of Health Behavior,False
+"Department of Nutrition, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Nutrition,False
+"San Diego State University, Graduate School of Public Health, Center for Behavioral and Community Health Studies, San Diego, California, ",n/a,True
+"Section on Society and Health, Department of Social Sciences and Health Policy, Division of Public Health Sciences, Maya Angelou Research Center on Minority Health, and Section on Infectious Diseases, Department of Internal Medicine, Medical Center Boulevard, Wake Forest University Health Sciences, Winston-Salem, North Carolina",n/a,True
+"Strengthening The Black Family, Inc., Raleigh, North Carolina",n/a,True
+"University of North Carolina, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"University of North Carolina, Chapel Hill, NC, USA, ",University of North Carolina at Chapel Hill,False
+"UNC Gillings School of Global Public Health, Chapel Hill, NC, USA",Gillings School of Global Public Health,False
+"UNC Gillings School of Global Public Health, Chapel Hill, NC, USA, ",Gillings School of Global Public Health,False
+"UNC Gillings School of Global Public Health, Chapel Hill, NC, USA, Lineberger Comprehensive Cancer Center, Chapel Hill, NC, USA",UNC Lineberger Comprehensive Cancer Center|Gillings School of Global Public Health,False
+"Duke University, Durham, NC, USA",n/a,True
+"University of Alabama Birmingham, Birmingham, AL, USA",n/a,True
+"University of Mississippi Medical Center, Jackson, MS, USA",n/a,True
+"University of Mississippi Medical Center, Jackson, MS, USA, Jackson State University, Jackson, MS, USA, Duke University, Durham, NC, USA, ",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"University of South Alabama, Mobile, AL, USA",n/a,True
+"Wake Forest University School of Medicine, Winston-Salem, NC, USA",n/a,True
+"University of Iowa, Iowa City, IA, USA",n/a,True
+"University of North Carolina–Chapel Hill, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"Wake Forest University, Winston-Salem, NC, USA",n/a,True
+"North Carolina Central University, Durham, NC, USA",n/a,True
+"Case Western Reserve University–Metro Health Medical Center, Cleveland, Ohio",n/a,True
+"Columbia University, New York, New York",n/a,True
+"Department of Obstetrics and Gynecology at the Oregon Health and Science University, Portland, Oregon",n/a,True
+"Drexel University, Philadelphia, Pennsylvania",n/a,True
+"Northwestern University, Chicago, Illinois",n/a,True
+"The George Washington University Biostatistics Center, Washington, District of Columbia",n/a,True
+"The Ohio State University, Columbus, Ohio",n/a,True
+"The University of Texas Health Science Center at Houston, Houston, Texas",n/a,True
+"University of Alabama at Birmingham, Birmingham, Alabama",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",University of North Carolina at Chapel Hill,False
+"University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"University of Texas Southwestern Medical Center, Dallas, Texas",n/a,True
+"University of Utah, Salt Lake City, Utah",n/a,True
+"Wake Forest University Health Sciences, Winston-Salem, North Carolina",n/a,True
+"Wayne State University, Detroit, Michigan",n/a,True
+"Department of Obstetrics and Gynecology, Penn State University College of Medicine;",n/a,True
+"Division of Biostatistics, Department of Public Health Sciences, Penn State College for Medicine, Hershey, Pennsylvania.",n/a,True
+"Division of Maternal Fetal Medicine, Department of Obstetrics and Gynecology, University of North Carolina School of Medicine, Chapel Hill, North Carolina;",Department of Obstetrics and Gynecology,False
+"Bethesda, Maryland",n/a,True
+"Case Western Reserve University-MetroHealth Medical Center, Cleveland, Ohio",n/a,True
+"Department of Obstetrics and Gynecology, Wayne State University, Detroit, Michigan",n/a,True
+"The Department of Obstetrics and Gynecology, Northwestern University, Chicago, Illinois",n/a,True
+"Thomas Jefferson University, Philadelphia, Pennsylvania",n/a,True
+"University of Alabama at Birmingham, Alabama",n/a,True
+"University of Miami, Miami, Florida",n/a,True
+"University of Tennessee, Memphis, Tennessee",n/a,True
+"Department of Obstetrics and Gynecology at University of Texas Medical Branch, Galveston, Texas",n/a,True
+"Oregon Health & Science University, Portland, Oregon",n/a,True
+"The George Washington University Biostatistics Center, Washington, DC",n/a,True
+"The University of Texas Southwestern Medical Center, Dallas, Texas",n/a,True
+"Department of Obstetrics and Gynecology, Case Western Reserve University-MetroHealth Medical Center, Cleveland, Ohio",n/a,True
+"Department of Obstetrics and Gynecology, Columbia University, New York",n/a,True
+"Department of Obstetrics and Gynecology, Drexel University, Philadelphia, Pennsylvania",n/a,True
+"Department of Obstetrics and Gynecology, Northwestern University, Chicago, Illinois",n/a,True
+"Department of Obstetrics and Gynecology, The Ohio State University, Columbus, Ohio",n/a,True
+"Department of Obstetrics and Gynecology, University of Alabama at Birmingham, Birmingham, Alabama",n/a,True
+"Department of Obstetrics and Gynecology, University of North Carolina at Chapel Hill, Chapel Hill",Department of Obstetrics and Gynecology,False
+"Department of Obstetrics and Gynecology, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Department of Obstetrics and Gynecology, University of Texas Health Science Center at Houston, Houston, Texas",n/a,True
+"Department of Obstetrics and Gynecology, University of Texas Medical Branch, Galveston, Texas",n/a,True
+"Department of Obstetrics and Gynecology, University of Texas Southwestern Medical Center, Dallas, Texas",n/a,True
+"Department of Obstetrics and Gynecology, University of Utah, Salt Lake City, Utah",n/a,True
+"Department of Obstetrics and Gynecology, Wake Forest University Health Sciences, Winston-Salem, North Carolina",n/a,True
+"Department of Obstetrics and Gynecology of the Oregon Health and Science University, Portland, Oregon",n/a,True
+"The George Washington University Biostatistics Center, Rockville, Maryland",n/a,True
+"University of Texas Medical Branch, Galveston, Texas",n/a,True
+"Department of Obstetrics and Gynecology University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Obstetrics and Gynecology,False
+"Department of Obstetrics and Gynecology University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Department of Obstetrics and Gynecology University of Texas Health Science Center at Houston, Houston, Texas",n/a,True
+"Department of Obstetrics and Gynecology, Oregon Health & Science University, Portland, Oregon",n/a,True
+"Department of Obstetrics and Gynecology, University of Cincinnati, Cincinnati, Ohio",n/a,True
+"Department of Biostatistics, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Biostatistics,False
+"Division of Neonatal-Perinatal Medicine, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Pediatrics,False
+"Duke Clinical Research Institute, Durham, North Carolina",n/a,True
+"Pediatrix Medical Group, Greenville, Sunrise, Florida",n/a,True
+"Department of Obstetrics and Gynecology, Columbia University, New York, New York",n/a,True
+"Department of Obstetrics and Gynecology, Northwestern University Feinberg School of Medicine, Chicago, Illinois",n/a,True
+"Department of Obstetrics and Gynecology, The George Washington University Biostatistics Center, Washington, District of Columbia",n/a,True
+"Department of Obstetrics and Gynecology, University of Alabama at Birmingham, Birmingham Alabama",n/a,True
+"Department of Obstetrics and Gynecology, University of Miami, Miami, Florida",n/a,True
+"Department of Obstetrics and Gynecology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Obstetrics and Gynecology,False
+"Department of Biostatistics, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Biostatistics,False
+"Department of Epidemiology, Gillings School of Global Public Health, Carolina Population Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Epidemiology|Carolina Population Center,False
+"Department of Obstetrics and Gynecology, University of North Carolina School of Medicine, Chapel Hill, North Carolina",Department of Obstetrics and Gynecology,False
+"Division of Genetics and Endocrinology, Children's Hospital of Boston, Harvard Medical School, Boston, Massachusetts",n/a,True
+"Department of Pediatrics, University of North Carolina, Chapel Hill, North Carolina",Department of Pediatrics,False
+"Duke University Medical Center, Duke Clinical Research Institute, Durham, North Carolina",n/a,True
+"Duke-National University of Singapore Graduate Medical School, Singapore",n/a,True
+"Pediatrix-Obstetrix Center for Research and Education, Sunrise, Florida",n/a,True
+"Biostatistics Center, The George Washington University, Washington, District of Columbia",n/a,True
+"Department of Obstetrics and Gynecology, Brown University, Providence, Rhode Island",n/a,True
+"Department of Obstetrics and Gynecology, MetroHealth Medical Center, Case Western Reserve University, Cleveland, Ohio",n/a,True
+"Department of Obstetrics and Gynecology, The University of Texas Health Science Center at Houston, Houston, Texas",n/a,True
+"Department of Obstetrics and Gynecology, The University of Texas Southwestern Medical Center, Dallas, Texas",n/a,True
+"Department of Obstetrics and Gynecology, University of Tennessee, Memphis, Tennessee",n/a,True
+"Division of Maternal-Fetal Medicine, Department of Obstetrics and Gynecology, Wayne State University, Detroit, Michigan",n/a,True
+"Department of Obstetrics and Gynecology, University of Alabama, Birmingham, Alabama",n/a,True
+"Department of Obstetrics and Gynecology, University of North Carolina, Chapel Hill, North Carolina",Department of Obstetrics and Gynecology,False
+"Department of Obstetrics and Gynecology, George Washington University Biostatistics Center, Washington, District of Columbia",n/a,True
+"Department of Obstetrics and Gynecology, NorthShore University Health System, Evanston, Illinois",n/a,True
+"Department of Obstetrics and Gynecology, Thomas Jefferson University and Drexel University, Philadelphia, Pennsylvania",n/a,True
+"Department of Obstetrics and Gynecology, University of Texas Health Science Center at Houston-Children's Memorial Hermann Hospital, Houston, Texas",n/a,True
+"The Eunice Kennedy Shriver National Institute of Child Health and Human Development, Bethesda, Maryland",n/a,True
+"Division of Maternal-Fetal Medicine, Department of Obstetrics and Gynecology, Jefferson Medical College of Thomas Jefferson University, Philadelphia, Pennsylvania",n/a,True
+"Division of Maternal-Fetal Medicine, Department of Obstetrics and Gynecology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Obstetrics and Gynecology,False
+"George Washington University Biostatistics Center, Washington, District of Columbia",n/a,True
+"Nationwide Children's Hospital, Columbus, Ohio",n/a,True
+"Departments of Obstetrics and Gynecology, Brown University, Providence, Rhode Island",n/a,True
+"Departments of Obstetrics and Gynecology, Case Western Reserve University-MetroHealth Medical Center, Cleveland, Ohio",n/a,True
+"Departments of Obstetrics and Gynecology, Northwestern University, Chicago, Illinois",n/a,True
+"Departments of Obstetrics and Gynecology, The Ohio State University, Columbus, Ohio",n/a,True
+"Departments of Obstetrics and Gynecology, University of Iowa, Iowa City, Iowa",n/a,True
+"Departments of Obstetrics and Gynecology, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Departments of Obstetrics and Gynecology, University of Tennessee, Memphis, Tennessee",n/a,True
+"Departments of Obstetrics and Gynecology, University of Texas Southwestern Medical Center, Dallas, Texas",n/a,True
+"Departments of Obstetrics and Gynecology, Wake Forest University Health Sciences, Winston-Salem, North Carolina",n/a,True
+"Department of Biostatistics, George Washington University Biostatistics Center, Washington, District of Columbia",n/a,True
+"Department of Obstetrics and Gynecology, Eunice Kennedy Shriver National Institute of Child Health and Human Development",n/a,True
+"Department of Obstetrics and Gynecology, Oregon Health and Science University, Portland, Oregon",n/a,True
+"University of Texas Health Science Center at San Antonio, San Antonio, Texas",n/a,True
+"Department of Medicine, Christchurch School of Medicine, Christchurch, New Zealand; and",n/a,True
+"Department of Pathology and Laboratory Medicine, University of North Carolina, Chapel Hill, North Carolina 27599-7525",Department of Pathology and Laboratory Medicine,False
+Department of Obstetrics and Gynecology; Greenville Hospital System; Greenville SC USA,n/a,True
+Department of Obstetrics and Gynecology; University of North Carolina; Chapel Hill NC USA,Department of Obstetrics and Gynecology,False
+"Department of Obstetrics, Gynecology and Reproductive Biology; College of Human Medicine; Michigan State University; Grand Rapids MI USA",n/a,True
+Department of Biostatistics; Gillings School of Global Public Health; University of North Carolina; Chapel Hill NC USA,Department of Biostatistics,False
+Department of Epidemiology; Gillings School of Global Public Health; University of North Carolina; Chapel Hill NC USA,Department of Epidemiology,False
+Department of Microbiology; Icahn School of Medicine at Mount Sinai; New York NY USA,n/a,True
+Department of Obstetrics and Gynecology; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Obstetrics and Gynecology,False
+Mammalian Genotyping Core; Lineberger Comprehensive Cancer Center; School of Medicine; University of North Carolina; Chapel Hill NC USA,UNC Lineberger Comprehensive Cancer Center,False
+Boston University School of Medicine,n/a,True
+"Division TEACH, University of North Carolina",University of North Carolina at Chapel Hill,False
+The University of North Carolina at Chapel Hill,University of North Carolina at Chapel Hill,False
+"Boys Town National Research Hospital, Center for Childhood Deafness, Omaha, NE",n/a,True
+"University of Iowa, Iowa City",n/a,True
+"University of North Carolina, Chapel Hill",University of North Carolina at Chapel Hill,False
+University of Illinois-Chicago,n/a,True
+University of North Carolina-Chapel Hill,University of North Carolina at Chapel Hill,False
+Duke University,n/a,True
+The Ohio State University,n/a,True
+"Federal University of Santa Catarina,  Brazil",n/a,True
+"Federal University of São Paulo,  Brazil",n/a,True
+"Greater Miami Skin and Laser Center,  USA",n/a,True
+"Hospital Angeles,  Mexico",n/a,True
+"Hospital General Dr Manuel Gea González,  México",n/a,True
+"Hospital do Servidor Público Municipal de São Paulo,  Brazil",n/a,True
+"University of Berne,  Switzerland",n/a,True
+"University of Bologna,  Italy",n/a,True
+"University of California,  USA",n/a,True
+"University of Liège,  Belgium",n/a,True
+"University of Miami,  USA",n/a,True
+"University of Mississippi; University of Alabama,  USA",n/a,True
+"University of North Carolina,  USA",University of North Carolina at Chapel Hill,False
+"University of Oregon,  USA",n/a,True
+"University of Washington,  USA",n/a,True
+"Université Libre de Bruxelles,  Belgium",n/a,True
+"Department of Chemistry, University of North Carolina, Chapel Hill, North Carolinar27599, United States",Department of Chemistry,False
+"Department of Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"School of Medicine, University of North Carolina, Chapel Hill, North Carolina 27599, United States",School of Medicine,False
+"Department of §Biomedical Engineering, University of North Carolina, Chapel Hill, North Carolina 27599, UnitedrStates, and North Carolina State University, Raleigh, North Carolina 27695, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Departmentrof Medicinal Chemistry and Masonic Cancer Center, University of Minnesota, Minneapolis, Minnesota 55455,rUnited States",n/a,True
+"Lovelace Respiratory Research Institute, Albuquerque, New Mexico 87108, United States",n/a,True
+"University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",University of North Carolina at Chapel Hill,False
+"Department of Agricultural andrBiological Engineering, Purdue University, West Lafayette, Indiana 47907, United States",n/a,True
+"Lineberger Comprehensive CancerrCenter, Department of Biology, School of Medicine, University of North Carolina, Chapel Hill, North Carolina 27599,rUnited States",UNC Lineberger Comprehensive Cancer Center|Department of Biology,False
+"School ofrBiomedical Engineeringrand Sciences, Virginia Tech-Wake Forest University, Blacksburg, Virginia 24061, United States",n/a,True
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"Department of Pharmacology and Toxicology, Virginia Commonwealth University Medical Center, Richmond, Virginia 23298, United States",n/a,True
+"Division of Molecular Pharmaceutics, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, North Carolina 27599, United States",Division of Molecular Pharmaceutics,False
+"Hitachi High-Technologies, Tokyo, Japan",n/a,True
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599, United States",Department of Chemistry,False
+"Complex Carbohydrate ResearchrCenter, University of Georgia, Athens,rGeorgia 30602, United States",n/a,True
+"Division of Chemical Biologyrand Medicinal Chemistry, Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolinar27599, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"LinebergerrComprehensive CancerrCenter, University of North Carolina, ChapelrHill, North Carolina 27599, United States",UNC Lineberger Comprehensive Cancer Center,False
+"Departmentrof Chemistry and Neuroscience Center University of North Carolina at Chapel Hill Chapel Hill, NC 27599-3290",UNC Neuroscience Center|Department of Chemistry,False
+"Departmentrof Chemistry, Roanoke College, Salem, VA 24153",n/a,True
+"Departmentrof Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599, United States",Department of Chemistry,False
+"Department of Biomedical Engineering,rUniversity of North Carolina, Chapel Hill, North Carolina 27599, UnitedrStates and North Carolina State University, Raleigh, North Carolinar27695, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Department of Chemistry, Universityrof North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"LinebergerrComprehensive CancerrCenter, University of North Carolina, Chapel Hill, North Carolinar27599, United States",UNC Lineberger Comprehensive Cancer Center,False
+"Department of Biostatistics and Department of Endodontics, University of North Carolina, Chapel Hill, North Carolina,r27599, United States",Department of Biostatistics|Department of Endodontics,False
+"Department of Chemistry, University of North Carolina, ChapelrHill, North Carolina 27599, United States",Department of Chemistry,False
+"Department of Pharmacology, University of North Carolina, ChapelrHill, North Carolina 27599, United States",Department of Pharmacology,False
+"Department of Biomedical Engineering, University of North Carolina, Chapel Hill, North Carolinar27599, United States and North Carolina State University, Raleigh, North Carolina 27695, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Departmentrof Pharmacology, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Pharmacology,False
+"Department of BiomedicalrEngineering, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, UnitedrStates",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, NorthrCarolina 27599, United States",Department of Chemistry,False
+"Departmentrof Pathologyrand Laboratory Medicine, Emory University School of Medicine, Atlanta, Georgia 30322, United States",n/a,True
+"Emory Center forrCritical Care, Emory University School of Medicine, Atlanta, Georgia 30322, United States",n/a,True
+"Department of Biomedical Engineering, University of North Carolina, Chapel Hill, North Carolinar27599, United States, and North Carolina State University, Raleigh, North Carolina 27695, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Department of Chemistry, CBr3290, University of North Carolina, ChapelrHill, North Carolina 27599, United States",Department of Chemistry,False
+"Department of Medicine, Divisionrof Hematology/Oncology, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Division of Hematology/Oncology,False
+"BioFluidica, LLC, c/o Carolina Kick-Start, 321 Bondurant Hall, Chapel Hill, North Carolina 27599, United States",n/a,True
+"Departmentrof Biomedical Engineering, University of North Carolina, 152 MacNiderrHall, Campus Box 7575, Chapel Hill, North Carolina 27599-7575, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Departmentrof Chemistry, Louisiana State University, 232 Choppin Hall, Baton Rouge, Louisiana 70803-1804, United States",n/a,True
+"Departmentrof Chemistry, University of North Carolina, Campus Box 3290, Chapel Hill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"Departmentrof Surgery, Division of Surgical Oncology and Endocrine Surgery, University of North Carolina School of Medicine, 170 Manning Drive, Chapel Hill, North Carolina 27514, United States",Division of Surgical Oncology|Department of Surgery,False
+"UNC Lineberger Comprehensive Cancer Center, 101 Manning Drive, ChapelrHill, North Carolina 27514, United States",UNC Lineberger Comprehensive Cancer Center,False
+"University of North Carolina, School of Medicine ChapelrHill, 321 S. ColumbiarStreet, Chapel Hill, NorthrCarolina 27514, United States",School of Medicine,False
+"Departmentrof Chemistry and Physics, University of North Carolina at Pembroke, Pembroke, North Carolina 28372, United States",n/a,True
+"Department of Pharmacology, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Pharmacology,False
+"Departments of Biostatistics and Endodontics, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Endodontics|Department of Biostatistics,False
+"Environmental Public Health Division, National Health and EnvironmentalrEffects Research Laboratory, U.S. Environmental Protection Agency, Research TrianglerPark, North Carolina 27711, United States",n/a,True
+"Departmentrof Biomedical Engineering, North Carolina State University, Raleigh, North Carolina, 27607, United States",n/a,True
+"Departmentrof Chemistry, Louisiana State University, Baton Rouge, Louisiana 70803, United States",n/a,True
+"Departmentrof Chemistry, University of North Carolina at Chapel Hill, CB 3290, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"Novan Therapeutics, 4222 EmperorrBoulevard, Suite 200, Durham, North Carolina 27703, United States",n/a,True
+"Departmentrof Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"Departmentsrof Surgery and Pharmacology, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Surgery|Department of Pharmacology,False
+"LinebergerrComprehensive Cancer Center, University of North Carolina School of Medicine, Chapel Hill, North Carolina 27599, United States",UNC Lineberger Comprehensive Cancer Center,False
+"Departmentrof Biomedical Engineering, University of North Carolina, Chapel Hill, North Carolina 27599, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Departmentrof Neurology, SUNY Downstate Medical Center, Brooklyn, New York 11203, United States",n/a,True
+"CurriculumrinrToxicology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-7461, United States",Curriculum in Toxicology,False
+"Departmentrof Nutrition, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-7461, United States",Department of Nutrition,False
+"Institute of Analytical Chemistry of the ASCR, v. v. i., Veveří 97, 602 00 Brno, Czech Republic",n/a,True
+"Departmentrof Psychology and Neuroscience, University of Colorado, Boulder, Colorado 80309-0345, United States",n/a,True
+"Departmentrof Biomedical Engineering, North Carolina State University, Raleigh, North Carolina 27695, United States",n/a,True
+"Departmentrof Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"Departmentrof Chemistry and Chemical Biology, Northeastern University, Boston, Massachusetts 02115, United States",n/a,True
+Department of Urology; University of North Carolina; Chapel Hill NC USA,Department of Urology,False
+Department of Urology; University of Virginia; Charlottesville VA USA,n/a,True
+Scott Department of Urology; Baylor College of Medicine; Houston TX USA,n/a,True
+Urology of Indiana; Male Reproductive Endocrinology and Surgery; Carmel IN USA,n/a,True
+Division of Cancer Epidemiology and Genetics; National Cancer Institute; National Institutes of Health; Rockville MD USA,n/a,True
+University Department of Growth and Reproduction; Copenhagen University Hospital (Rigshospitalet); Copenhagen Denmark,n/a,True
+"Department of Biostatistics, School of Public Health, University of North Carolina, Chapel Hill, NC, USA",Department of Biostatistics,False
+"Department of Epidemiology, School of Public Health, University of North Carolina, Chapel Hill, NC, USA",Department of Epidemiology,False
+"Department of Surgery, Center for Translational Injury Research, University of Texas Health Science Center-Houston, Houston, TX, USA, ",n/a,True
+"Division of Epidemiology and Community Health, School of Public Health, University of Minnesota, Minneapolis, MN, USA",n/a,True
+"National Health Research Institutes, Taipei, Taiwan, ROC",n/a,True
+Department of Biostatistics; St. Jude Children's Research Hospital; Memphis TN 38105 USA,n/a,True
+Department of Bone Marrow Transplantation and Cellular Therapy; St. Jude Children's Research Hospital; Memphis TN 38105 USA,n/a,True
+"Department of Genetics, Department of Biostatistics; University of North Carolina; Chapel Hill NC 27599 USA",Department of Genetics|Department of Biostatistics,False
+Department of Oncology; St. Jude Children's Research Hospital; Memphis TN 38105 USA,n/a,True
+Department of Pharmaceutical Sciences; St. Jude Children's Research Hospital; Memphis TN 38105 USA,n/a,True
+Department of Statistics and Probability; Michigan State University; East Lansing MI 48824 USA,n/a,True
+Johns Hopkins Medical Institute; Baltimore MD 21231 USA,n/a,True
+"Key Laboratory of Systems and Control, Academy of Mathematics and Systems Science; Chinese Academy of Sciences; Beijing 100190 P.R. China",n/a,True
+University of Colorado School of Medicine and Children's Hospital Colorado; Aurora CO 80045 USA,n/a,True
+"From Indiana University School of Medicine, Regenstrief Institute, Indiana University Melvin and Bren Simon Cancer Center, Richard L. Roudebush Veterans Affairs Medical Center, and Indianapolis Gastroenterology Research Foundation, Indianapolis, Indiana, and University of North Carolina at Chapel Hill, Chapel Hill, North Carolina.",n/a,True
+Department of Preventive Medicine; Northwestern University Feinberg School of Medicine; Chicago; IL,n/a,True
+Departments of Nutrition and Epidemiology; University of North Carolina-Chapel Hill; Chapel Hill; NC,Department of Nutrition|Department of Epidemiology,False
+"Departments of Psychiatry, Neurology, and Epidemiology; University of California, San Francisco and San Francisco VA Medical Center; San Francisco; CA",n/a,True
+"Division of Cardiovascular Sciences; National Heart, Lung, and Blood Institute; Bethesda; MD",n/a,True
+Division of Epidemiology and Community Health; University of Minnesota; Minneapolis; MN,n/a,True
+Division of Research; Kaiser Permanente Northern California; Oakland; CA,n/a,True
+"Laboratory of Epidemiology, Demography, and Biometry; National Institute on Aging; Bethesda; MD",n/a,True
+Department of Cell and Molecular Physiology; University of North Carolina; Chapel Hill; NC,Department of Cell and Molecular Physiology,False
+Department of Community Health Sciences; University of Calgary; Calgary; Alberta; Canada,n/a,True
+Department of Neurology; Korea University College of Medicine; Seoul; South Korea,n/a,True
+Department of Physiology; Hotchkiss Brain Institute; University of Calgary; Calgary; Alberta; Canada,n/a,True
+Departments of Radiology; Keimyung University; Daegu; South Korea,n/a,True
+Neurology; Dongsan Medical Center; Keimyung University; Daegu; South Korea,n/a,True
+Department of Biostatistical Sciences; Division of Public Health Sciences; Wake Forest University School of Medicine; Winston-Salem NC,n/a,True
+Department of Environmental Sciences and Engineering; Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapel Hill NC,Department of Environmental Sciences and Engineering,False
+Department of Epidemiology; Brown University School of Public Health; Providence RI,n/a,True
+Department of Medicine; Brigham and Women's Hospital; Harvard Medical School; Boston MA,n/a,True
+"Department of Neurology; University of Southern California, Keck School of Medicine; Los Angeles CA",n/a,True
+"Department of Preventive Medicine; University of Southern California, Keck School of Medicine; Los Angeles CA",n/a,True
+Department of Psychology; University of Southern California; Los Angeles CA,n/a,True
+Department of Psychology; University of Wisconsin; Milwaukee WI,n/a,True
+"Department of Epidemiology, Gillings School of Global Public Health; University of North Carolina; Chapel Hill NC",Department of Epidemiology,False
+Department of Medicine; Wake Forest School of Medicine; Winston-Salem NC,n/a,True
+Department of Neurology and Feil Family Brain and Mind Research Institute; Weill Cornell Medical College; New York NY,n/a,True
+Division of Cardiology; Weill Cornell Medical College; New York NY,n/a,True
+Division of Epidemiology and Community Health; University of Minnesota; Minneapolis MN,n/a,True
+"Epidemiological Cardiology Research Center, Department of Epidemiology and Prevention; Wake Forest School of Medicine; Winston-Salem NC",n/a,True
+"Department of Epidemiology; Gillings School of Global Public Health, University of North Carolina; Chapel Hill NC",Department of Epidemiology,False
+Departments of Neurology; Neurosurgery; Pharmacology; Radiology; and Kinesiology; and Hershey Brain Analysis Research Laboratory for Neurodegenerative Disorders; Penn State Milton S. Hershey Medical Center; Hershey PA,n/a,True
+"Division of Epidemiology and Community Health; School of Public Health, University of Minnesota; Minneapolis MN",n/a,True
+Division of Geriatric Medicine; University of Mississippi Medical Center; Jackson MS,n/a,True
+"Epidemiology Branch; National Institute of Environmental Health Sciences, Research Triangle Park; NC",n/a,True
+Center for Women's Health Research; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Center for Women's Health Research,False
+Children's Eating Laboratory; Department of Pediatrics; Section of Nutrition; University of Colorado Anschutz Medical Campus; Aurora Colorado,n/a,True
+Department of Nutrition; Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Nutrition,False
+Instituto de Investigacion Nutricional; Lima Peru,n/a,True
+Michigan Public Health Institute; Okemos Michigan,n/a,True
+National Institute of Nutrition; Andhra Pradesh India,n/a,True
+Department of Microbiology; Oregon State University; Corvallis Oregon,n/a,True
+Institute of Marine Sciences; University of North Carolina at Chapel Hill; Morehead City North Carolina,Institute of Marine Sciences,False
+"Department of Biology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-3280; email: , ,",Department of Biology,False
+"Department of Biology, University of North Carolina, Chapel Hill, North Carolina 27599-3280; email:",Department of Biology,False
+"Department of Chemistry and Curriculum in Applied Sciences and Engineering, University of North Carolina, Chapel Hill, North Carolina 27599-3290; email:",Curriculum in Applied Sciences and Engineering|Department of Chemistry,False
+"Genome Integrity and Structural Biology Laboratory, National Institute of Environmental Health Sciences, NIH, Research Triangle Park, North Carolina 27709; email:",n/a,True
+"Department of Microbiology and Immunology, Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, North Carolina 27599; email: , , ",UNC Lineberger Comprehensive Cancer Center|Department of Microbiology and Immunology,False
+"Department of Pharmacology and Experimental Therapeutics, Stritch School of Medicine, Loyola University Chicago, Maywood, Illinois 60153; email:",n/a,True
+"Department of Pharmacology, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-7365; email:",Department of Pharmacology,False
+"Departments of Medicine, Microbiology and Immunology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599",Department of Medicine,False
+"McAllister Heart Institute, University of North Carolina, Chapel Hill, North Carolina 27599; email: , ",UNC McAllister Heart Institute,False
+"Brody School of Medicine, East Caroline University, Greenville, North Carolina 27834",n/a,True
+"Division of Hematology/Oncology, Department of Medicine, University of North Carolina, Chapel Hill, North Carolina 27599; email: ",Division of Hematology/Oncology,False
+Department of Biology and,n/a,True
+"Department of Psychology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599; email: ",Department of Psychology and Neuroscience,False
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, North Carolina 27599; email: ",Department of Epidemiology,False
+"Department of Preventive Medicine, Mount Sinai School of Medicine, New York, NY 10029; email: ",n/a,True
+"Carolina Population Center, University of North Carolina, Chapel Hill, North Carolina; email: ",Carolina Population Center,False
+"Department of Sociology, Duke University, Durham, North Carolina 27708; email: ",n/a,True
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, USA",Department of Chemistry,False
+"Department of Mechanical and Aerospace Engineering, North Carolina State University, Raleigh, North Carolina 27695, USA",n/a,True
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA.",Department of Exercise and Sport Science,False
+" a  US EPA, Research Triangle Park, NC",n/a,True
+" b  VA Northern, California",n/a,True
+" c  University of California, Davis, School of Medicine",n/a,True
+" d  Department of Physiology, Ross University, Portsmouth, Dominica, West Indies",n/a,True
+" e  Department of Pediatrics, Population Health Sciences, and Biomedical Engineering, University of Wisconsin, School of Medicine and Public Health, Madison",n/a,True
+Brigham and Women's Hospital; Boston Massachusetts,n/a,True
+Cincinnati Children's Hospital Medical Center and Cincinnati VA Medical Center; Cincinnati Ohio,n/a,True
+Emory University School of Medicine; Atlanta Georgia,n/a,True
+Hospital for Special Surgery and Weill Cornell Medical College; New York New York,n/a,True
+Johns Hopkins School of Medicine; Baltimore Maryland,n/a,True
+Mayo Clinic; Rochester Minnesota,n/a,True
+Medical University of South Carolina; Charleston,n/a,True
+"Northwestern University, Feinberg School of Medicine; Chicago Illinois",n/a,True
+Oklahoma Medical Research Foundation and University of Oklahoma Health Sciences Center; Oklahoma City,n/a,True
+Oklahoma Medical Research Foundation; Oklahoma City,n/a,True
+State University of New York Downstate Medical Center; Brooklyn,n/a,True
+The Ohio State University Wexner Medical Center; Columbus,n/a,True
+University of Alabama at; Birmingham,n/a,True
+University of California; Los Angeles,n/a,True
+University of California; San Francisco,n/a,True
+University of Florida; Gainesville,n/a,True
+University of North Carolina at; Chapel Hill,University of North Carolina at Chapel Hill,False
+University of Texas Health Science Center at; Houston,n/a,True
+Virginia Commonwealth University Medical Center; Richmond,n/a,True
+Wake Forest School of Medicine; Winston-Salem North Carolina,n/a,True
+Children's Mercy Hospitals and Clinics; Kansas City Missouri,n/a,True
+Duke University Medical Center; Durham North Carolina,n/a,True
+University of North Carolina; Chapel Hill,University of North Carolina at Chapel Hill,False
+Duke University School of Medicine; Durham North Carolina,n/a,True
+New York University School of Medicine and New York University Langone Medical Center; New York New York,n/a,True
+Pfizer Worldwide Research and Development; St. Louis Missouri,n/a,True
+"Boston University School of Public Health, Boston, and National Heart, Lung, and Blood Institute Framingham Heart Study; Framingham; Massachusetts",n/a,True
+"Hebrew SeniorLife, Harvard Medical School, and Harvard School of Public Health; Boston; Massachusetts",n/a,True
+Hebrew SeniorLife; Boston; Massachusetts,n/a,True
+"La Trobe University, Melbourne; Victoria; Australia",n/a,True
+Arthritis Research Centre of Canada; Richmond; British Columbia; Canada,n/a,True
+CDC; Atlanta; Georgia,n/a,True
+"University of British Columbia, Vancouver, and Arthritis Research Centre of Canada; Richmond; British Columbia; Canada",n/a,True
+University of Toronto; Toronto; Ontario; Canada,n/a,True
+Allegheny General Hospital; Pittsburgh Pennsylvania,n/a,True
+Cedars-Sinai Medical Center/University of California; Los Angeles,n/a,True
+"Dalhousie University and Queen Elizabeth II Health Sciences Centre; Halifax, Nova Scotia Canada",n/a,True
+Feinstein Institute; New York New York,n/a,True
+Hanyang University Hospital for Rheumatic Diseases; Seoul South Korea,n/a,True
+Johns Hopkins University; Baltimore Maryland,n/a,True
+Kantonsspital; Schaffhausen Switzerland,n/a,True
+Landspitali University Hospital; Reykjavik Iceland,n/a,True
+"McGill University; Montreal, Quebec Canada",n/a,True
+Northwestern University; Chicago Illinois,n/a,True
+Oklahoma-Medical Research Foundation; Oklahoma City,n/a,True
+St. Thomas' Hospital and King's College London School of Medicine; London UK,n/a,True
+The Karolinksa Institute; Stockholm Sweden,n/a,True
+"Toronto Western Hospital, Toronto, Ontario, Université Laval, Quebéc City, Quebéc, and Centre de Recherché du CHU de Quebéc; Montréal, Quebéc Canada",n/a,True
+"Toronto Western Hospital; Toronto, Ontario Canada",n/a,True
+University College; London UK,n/a,True
+University Hospital Lund; Lund Sweden,n/a,True
+University of Birmingham; Alabama,n/a,True
+"University of Manchester, Manchester Academic Health Science Centre, The Kellgren Centre for Rheumatology, NIHR Manchester Musculoskeletal Biomedical Research Unit, and Central Manchester University Hospitals NHS Foundation Trust; Manchester UK",n/a,True
+University of San Diego; California,n/a,True
+Emory University; Atlanta Georgia,n/a,True
+University of Pittsburgh; Pittsburgh Pennsylvania,n/a,True
+Washington University at St. Louis; St. Louis Missouri,n/a,True
+University of California Davis School of Medicine; Sacramento,n/a,True
+Brigham and Women's Hospital and Harvard School of Public Health; Boston Massachusetts,n/a,True
+University of Michigan; Ann Arbor,n/a,True
+Baltimore Veterans Affairs Maryland Health Care System; Baltimore,n/a,True
+Johns Hopkins University School of Medicine; Baltimore Maryland,n/a,True
+Massachusetts General Hospital; Boston,n/a,True
+"Perelman School of Medicine, University of Pennsylvania; Philadelphia",n/a,True
+Texas Children's Hospital and Baylor College of Medicine; Houston,n/a,True
+UT Southwestern Medical Center and Dallas Veterans Affairs Medical Center; Dallas Texas,n/a,True
+Washington University School of Medicine; St. Louis Missouri,n/a,True
+"Department of Psychiatry and Behavioral Sciences, University of Texas at Houston School of Medicine, 1300 Moursund Street, Houston, TX 77030, U.S.A.",n/a,True
+"Department of Psychiatry, University of North Carolina School of Medicine, Chapel Hill, NC 27599-7160, U.S.A.",Department of Psychiatry,False
+"Department of Psychiatry, University of Texas Health Science Center at San Antonio, San Antonio, TX 78229, U.S.A.",n/a,True
+"Laboratory of Neuro Imaging, Department of Neurology, University of California, Los Angeles, CA 90095, U.S.A.",n/a,True
+"Scientific Institute IRCCS, E. Medea, and Section of Psychiatry, Department of Pathology and Experimental and Clinical Medicine, University of Udine, Udine, Italy",n/a,True
+"Semel Institute for Neuroscience and Human Behavior, University of California, Los Angeles, CA 90095, U.S.A.",n/a,True
+"Department of Cell and Developmental Biology, University of North Carolina, 7109E Neuroscience Research Building, 103 Mason Farm Road, CB7250, UNC School of Medicine, Chapel Hill, NC 27599, U.S.A.",Department of Cell Biology and Physiology,False
+"Department of Neurology, Washington University, 660 S. Euclid Avenue, St. Louis, MO 63110, U.S.A.",n/a,True
+"Department of Pediatrics, Washington University, 660 S. Euclid Avenue, St. Louis, MO 63110, U.S.A.",n/a,True
+"Department of Pathology and Laboratory Medicine, University of British Columbia, Vancouver, British Columbia, Canada V5Z 4H4",n/a,True
+"Department of Pediatrics, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, U.S.A.",Department of Pediatrics,False
+"Seoul National University Boramae Medical Center, Seoul, Korea",n/a,True
+"University of Connecticut, Storrs, CT, USA",n/a,True
+"University of North Carolina at Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"Academic Unit of Psychiatry and Addiction Medicine, ANU Medical School, Canberra, and; Mental Health Service, ACT Health Directorate, Canberra Hospital, Woden, ACT, Australia",n/a,True
+"Academic Unit of Psychiatry and Addiction Medicine, Australian National University Medical School, Canberra, and; Mental Health Service, Australian Capital Territory Health Directorate, Canberra Hospital, Woden, ACT, Australia",n/a,True
+"Center for Medical Imaging and Physiology, Skåne University Hospital, Lund, and; Diagnostic Radiology, Department of Clinical Sciences, Lund University, Lund, Sweden",n/a,True
+"Clinical Memory Research Unit, Department of Clinical Sciences, Lund University, Lund, Sweden",n/a,True
+"Department of Neurobiology, Care Sciences and Society, Division of Clinical Geriatrics, Karolinska Institute, Stockholm, Sweden",n/a,True
+"Departments of Psychiatry and Computer Science, University of North Carolina, Chapel Hill, NC, USA",Department of Psychiatry|Department of Computer Science,False
+"Imaging Genetics Center, University of Southern California (USC) Institute for Neuroimaging and Informatics, Keck School of Medicine, USC, Marina del Rey, CA, USA; Departments of Neurology and Psychiatry, University of California at Los Angeles (UCLA) School of Medicine, UCLA, CA, USA; and Departments of Neurology, Psychiatry, Engineering, Radiology and Ophthalmology, Keck School of Medicine, USC, USA",n/a,True
+"Neuropsychiatry Unit, Royal Melbourne Hospital, Melbourne, and; Melbourne Neuropsychiatry Centre, University of Melbourne and Northwestern Mental Health, Melbourne, VIC, Australia",n/a,True
+"School of Psychiatry and Clinical Neurosciences, University of Western Australia, Crawley; and; Peel and Rockingham Kwinana Mental Health Service, Rockingham, WA, Australia",n/a,True
+"School of Psychology and Psychiatry, Faculty of Medicine, Nursing and Health Sciences, Monash University, Melbourne, VIC, Australia",n/a,True
+"Discipline of Psychiatry, Sydney Medical School, University of Sydney, Sydney, Australia",n/a,True
+"Melbourne Neuropsychiatry Centre, University of Melbourne and Melbourne Health, Melbourne, Australia",n/a,True
+"Neuroimaging Research and Analysis Laboratories, University of North Carolina, Chapel Hill, USA",Department of Psychiatry,False
+"Carolina Institute for Developmental Disabilities, University of North Carolina at Chapel Hill, USA",Carolina Institute for Developmental Disabilities,False
+"Carolina Institute for Developmental Disabilities, University of North Carolina at Chapel Hill, USA, ",Carolina Institute for Developmental Disabilities,False
+"Carolina Institute for Developmental Disabilities, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Carolina Institute for Developmental Disabilities,False
+"Division of Occupational Science and Occupational Therapy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Division of Occupational Science and Occupational Therapy,False
+"Groden Center, Providence, Rhode Island, USA",n/a,True
+"University of North Carolina at Chapel Hill, USA",University of North Carolina at Chapel Hill,False
+"Cleveland Clinic, USA",n/a,True
+"Kennedy Krieger Institute, USA",n/a,True
+"Stanford University, USA",n/a,True
+"University Hospitals Case Medical Center, USA",n/a,True
+"Washington University in St. Louis, USA",n/a,True
+"Frank Porter Graham Child Development Institute, USA and University of North Carolina at Chapel Hill, USA",Frank Porter Graham Child Development Institute,False
+"Northwestern University, USA",n/a,True
+"The University of North Carolina at Chapel Hill, USA",University of North Carolina at Chapel Hill,False
+Center for Neurosensory Disorders; University of North Carolina School of Dentistry; Chapel Hill; NC,Center for Pain Research and Innovation,False
+Department of Allied Health Sciences; Division of Occupational Science and Occupational Therapy; University of North Carolina; Chapel Hill; NC,Department of Allied Health Sciences|Division of Occupational Science and Occupational Therapy,False
+Kennedy Krieger Institute; Johns Hopkins University; Baltimore; MD,n/a,True
+Center on Child Development and Disabilities; University of Washington; Seattle Washington,n/a,True
+Department of Psychiatry; University of California; Los Angeles California,n/a,True
+Department of Psychiatry; University of North Carolina; Chapel Hill North Carolina,Department of Psychiatry,False
+Carolina Institute for Developmental Disabilities; School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Carolina Institute for Developmental Disabilities,False
+School of Behavioral and Brain Sciences; The University of Texas at Dallas; Richardson; Texas,n/a,True
+The Menninger Clinic and Baylor College of Medicine,n/a,True
+"The University of South Dakota, Vermillion",n/a,True
+"Veterans Affairs Medical Center and Medical University of South Carolina, Charleston",n/a,True
+"Biochemistry,",n/a,True
+"Department of Biomedical Sciences, College of Medicine, Florida State University, Tallahassee, Florida 32306; and",n/a,True
+"Department of Genetics, Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599",Department of Genetics|UNC Lineberger Comprehensive Cancer Center,False
+Departments of Genetics and,n/a,True
+"Curriculum in Genetics and Molecular Biology, University of North Carolina, Chapel Hill, NC 27599",Curriculum in Genetics and Molecular Biology,False
+"Department of Biochemistry and Biophysics, University of North Carolina, Chapel Hill, NC 27599",Department of Biochemistry and Biophysics,False
+"Department of Biology, University of North Carolina, Chapel Hill, NC 27599",Department of Biology,False
+"Department of Otolaryngology-Head and Neck Surgery, University of North Carolina at Chapel Hill, NC, USA.",Department of Otolaryngology/Head and Neck Surgery,False
+"Johns Hopkins Bloomberg School of Public Health; Department of Epidemiology; 615 N. Wolfe Street, W5010 Baltimore Maryland USA 21205",n/a,True
+MetroWest Medical Center; 115 Lincoln Street Framingham Massachusetts USA 01702,n/a,True
+"University of California, Irvine; Ophthalmology; 118 Med Surge I, Bldg. 810 Mail Code: 4375 Irvine California USA 92697",n/a,True
+University of North Carolina; Department of Ophthalmology; 5151 Bioinformatics Bldg CB #7040 Chapel Hill North Carolina USA 27599,Department of Ophthalmology,False
+" a   Dept. of Biostatistics , University of North Carolina , Cb#7400,  Chapel Hill ,  North Carolina ,  27599",Department of Biostatistics,False
+"Department of Dental Ecology, University of North Carolina; Chapel Hill; NC; USA",Department of Dental Ecology,False
+Department of Epidemiology; University of North Carolina; Chapel Hill NC USA,Department of Epidemiology,False
+National Institute of Dental and Craniofacial Research; National Institutes of Health (NIDCR/NIH); Bethesda MD USA,n/a,True
+Office of Science Policy and Analysis; National Institute of Dental and Craniofacial Research; National Institutes of Health (NIDCR/NIH); Bethesda MD USA,n/a,True
+Dental School; University of Texas Health Science Center at San Antonio; San Antonio TX USA,n/a,True
+Kaiser Permanente Center for Health Research; Portland OR USA,n/a,True
+School of Dentistry; University of Alabama at Birmingham; Birmingham AL USA,n/a,True
+School of Dentistry; University of North Carolina; Chapel Hill NC USA,School of Dentistry,False
+Dental School; University of Texas Health Science Center; San Antonio TX 78229 USA,n/a,True
+Kaiser Permanente Center for Health Research; Portland OR 97227 USA,n/a,True
+School of Dentistry; University of Alabama; Birmingham AL 35294 USA,n/a,True
+School of Dentistry; University of North Carolina; Chapel Hill NC 27599 USA,School of Dentistry,False
+Cerebrovascular Center; School of Medicine; The Johns Hopkins Hospital; Baltimore MD USA,n/a,True
+Department of Conservative Dentistry; School of Dentistry; Prince of Songkla University; Hat Yai Songkla Thailand,n/a,True
+Department of Dental Ecology; School of Dentistry; University of North Carolina; Chapel Hill NC USA,Department of Dental Ecology,False
+Division of Epidemiology and Community Health; School of Public Health; University of Minnesota; Minneapolis MN USA,n/a,True
+Division of Geriatrics and Gerontology; Department of Medicine; University of Mississippi Medical Center; Jackson MS USA,n/a,True
+Department of Computer Science; University of North Carolina at Chapel Hill; Brooks Computer Science Building 201 S. Columbia St. Chapel Hill NC USA,Department of Computer Science,False
+"Center for Child and Family Policy, Duke University",n/a,True
+"Department of Psychology, Temple University",n/a,True
+Northeastern University,n/a,True
+Pomona College,n/a,True
+Department of Pharmacology; University of North Carolina; Chapel Hill; North Carolina,Department of Pharmacology,False
+"Graduate Program in Mechanobiology; Mechanobiology Institute, National University of Singapore; Singapore",n/a,True
+Department of Cellular and Molecular Physiology; Penn State College of Medicine; Hershey; Pennsylvania,n/a,True
+"Department of Cell Biology and Physiology; School of Medicine, UNC Chapel Hill; North Carolina",Department of Cell Biology and Physiology,False
+Department of Physics; University of Maryland; College Park Maryland,n/a,True
+Department of Psychiatry; University of California San Diego and VA Healthcare System; San Diego; California; USA,n/a,True
+Depression Clinical and Research Program; Massachusetts General Hospital; Boston; Massachusetts; USA,n/a,True
+Duke-NUS Graduate Medical School Singapore; Singapore,n/a,True
+University of North Carolina School of Medicine; Department of Psychiatry; Chapel Hill; North Carolina; United States,Department of Psychiatry,False
+University of Pittsburgh Medical Center; Western Psychiatric Institute and Clinic; Pittsburgh; Pennsylvania; United States,n/a,True
+University of Pittsburgh; Epidemiology Data Center; Pittsburgh; Pennsylvania; United States,n/a,True
+University of Texas Southwestern Medical Center at Dallas; Dallas; Texas; United States,n/a,True
+VA Medical Center; Tuscaloosa; Alabama; United States,n/a,True
+Behavioral Endocrinology Branch; National Institute of Mental Health; National Institutes of Health; Department of Health & Human Services; Bethesda; Maryland,n/a,True
+"Department of Mental Health, Faculdade de Ciências Médicas; Universidade Nova de Lisboa; Lisbon; Portugal",n/a,True
+Department of Psychiatry; University of North Carolina - Chapel Hill; Chapel Hill; North Carolina,Department of Psychiatry,False
+University of North Carolina McAllister Heart Institute; UNC-Chapel Hill; Chapel Hill North Carolina,UNC McAllister Heart Institute,False
+Department of Cell Biology and Physiology; University of North Carolina at Chapel Hill; North Carolina,Department of Cell Biology and Physiology,False
+Department of Medicine and Clinical Science; Kyoto University Graduate School of Medicine; Kyoto Japan,n/a,True
+"Department of Applied Psychology; NYU, 246 Greene St, Kimball Hall, 8th floor; New York NY 10003",n/a,True
+"Department of HDFS, 110 Henderson South; Pennsylvania State University, University Park; PA 16802",n/a,True
+"Department of Psychology; The Ohio State University, 1835 Neil Avenue; Columbus OH 43210",n/a,True
+"Frank Porter Graham Child Development Center; 521 S. Greensboro Street, CB 8185; NC 27599",n/a,True
+The Research Institute at Nationwide Children's Hospital & The Ohio State University; 575 Children's Crossroad WB5149; Columbus OH 43215,n/a,True
+Carolina Institute for Developmental Disabilities; University of North Carolina at Chapel Hill; USA,Carolina Institute for Developmental Disabilities,False
+Children's Hospital of Philadelphia; University of Pennsylvania; USA,n/a,True
+Scientific Computing and Imaging Institute; University of Utah; USA,n/a,True
+"Division of Maternal-Fetal Medicine, Department of Obstetrics and Gynecology; University of North Carolina; Chapel Hill; NC",Department of Obstetrics and Gynecology,False
+"Division of Maternal-Fetal Medicine, Department of Obstetrics, and Gynecology; Baylor College of Medicine; Houston; TX",n/a,True
+"Memorial Health University Medical Center; Mercer School of Medicine, Savannah Campus; Savannah; GA",n/a,True
+Indiana University School of Medicine; Indianapolis IN USA,n/a,True
+St Joseph Mercy Hospital; Ann Arbor MI USA,n/a,True
+University of North Carolina; Chapel Hill NC USA,University of North Carolina at Chapel Hill,False
+"Department of Endocrinology and Metabolism; Odense University Hospital, University of Southern Denmark; Odense Denmark",n/a,True
+"Department of Medicine, University of North Carolina School of Medicine; Chapel Hill NC USA",Department of Medicine,False
+"Dept. of Nephrology, Hypertension & Rheumatology, Friedrich Alexander University of Erlangen; Munchen Germany",n/a,True
+Diabeteszentrum; Bad Lauterberg Germany,n/a,True
+"Division of Cardiology, Department of Internal Medicine; University of Texas Southwestern; Dallas TX USA",n/a,True
+International Diabetes Center at Park Nicollet; Minneapolis MN USA,n/a,True
+Memorial Sloan-Kettering Cancer Center; New York NY USA,n/a,True
+"Novo Nordisk, A/S; Bagsvaerd Denmark",n/a,True
+"Samuel Lunenfeld Research Institute, Mount Sinai Hospital, University of Toronto; Toronto Canada",n/a,True
+"Thyroid Unit and Department of Medicine; Massachusetts General Hospital, Harvard Medical School; Boston MA USA",n/a,True
+Atlanta Diabetes Associates; Atlanta GA USA,n/a,True
+Coffs Harbour Diabetes Clinic; Coffs Harbour NSW Australia,n/a,True
+Department of Internal Medicine; University of Manitoba; Winnipeg MB Canada,n/a,True
+Department of Medicine; University of North Carolina; Chapel Hill NC USA,Department of Medicine,False
+Endocrine and Metabolic Consultants; Rockville MD USA,n/a,True
+Novo Nordisk A/S; Søborg Denmark,n/a,True
+"Oxford Centre for Diabetes, Endocrinology and Metabolism, and NIHR Oxford Biomedical Research Centre, Churchill Hospital; Oxford UK",n/a,True
+Cancer Prevention Program; Division of Public Health Sciences; Public Health Sciences Laboratories; Fred Hutchinson Cancer Research Center; Seattle; WA,n/a,True
+Department of Biostatistical Sciences; School of Medicine; Wake Forest University; Winston-Salem; NC,n/a,True
+Department of Biostatistics; Gillings School of Global Public Health; School of Nursing; University of North Carolina; Chapel Hill; NC,Department of Biostatistics|School of Nursing,False
+Department of Epidemiology; Colorado School of Public Health; University of Colorado Denver; Aurora; CO,n/a,True
+Department of Health Sciences; Furman University; Greenville; SC,n/a,True
+Department of Nutrition; Gillings School of Global Public Health; University of North Carolina; Chapel Hill; NC; USA,Department of Nutrition,False
+Department of Pediatric Endocrinology and Diabetes; Children's Hospital & Regional Medical Center; Seattle; WA,n/a,True
+Department of Research and Evaluation; Kaiser Permanente Southern California; Pasadena; CA,n/a,True
+Northwest Lipid Metabolism and Diabetes Research Laboratories; University of Washington; Seattle; WA,n/a,True
+Department of Biostatistics; University of North Carolina Gillings School of Public Health; Chapel Hill NC USA,Department of Biostatistics,False
+Department of Psychiatry; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Psychiatry,False
+Division of Paediatric Endocrinology; Department of Paediatrics; Kocaeli University; Kocaeli Turkey,n/a,True
+Division of Paediatric Endocrinology; Department of Paediatrics; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Pediatrics,False
+Albert Einstein College of Medicine; Bronx NY,n/a,True
+Department of Nutrition; University of North Carolina; Chapel Hill NC,Department of Nutrition,False
+George Washington University; Washington DC,n/a,True
+Lund University; Malmö; Sweden and Harvard School of Public Health; Boston MA,n/a,True
+Massachusetts General Hospital and Harvard Medical School; Boston MA,n/a,True
+University of Hawaii; Honolulu HI,n/a,True
+University of Pittsburgh; Pittsburgh PA USA,n/a,True
+Department of Endocrinology and Metabolism; Peking University People's Hospital; Beijing China,n/a,True
+Department of Nutrition; University of North Carolina; Chapel Hill NC USA,Department of Nutrition,False
+Departments of Biostatistics; University of North Carolina; Chapel Hill NC USA,Department of Biostatistics,False
+Barbara Davis Center for Diabetes; University of Colorado School of Medicine; Aurora CO USA,n/a,True
+Children's Endocrinology and Diabetes; WakeMed Children's Hospital; Raleigh NC USA,n/a,True
+Department of Nutrition and Department of Medicine; University of North Carolina Chapel Hill; Chapel Hill NC USA,Department of Nutrition|Department of Medicine,False
+Department of Nutrition; University of North Carolina Chapel Hill; Chapel Hill NC USA,Department of Nutrition,False
+Department of Research; Nemours Children's Clinic; Jacksonville FL USA,n/a,True
+Division of Pediatric Endocrinology; Cincinnati Children's Hospital Medical Center; Cincinnati OH USA,n/a,True
+Division of Pulmonary Medicine and Anderson Center for Health Systems Excellence; Cincinnati Children's Hospital Medical Center; Cincinnati OH USA,n/a,True
+Northwest Lipid Metabolism and Diabetes Research Laboratories; University of Washington; Seattle WA USA,n/a,True
+School of Nursing; University of North Carolina at Chapel Hill; Chapel Hill NC USA,School of Nursing,False
+"Applied Genomics, Inc., Sunnyvale, CA, USA",n/a,True
+"Dept. of Genetics and Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill, NC, USA",Department of Genetics|UNC Lineberger Comprehensive Cancer Center,False
+Department of Psychology; Duke University; Durham USA,n/a,True
+Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill USA,UNC Lineberger Comprehensive Cancer Center,False
+"Biometrics and Advanced Analytics, Eli Lilly and Company, Indianapolis, IN, USA Submitted 26-Mar-2013; accepted 23-Jul-2013.",n/a,True
+"Clinical Trial Solutions, Tessella, Abingdon, Oxfordshire , UK",n/a,True
+"Department of Biostatistics, University of North Carolina at Chapel Hill, NC, USA",Department of Biostatistics,False
+"Innovation, Quintiles, Durham, NC, USA",n/a,True
+"Oncology Biostatistics &amp; Bioinformatics, Sidney Kimmel Comprehensive Cancer Center at Johns Hopkins, Baltimore, MD, USA",n/a,True
+"Statistical Research and Consulting Center, Pfizer Inc, Collegeville, PA, USA",n/a,True
+Department of Psychiatry; Harvard Medical School at Beth Israel Deaconess Medical Center and Massachusetts General Hospital; Boston; Massachusetts; USA,n/a,True
+Department of Psychiatry; UCSD; San Diego; California; USA,n/a,True
+Department of Psychiatry; University of Calgary; Calgary; Alberta; Canada,n/a,True
+Department of Psychiatry; University of North Carolina; Chapel Hill; North Carolina; USA,Department of Psychiatry,False
+Department of Psychiatry; Yale University; New Haven; Connecticut; USA,n/a,True
+Department of Psychiatry; Zucker Hillside Hospital; Long Island; New York; USA,n/a,True
+Departments of Psychology and Psychiatry; Emory University; Atlanta; Georgia; USA,n/a,True
+Department of Psychiatry; Harvard Medical School at Beth Israel Deaconess Medical Center and Massachusetts General Hospital; Boston Massachusetts,n/a,True
+Department of Psychiatry; UCSD; San Diego,n/a,True
+Department of Psychiatry; University of Calgary; Calgary Alberta Canada,n/a,True
+Department of Psychiatry; Zucker Hillside Hospital; Long Island New York,n/a,True
+Department of Psychology; Yale University; New Haven Connecticut,n/a,True
+Departments of Psychology and Psychiatry and Biobehavioral Sciences; UCLA; Los Angeles California,n/a,True
+Departments of Psychology and Psychiatry; Emory University; Atlanta Georgia USA,n/a,True
+Department of Psychiatry; Beth Israel Deaconess Medical Center and Massachusetts General Hospital; Harvard Medical School; Boston Massachusetts USA,n/a,True
+Department of Psychiatry; University of California; San Diego California USA,n/a,True
+Department of Psychiatry; University of North Carolina; Chapel Hill North Carolina USA,Department of Psychiatry,False
+Department of Psychiatry; Zucker Hillside Hospital; Long Island New York USA,n/a,True
+Department of Psychology and Psychiatry and Biobehavioral Sciences; University of California; Los Angeles California USA,n/a,True
+Department of Psychology and Psychiatry; Emory University; Atlanta Georgia USA,n/a,True
+Department of Psychology; Yale University; New Haven Connecticut USA,n/a,True
+Department of Biology; North Carolina State University; Raleigh; North Carolina; 27695,n/a,True
+Department of Biology; University of North Carolina; Chapel Hill; North Carolina; 27599,Department of Biology,False
+Department of Biology; University of Vermont; Burlington; Vermont; 05405,n/a,True
+Department of Ecology and Evolutionary Biology; University of Tennessee; Knoxville; Tennessee; 37996,n/a,True
+Harvard Forest; Harvard University; Petersham; Massachusetts; 01366,n/a,True
+Biology Department; University of North Carolina; Chapel Hill; North Carolina,Department of Biology,False
+Biology Department; University of Washington; Seattle; Washington,n/a,True
+Department of Biological Science; Florida State University; Tallahassee; Florida,n/a,True
+Department of Biological Sciences; University of Notre Dame; Notre Dame; Indiana,n/a,True
+"Department of Ecology, Evolution and Environmental Biology; Columbia University; New York; New York",n/a,True
+Department of Ecology; Evolution and Organismal Biology; Iowa State University; Ames; Iowa,n/a,True
+"Department of Plant Sciences; University of California, Davis; Davis; California",n/a,True
+Environment and Sustainability Program and Department of Biological Sciences; University of South Carolina; Columbia; South Carolina,n/a,True
+National Park Service; Schoodic Education and Research Center and Acadia National Park; Bar Harbor; Maine,n/a,True
+School of Natural Resources and Environment; University of Michigan; Ann Arbor; Michigan,n/a,True
+Department of Biology; The University of North Carolina at Chapel Hill; Chapel Hill; North Carolina; 27599,Department of Biology,False
+Hawaii Institute of Marine Biology; School of Ocean and Earth Science and Technology; University of Hawaii; Kaneohe; Hawaii; 96744,n/a,True
+National Oceanographic Data Center; National Oceanic and Atmospheric Administration; Silver Spring; Maryland; 20910,n/a,True
+The Betty and Gordon Moore Center for Ecosystem Science and Economics; Conservation International; Arlington; Virginia; 22202,n/a,True
+The Cawthron Institute; 98 Halifax Street East; Private Bag 2; Nelson; New Zealand; 7042,n/a,True
+Department of Human Genetics; The University of Chicago; 920 East 58th Street Chicago Illinois 60637,n/a,True
+Department of Biology; University of North Carolina; CB#3280 Chapel Hill NC 27599,Department of Biology,False
+CEFE UMR 5175; CNRS - Université de Montpellier - Université Paul-Valéry Montpellier; EPHE 1919 route de Mende Montpellier CEDEX 5 F-34293 France,n/a,True
+Department of Biology; University of North Carolina; Chapel Hill North Carolina 27599-3280,Department of Biology,False
+Ecoinformatics & Biodiversity; Department of Bioscience; Aarhus University; Ny Munkegade 114 Aarhus C DK-8000 Denmark,n/a,True
+Ecology & Evolutionary Biology; University of Arizona; Biosciences West 310 Tuscon Arizona 85721,n/a,True
+Integrative Biology; University of California; 3040 VLSB Berkeley California 94720-3140,n/a,True
+Missouri Botanical Garden; P.O. 299 St. Louis Missouri 63166-0299,n/a,True
+CNRS; UMR5175; Centre d'Ecologie Fonctionnelle et Evolutive; F-34000 Montpellier France,n/a,True
+Center for Theoretical Study; Charles University in Prague and Academy of Sciences of the Czech Republic; Jilská 1 110 00 Praha Czech Republic,n/a,True
+Department of Biology; University of Maryland; College Park MD 20742 USA,n/a,True
+Department of Biology; University of North Carolina; Chapel Hill NC 27599-3280 USA,Department of Biology,False
+Department of Computer Science and Information Systems; Bradley University; 1501 W Bradley Avenue Peoria IL 61625 USA,n/a,True
+Department of Ecology and Evolutionary Biology; University of Arizona; Tucson AZ 85721 USA,n/a,True
+Ecoinformatics and Biodiversity Group; Department of Bioscience; Aarhus University; DK-8000 Aarhus C Denmark,n/a,True
+"Landcare Research; P.O. Box 69040, Lincoln 7640 New Zealand",n/a,True
+Missouri Botanical Garden; P.O. Box 299 St. Louis MO 63166-0299 USA,n/a,True
+"National Center for Ecological Analysis and Synthesis; University of California; 735 State Street, Suite 300 Santa Barbara CA 93101 USA",n/a,True
+"New York Botanical Garden; 2900 Southern Blvd, Bronx, NY 10458-5126 USA",n/a,True
+School of Biology and Ecology/Sustainability Solutions Initiative; University of Maine; Orono ME 04469 USA,n/a,True
+Department of Biology; Howard Hughes Medical Institute; Curriculum in Genetics and Molecular Biology; Carolina Center for Genome Sciences; University of North Carolina; Chapel Hill NC 27599 USA,n/a,True
+Duke University Program in Genetics and Genomics; Department of Biology; Duke University; Durham NC 27708 USA,n/a,True
+Joint Genome Institute; Walnut Creek CA 94598 USA,n/a,True
+"University of Michigan, Ann Arbor",n/a,True
+"Department of Anatomy and Structural Biology, Albert Einstein College of Medicine, New York, United States",n/a,True
+"Department of Chemistry, Division of Chemical Biology and Medicinal Chemistry, University of North Carolina, Chapel Hill, United States",Department of Chemistry|Division of Chemical Biology and Medicinal Chemistry,False
+"Institute of Molecular Biology, Johannes Gutenberg University of Mainz, Mainz, Germany",n/a,True
+"Laboratory of Receptor Biology and Gene Expression, Center for Cancer Research, National Cancer Institute, National Institutes of Health, Bethesda, United States",n/a,True
+"Department of Biochemistry and Biophysics, University of North Carolina at Chapel Hill, Chapel Hill, United States",Department of Biochemistry and Biophysics,False
+"Department of Chemical Biology and Therapeutics, St Jude Children’s Research Hospital, Memphis, United States",n/a,True
+"Department of Chemistry and Chemical Biology, Cornell University, Argonne, United States",n/a,True
+"Department of Molecular Physiology and Biophysics, University of Iowa, Iowa City, United States",n/a,True
+"Department of Structural Biology, St Jude Children’s Research Hospital, Memphis, United States",n/a,True
+"Hartwell Center for Bioinformatics and Biotechnology, St Jude Children’s Research Hospital, Memphis, United States",n/a,True
+"Institut Curie, CNRS UMR 3306, INSERM U1005, Orsay, France",n/a,True
+"Physical Biosciences Division, Lawrence Berkeley National Laboratory, Berkeley, United States",n/a,True
+"Centre for Gene Regulation and Expression, College of Life Sciences, University of Dundee, Dundee, United Kingdom",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill, Chapel Hill, United States",UNC Lineberger Comprehensive Cancer Center,False
+"Wellcome Trust Genome Campus, Wellcome Trust Sanger Institute, Cambridge, United Kingdom",n/a,True
+"UNC Neuroscience Center, University of North Carolina, Chapel Hill, United States",UNC Neuroscience Center,False
+"Department of Biology and the Carolina Center for Genome Sciences, University of North Carolina at Chapel Hill, Chapel Hill, United States",Department of Biology|Carolina Center for Genome Sciences,False
+"Department of Plant Sciences, University of Cambridge, Cambridge, United Kingdom",n/a,True
+"Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom",n/a,True
+"Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom",n/a,True
+"Children's Brain Tumour Research Centre, University of Nottingham, Nottingham, United Kingdom",n/a,True
+"Department of Hematologic Oncology, Dana-Farber Cancer Institute, Boston, United States",n/a,True
+"Department of Internal Medicine, University of North Carolina, Chapel Hill, United States",Department of Medicine,False
+"Department of Pathology, MD Anderson Cancer Center, Houston, United States",n/a,True
+"Institute of Cancer Research, Sutton, London, United Kingdom",n/a,True
+"Laboratory of Cancer Epigenome, National Cancer Centre, Singapore, Singapore",n/a,True
+"Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia",n/a,True
+"National Institute of Environmental Health Sciences, National Institute of Health, Triangle, North Carolina, United States",n/a,True
+"Weatherall Institute for Molecular Medicine, University of Oxford, Oxford, United Kingdom",n/a,True
+"Cell Biology and Physiology Center, National Heart, Lung, and Blood Institute, Bethesda, United States",n/a,True
+"Curriculum in Genetics and Molecular Biology, University of North Carolina at Chapel Hill, Chapel Hill, United States",Curriculum in Genetics and Molecular Biology,False
+"Cardiovascular Research Institute, University of California, San Francisco, San Francisco, United States",n/a,True
+"Department of Biochemistry, University of Zurich, Zurich, Switzerland",n/a,True
+"Department of Exercise Sciences, Brigham Young University, Provo, United States",n/a,True
+"Cancer Research Institute, Beth Israel Deaconess Cancer Center, Department of Medicine and Pathology, Beth Israel Deaconess Medical Center, Harvard Medical School, Boston, United States",n/a,True
+"Department of Cell Biology, Harvard Medical School, Boston, United States",n/a,True
+"Department of Histology and Embryology, Tongji Medical College, Huazhong University of Science and Technology, Wuhan, China",n/a,True
+"Interdisciplinary Research Center on Biology and Chemistry, Shanghai Institute of Organic Chemistry, Chinese Academy of Sciences, Shanghai, China",n/a,True
+"Lineberger Comprehensive Cancer Center, Department of Biochemistry and Biophysics, University of North Carolina at Chapel Hill, Chapel Hill, United States",Department of Biochemistry and Biophysics|UNC Lineberger Comprehensive Cancer Center,False
+"Molecular and Cell Biology Lab, Institutes of Biomedical Sciences, Fudan University, Shanghai, China",n/a,True
+"Shanghai Institute of Materia Medica, Chinese Academy of Sciences, Shanghai, China",n/a,True
+"Department of Pharmacology and Cancer Biology, Duke University Medical Center, Durham, United States",n/a,True
+"Department of Pharmacology, University of North Carolina at Chapel Hill, Chapel Hill, United States",Department of Pharmacology,False
+"Institute of Integrative Biology, University of Liverpool, Liverpool, United Kingdom",n/a,True
+"Department of Clinical Laboratory; Taiyuan Central Hospital; Taiyuan, Shanxi P. R. China",n/a,True
+"Department of Pharmacology, Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill North Carolina USA",UNC Lineberger Comprehensive Cancer Center|Department of Pharmacology,False
+Institut für Humangenetik; Universitätsklinikum Essen; Essen Germany,n/a,True
+"Laboratory for Novel Sequencing Technology, Functional and Medical Genomics; Berlin Institute for Medical Systems Biology, Max-Delbrueck-Center for Molecular Medicine; Berlin Germany",n/a,True
+"Laboratory for RNA Biology and Posttranscriptional Regulation; Berlin Institute for Medical Systems Biology, Max-Delbrueck-Center for Molecular Medicine; Berlin Germany",n/a,True
+"Laboratory for Systems Biology of Gene Regulatory Elements; Berlin Institute for Medical Systems Biology, Max-Delbrueck-Center for Molecular Medicine; Berlin Germany",n/a,True
+Max-Planck-Institute for Molecular Genetics; Berlin Germany,n/a,True
+Department of Medicine; Vanderbilt University; Nashville TN USA,n/a,True
+Department of Microbiology and Immunology; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Microbiology and Immunology,False
+Division of Infectious Diseases and Vaccinology; School of Public Health; University of California; Berkeley CA USA,n/a,True
+Program in Emerging Infectious Diseases; Duke-NUS Graduate Medical School; Singapore City Singapore,n/a,True
+The Vanderbilt Vaccine Center; Vanderbilt University; Nashville TN USA,n/a,True
+"Centers for Disease Control and Prevention, Atlanta, Georgia, USA; †Universidad del Valle, Guatemala City, Guatemala; and ‡University of North Carolina, Chapel Hill, North Carolina, USA",n/a,True
+"Centers for Disease Control and Prevention, Fort Collins, Colorado, USA;",n/a,True
+"Medical Research Institute, Colombo, Sri Lanka",n/a,True
+"University of California, Berkeley, California, USA;",n/a,True
+"University of North Carolina, Chapel Hill, North Carolina, USA;",University of North Carolina at Chapel Hill,False
+"First Municipal Clinical Infectious Hospital of Novosibirsk, Novosibirsk, Russia;",n/a,True
+"Novosibirsk State Medical Academy, Novosibirsk, Russia;",n/a,True
+"Stanford University, Palo Alto, California, USA;",n/a,True
+"State Research Center of Virology and Biotechnology VECTOR, Koltsovo, Novosibirsk Region, Russia;",n/a,True
+"University of North Carolina, Chapel Hill, North Carolina, USA",University of North Carolina at Chapel Hill,False
+"The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",University of North Carolina at Chapel Hill,False
+"Centers for Disease Control and Prevention, Atlanta, Georgia, USA",n/a,True
+"Emory University, Atlanta, Georgia, USA",n/a,True
+"Office of Public Health Preparedness and Response, Raleigh, North Carolina, USA",n/a,True
+"University of Michigan, Ann Arbor, Michigan, USA",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA;",University of North Carolina at Chapel Hill,False
+"Georgia Division of Public Health, Atlanta, Georgia, USA;",n/a,True
+"US Food and Drug Administration, Laurel, Maryland, USA;",n/a,True
+"University of Georgia, Athens, Georgia, USA;",n/a,True
+"Bundeswehr Institute of Microbiology, Munich, Germany",n/a,True
+"Johns Hopkins Bloomberg School of Public Health, Baltimore, Maryland, USA",n/a,True
+"Kinshasa School of Public Health, Kinshasa, Democratic Republic of Congo",n/a,True
+"Ministry of Health, Kinshasa, Democratic Republic of Congo",n/a,True
+"National Institute of Biomedical Research, Kinshasa, Democratic Republic of Congo",n/a,True
+"National Institutes of Health, Bethesda, Maryland, USA",n/a,True
+"University of California, Los Angeles, California, USA",n/a,True
+"World Health Organization, Geneva, Switzerland",n/a,True
+"World Health Organization, Kinshasa, Democratic Republic of Congo",n/a,True
+"University of Malawi, Blantyre, Malawi;",n/a,True
+"University of Malawi, Blantyre, Malawi;Michigan State University, East Lansing, Michigan, USA",n/a,True
+"University of Maryland School of Medicine, Baltimore, Maryland, USA",n/a,True
+"US Naval Medical Research Unit No. 2, Jakarta, Indonesia",n/a,True
+"University of North Carolina at Chapel Hill School of Public Health, Chapel Hill, North Carolina, USA",Gillings School of Global Public Health,False
+Deceased.,n/a,True
+"RAND Corporation, Santa Monica, CA, USA",n/a,True
+"San Diego State University, CA, USA",n/a,True
+"Technical University of Denmark, Kongens Lyngby",n/a,True
+"The RAND Corporation, Santa Monica, CA, USA",n/a,True
+"University of California, San Diego, USA",n/a,True
+"University of Minnesota, Minneapolis, USA",n/a,True
+"University of North Carolina, Chapel Hill, USA",University of North Carolina at Chapel Hill,False
+Curriculum in Toxicology; University of North Carolina; Chapel Hill North Carolina,Curriculum in Toxicology,False
+"Department of Environmental Sciences and Engineering; Gillings School of Global Public Health, University of North Carolina; Chapel Hill North Carolina",Department of Environmental Sciences and Engineering,False
+"Department of Epidemiology; Gillings School of Global Public Health, University of North Carolina; Chapel Hill North Carolina",Department of Epidemiology,False
+"Department of Genetics; School of Medicine, University of North Carolina; Chapel Hill North Carolina",Department of Genetics,False
+"Department of Nutrition; Gillings School of Global Public Health, University of North Carolina; Chapel Hill North Carolina",Department of Nutrition,False
+Facultad de Medicina; Universidad Juárez del Estado de Durango; Gómez Palacio Durango Mexico,n/a,True
+Arctic Technology; Shell Technology Norway; Oslo N-0277 Norway,n/a,True
+Crop and Soil Sciences; Cornell University; Ithaca NY 14853 USA,n/a,True
+Department of Department of Microbiology Graduate Group; University of California; Davis CA 95616 USA,n/a,True
+Department of Earth Sciences; Indiana University-Purdue University; Indianapolis IN 46202 USA,n/a,True
+Department of Earth and Planetary Sciences; Washington University; St. Louis MO 63130 USA,n/a,True
+Department of Evolution and Ecology; University of California; Davis CA 95616 USA,n/a,True
+Department of Marine Sciences; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 USA,Department of Marine Sciences,False
+Department of Microbiology; Cornell University; Ithaca NY 14853 USA,n/a,True
+Division of Geological and Planetary Sciences; California Institute of Technology; Pasadena CA 91125 USA,n/a,True
+Ecology and Evolutionary Biology; University of Arizona; Tucson AZ 85721 USA,n/a,True
+UC Davis Genome Center; University of California; Davis CA 95616 USA,n/a,True
+Department of Medical Microbiology and Immunology; University of Wisconsin-Madison; Madison WI USA,n/a,True
+Department of Microbiology and Immunology; University of North Carolina; Chapel Hill NC USA,Department of Microbiology and Immunology,False
+"Departmentrof Environmental Sciences and Engineering,rGillings School of Global Public Health, University of North Carolina, Chapel Hill, North Carolina 27599-7431,rUnited States",Department of Environmental Sciences and Engineering,False
+"Center for EnvironmentalrBiotechnology, The University of Tennessee, Knoxville, Tennessee 37996-1605, United States",n/a,True
+"Civil Engineering and EngineeringrMechanics, Columbia University, New York,rNew York 10027, United States",n/a,True
+"Department of Earthrand Planetary Sciences, The University of Tennessee, Knoxville, Tennessee 37996-1410, United States",n/a,True
+"Department of Environmental Science, Barnard College, New York, New York 10027, United States",n/a,True
+"Department of Geography, University of North Carolina—Chapel Hill, ChapelrHill, North Carolina 27599-3220, United States",Department of Geography,False
+"Department of Geology, University of Dhaka, Dhaka 1000, Bangladesh",n/a,True
+"Lamont-Doherty Earth Observatory of Columbia University, Route 9W,rPalisades, New York 10964, United States",n/a,True
+"Departmentrof Environmental Sciences and Engineering, Gillings Schoolrof Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, UnitedrStates",Department of Environmental Sciences and Engineering,False
+"Departmentrof Pediatrics, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NorthrCarolina, United States",Department of Pediatrics,False
+"Department of Environmental Science and Engineering,rGillings School of Global Public Health, University of North Carolina, Chapel Hill, NC",Department of Environmental Sciences and Engineering,False
+"Alion Science and Technology, Research Triangle Park, North Carolina, United States of America",n/a,True
+"Atmospheric Research &amp; Analysis, Inc., Cary, North Carolina, United States of America",n/a,True
+"Department of Environmental Sciences and Engineering, Gillings School of Global Public Health, The University of North Carolina at Chapel Hill, North Carolina, United States of America",Department of Environmental Sciences and Engineering,False
+"Electric Power Research Institute, Palo Alto, California, United States of America",n/a,True
+"Electric Power Research Institute, Washington, DC, United States of America",n/a,True
+"National Exposure Research Laboratory, U.S. Environmental Protection Agency, Research Triangle Park, North Carolina, United States of America",n/a,True
+"Department of Environmental Sciences and Engineering, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, United States",Department of Environmental Sciences and Engineering,False
+"Alion Science and Technology, P.O. Box 12313, Research Triangle Park,rNorth Carolina 27709, United States",n/a,True
+"Chemical Sciences Division, NOAA Earth System Research Laboratory, Boulder, Colorador80305, United States .",n/a,True
+"Cooperative Institute for Researchrin Environmental Sciences, University of Colorado, Boulder, Colorado 80309, United States",n/a,True
+"Department of Atmospheric Sciences, Texas A&amp;M University, College Station, Texas 77843,rUnited States",n/a,True
+"Department of Chemical Engineering, California Institute of Technology, Pasadena, Californiar91125, United States",n/a,True
+"Department of Chemistry, Aarhus University, 8000 Aarhus C, Denmark",n/a,True
+"Department of EnvironmentalrScience, Policy and Management, University of California, Berkeley, California 94720, United States",n/a,True
+"Department of EnvironmentalrSciences and Engineering, Gillings School of Global Public Health, The University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",Department of Environmental Sciences and Engineering,False
+"Instituterof Ion Physics andrApplied Physics, University of Innsbruck, Innsbruck, Austria",n/a,True
+"National Center for Atmospheric Research, Atmospheric Chemistry Division,rBoulder, Colorado 80301, United States",n/a,True
+"Scripps Institutionrof Oceanography, University of California, San Diego, La Jolla, Californiar92093, United States",n/a,True
+"U.S. Environmental Protection Agency, Office of Research and Development,rNational Exposure Research Laboratory, Research Triangle Park, NorthrCarolina 27711, United States",n/a,True
+"Biostatistics and Epidemiology Division, Health Canada, Ottawa, Ontario  K1A 0K9, Canada",n/a,True
+"Departmentrof Physics and AtmosphericrScience, Dalhousie University, Halifax,rNova Scotia B3H 4R2, Canada",n/a,True
+"Division of Environmental HealthrSciences, University of California, Berkeley, Berkeley, California 94720-1900, United States",n/a,True
+"Environmental Sciences and Engineering, University of North Carolina, Chapel Hill, North Carolinar27599, United States",Department of Environmental Sciences and Engineering,False
+"Risk Management Solutions, 7575 Gateway Blvd  Newark, California 94560,rUnited States",n/a,True
+"ZevRoss Spatial Analysis, 120 North Aurora Street, Suite 3A, Ithaca,rNew York 14850, United States",n/a,True
+"Departmentrof EnvironmentalrSciences and Engineering, Gillings School of Global Public Health, 1303 Michael Hooker Research Center, University of North Carolina, Chapel Hill, North Carolina 27599-7431, United States",Department of Environmental Sciences and Engineering,False
+"Departmentrof Environmental Science and Engineering, Gillings School of GlobalrPublic Health, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Environmental Sciences and Engineering,False
+"North CarolinarDepartment of Environment and Natural Resources, Division of WaterrResources,  Raleigh, NorthrCarolina 27699, United States",n/a,True
+"Departmentrof Chemistry, Oregon State University, Corvallis, Oregon 97331, United States",n/a,True
+"Departmentrof Environmental &amp; Molecular Toxicology, Oregon State University, Corvallis, Oregon 97331, United States",n/a,True
+"Departmentrof Environmental Sciences &amp; Engineering, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Department of Environmental Sciences and Engineering,False
+"AtmosphericrChemistry Division, National Center for Atmospheric Research, Boulder, Colorado 80307, United States",n/a,True
+"CooperativerInstitute for Research in Environmental Sciences and Department ofrChemistry and Biochemistry, University of Colorado, Boulder, Colorado 80309, United States",n/a,True
+"Departmentrof Environmental Science, Policy and Management, University of California, Berkeley, California 94720, United States",n/a,True
+"Departmentrof Environmental Sciences and Engineering, Gillings School of GlobalrPublic Health, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Department of Environmental Sciences and Engineering,False
+Department of Biostatistics; University of North Carolina; Chapel Hill; NC; U.S.A.,Department of Biostatistics,False
+Department of Statistics; North Carolina State University; Raleigh; NC; U.S.A.,n/a,True
+Texas Department of State Health Services; Austin; TX; U.S.A.,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill; NC 27599-7420; U.S.A.,Department of Biostatistics,False
+International Centre for Diarrhoeal Disease Research; GPO Box 128; Dhaka 1000; Bangladesh,n/a,True
+"Brain Mind Institute EPFL - Lausanne and Center for Psychiatric Neuroscience, Department of Psychiatry; University of Lausanne Medical School; Lausanne; Switzerland",n/a,True
+Center for Health Sciences; SRI International; Menlo Park; CA; USA,n/a,True
+"Department of Psychiatry and Biobehavioral Sciences, David Geffen School of Medicine; University of California at Los Angeles; Los Angeles; CA; USA",n/a,True
+Department of Psychiatry; University of California at San Diego; San Diego; CA; USA,n/a,True
+Department of Psychiatry; University of Maryland School of Medicine; Baltimore; MD; USA,n/a,True
+Department of Psychiatry; University of Minnesota; Minneapolis; MN; USA,n/a,True
+Department of Psychiatry; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Psychiatry,False
+Department of Psychiatry; University of Pennsylvania; Philadelphia; PA; USA,n/a,True
+Department of Psychology; Florida State University; Tallahassee; FL; USA,n/a,True
+Department of Psychology; Michigan State University; East Lansing; MI; USA,n/a,True
+"Eating Disorders Section, Institute of Psychiatry, King's College; University of London; UK",n/a,True
+Eating Recovery Center; Denver; CO; USA,n/a,True
+Johns Hopkins University School of Medicine; Division of General Internal Medicine; Baltimore MD,n/a,True
+"Laboratory of Neurogenetics, National Institute on Alcohol Abuse and Alcoholism; National Institutes of Health; Bethesda; MD; USA",n/a,True
+Neuropsychiatric Research Biotechnologies; University of Pisa; Pisa; Italy,n/a,True
+New York Presbyterian Hospital-Westchester Division; Weill Medical College of Cornell University; White Plains; NY; USA,n/a,True
+"Roseneck Hospital for Behavioral Medicine, Prien, Germany and Department of Psychiatry; University of Munich (LMU); Munich; Germany",n/a,True
+Scripps Genomic Medicine; The Scripps Research Institute; La Jolla; CA; USA,n/a,True
+Department of Psychology; University of North Carolina at Chapel Hill; NC; USA,Department of Psychology and Neuroscience,False
+Department of Clinical Neuroscience and the Neuropsychiatric Research Institute; Fargo; ND; USA,n/a,True
+"Department of Psychiatry, Institute of Psychiatry; Kings College; London; UK",n/a,True
+Department of Psychiatry; The Toronto Hospital; Toronto; Canada,n/a,True
+Department of Psychiatry; University of California; San Diego; CA; USA,n/a,True
+Department of Psychiatry; University of Pennsylvania School of Medicine; Philadelphia; PA; USA,n/a,True
+"Semel Institute for Neuroscience and Human Behavior, David Geffen School of Medicine; University of California at Los Angeles; Los Angeles; CA; USA",n/a,True
+Virginia Institute for Psychiatric and Behavioral Genetics; Virginia Commonwealth University; Richmond; VA; USA,n/a,True
+Department of Academic Psychiatry; King's College London; London; UK,n/a,True
+Department of Psychiatry and Biobehavioral Sciences; David Geffen School of Medicine; University of California at Los Angeles; Los Angeles; CA; USA,n/a,True
+Department of Psychiatry; University of North Carolina; Chapel Hill; NC; USA,Department of Psychiatry,False
+Department of Psychological Medicine; University of Birmingham; UK,n/a,True
+"Klinik Roseneck, Hospital for Behavioral Medicine; Prien and University of Munich (LMU); Munich; Germany",n/a,True
+Neuropsychiatric Research Institute and Department of Clinical Neuroscience; University of North Dakota School of Medicine and Health Sciences; Fargo; ND; USA,n/a,True
+Department of Psychiatry; University of North Carolina at Chapel Hill; Chapel Hill; NC; 27599; USA,Department of Psychiatry,False
+Department of Academic Psychiatry; King's College London; UK,n/a,True
+"Department of Psychiatry and Biobehavioral Sciences; David Geffen School of Medicine, University of California, Los Angeles; USA",n/a,True
+"Department of Psychiatry, Eating Disorders Clinic; University of California, San Diego; USA",n/a,True
+Department of Psychiatry; The Toronto Hospital; Canada,n/a,True
+Department of Psychiatry; University of Maryland School of Medicine; USA,n/a,True
+Department of Psychiatry; University of North Carolina; USA,Department of Psychiatry,False
+Department of Psychiatry; University of Pennsylvania; USA,n/a,True
+Department of Psychology; Michigan State University; USA,n/a,True
+Eating Recovery Center; USA,n/a,True
+"Klinik Roseneck, Hospital for Behavioral Medicine; Prien and University of Munich (LMU); Germany",n/a,True
+Neuropsychiatric Research Institute; USA,n/a,True
+Neuroscience Program; Michigan State University; USA,n/a,True
+New York Presbyterian Hospital-Westchester Division; Weill Medical College of Cornell University; USA,n/a,True
+Department of Psychiatry and Behavioral Neuroscience; The University of Chicago; Chicago IL USA,n/a,True
+Department of Psychiatry; University of Minnesota; Minneapolis MN USA,n/a,True
+"n        n        Baylor College of Medicine, Department of Medicine, Division of Atherosclerosis and Vascular Medicine, Houston, TX 77030, USA",n/a,True
+"n        n        Center for Applied Genomics, Abramson Research Center, The Children's Hospital of Philadelphia, Philadelphia, PA, USA",n/a,True
+"n        n        Centre for Cardiovascular Genetics, Institute of Cardiovascular Science,n        University College London, Rayne Building, London WC1E 6JF, UK",n/a,True
+"n        n        Centre for Population Health Sciences, University of Edinburgh, Teviot Place, Edinburgh EH8 9AG, UK",n/a,True
+"n        n        Department of Cardiology, Division Heart and Lungs, University Medical Center Utrecht, Utrecht, The Netherlands",n/a,True
+"n        n        Department of Cardiovascular Sciences, University of Leicester, Leicester, UK",n/a,True
+"n        n        Department of Epidemiology, School of Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC 27514, USA",Department of Epidemiology,False
+"n        n        Department of Genetics Environment and Evolution, UCL Genetics Institute, 2nd Floor, Darwin Building, Gower Street, London WC1E 6BT, UK",n/a,True
+"n        n        Department of Medical Genetics, Division of Biomedical Genetics, University Medical Center Utrecht, Utrecht, The Netherlands",n/a,True
+"n        n        Department of Medicine, Brigham and Women's Hospital, Boston, MA, USA",n/a,True
+"n        n        Department of Medicine, McMaster University, Hamilton, ON, CanadaL8S 4L8",n/a,True
+"n        n        Department of Medicine, University of Vermont, 208 South Park Dr, Colchester, VT 05446, USA",n/a,True
+"n        n        Department of Vascular Medicine, Academic Medical Center, Amsterdam 1105 AZ, The Netherlands",n/a,True
+"n        n        Division of Health Sciences, Warwick Medical School, University of Warwick, Coventry, UK",n/a,True
+"n        n        Durrer Center for Cardiogenetic Research, ICIN-Netherlands Heart Institute, Utrecht, The Netherlands",n/a,True
+"n        n        Faculty of Epidemiology and Population Health, London School of Hygiene and Tropical Medicine, Keppel Street, London WC1E 7HT, UK",n/a,True
+"n        n        Genetic Epidemiology Group, Institute of Cardiovacular Science, Faculty of Population Healh Sciences, University College London, 1–19 Torrington Place, London WC1E 6BT, UK",n/a,True
+"n        n        Institute of Cardiovascular and Medical Sciences, University of Glasgow, 126 University Place, Glasgow G12 8TA, UK",n/a,True
+"n        n        Leeds Institute of Genetics, Health and Therapeutics, University of Leeds, Leeds, UK",n/a,True
+"n        n        The University of Texas Health Science Center at Houston, Houston, TX, USA",n/a,True
+"College of Nursing, University of Kentucky, USA",n/a,True
+"Nursing Research and Innovation, Cleveland Clinic, USA",n/a,True
+"School of Nursing, Emory University, USA",n/a,True
+"School of Nursing, University of Pennsylvania, USA",n/a,True
+"University of California Los Angeles School of Nursing, USA",n/a,True
+"University of Michigan School of Nursing, USA",n/a,True
+"University of North Carolina at Chapel Hill, School of Nursing, USA",School of Nursing,False
+"School of Nursing, University of California Los Angeles, USA",n/a,True
+"School of Nursing, University of North Carolina Chapel Hill, USA",School of Nursing,False
+"Emory University Nell Hodgson Woodruff School of Nursing, Atlanta, GA, USA",n/a,True
+"University of Arkansas for Medical Sciences College of Nursing, Little Rock, AR, USA",n/a,True
+"University of Kentucky College of Nursing, Lexington, KY, USA",n/a,True
+"University of Michigan School of Nursing, Ann Arbor, MI, USA",n/a,True
+"University of North Carolina Chapel Hill School of Nursing, Chapel Hill, NC, USA",School of Nursing,False
+Bassett Research Institute; Cooperstown NY USA,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Biostatistics,False
+Department of Medicine; Columbia University College of Physicians and Surgeons; New York NY USA,n/a,True
+Department of Nutritional Sciences; The Pennsylvania State University; University Park PA USA,n/a,True
+Department of Pathology; University of Vermont; Burlington VT USA,n/a,True
+Department of Pediatrics; Columbia University Medical Center; New York NY USA,n/a,True
+Departments of Pathology and Biochemistry; University of Vermont; Burlington VT USA,n/a,True
+"Division of Cardiovascular Sciences; National Heart, Lung, and Blood Institute; Bethesda MD USA",n/a,True
+Pennington Biomedical Research Center; Baton Rouge; LA USA,n/a,True
+School of Public Health; University of Minnesota; Minneapolis MN USA,n/a,True
+Columbia University Medical Center; New York NY United States,n/a,True
+Duke Clinical Research Institute; Duke University Medical Center; Durham NC United States,n/a,True
+"University of North Carolina School of Medicine, Department of Medicine, Division of Cardiology; Chapel Hill NC United States",Division of Cardiology,False
+Department of Medicine; Duke University; Durham NC USA,n/a,True
+Department of Pathology and Laboratory Medicine; University of North Carolina; 701 Brinkhous Bullit Building Chapel Hill NC 27599-7525 USA,Department of Pathology and Laboratory Medicine,False
+"Department of Epidemiology; University of North Carolina at Chapel Hill; Bank of America Center, 137 E. Franklin St, Suite 306 Chapel Hill NC 27514 USA",Department of Epidemiology,False
+Department of Medicine; University of Mississippi; Jackson MS USA,n/a,True
+Department of Medicine; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Medicine,False
+Division of Epidemiology and Community Health; University of Minnesota; Minneapolis MN USA,n/a,True
+Division of Public Health Sciences; Wake Forest University Health Sciences; Winston-Salem NC USA,n/a,True
+"National Heart, Lung, and Blood Institute; Bethesda MD USA",n/a,True
+Columbia University Medical Center; New York NY USA,n/a,True
+University of Arizona; Tucson AZ USA,n/a,True
+Wake Forest University School of Medicine; Winston-Salem NC USA,n/a,True
+Ohio State University; Columbus OH USA,n/a,True
+University of Mississippi Medical Center; Jackson MS USA,n/a,True
+University of North Carolina at Chapel Hill; Chapel Hill NC 27599 USA,University of North Carolina at Chapel Hill,False
+Duke University and the Duke Clinical Research Institute; Durham NC USA,n/a,True
+Montefiore Einstein Center for Heart and Vascular Care; Bronx NY USA,n/a,True
+Thomas Jefferson University; Philadelphia PA USA,n/a,True
+University of North Carolina at Chapel Hill; Chapel Hill NC USA,University of North Carolina at Chapel Hill,False
+Attikon University Hospital; Athens Greece,n/a,True
+British Heart Foundation Cardiovascular Research Centre; University of Glasgow; Glasgow UK,n/a,True
+Center for Cardiovascular Innovation; Northwestern University Feinberg School of Medicine; Chicago IL USA,n/a,True
+Centre for Clinical and Basic Research; IRCCS San Raffaele; Rome Italy,n/a,True
+Hull York Medical School; Kingston-Upon-Hull UK,n/a,True
+University Medical Centre; Groningen The Netherlands,n/a,True
+University of Alabama at Birmingham; Birmingham AL USA,n/a,True
+University of Brescia; Brescia Italy,n/a,True
+Department of Endocrinology; Huadong Hospital; Fudan University; Shanghai; China,n/a,True
+Department of Microbiology and Immunology; University of North Carolina; Chapel Hill; NC; USA,Department of Microbiology and Immunology,False
+Department of Pediatrics; University of Minnesota; Minnesota USA,n/a,True
+"Division of Molecular Immunology; Research Center Borstel, Leibniz Center for Medicine and Biosciences; Borstel Germany",n/a,True
+Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill NC USA,UNC Lineberger Comprehensive Cancer Center,False
+Chinese Academy of Science; Institut Pasteur of Shanghai; Shanghai China,n/a,True
+Department of Immunology; University of North Carolina; NC USA,Department of Microbiology and Immunology,False
+Department of Microbiology and Immunology; Center for Primate Biomedical Research; University of Illinois College of Medicine; Chicago IL USA,n/a,True
+Bowles Center for Alcohol Studies; University of North Carolina; CB #7178; Chapel Hill; NC; 27599-7178; USA,Bowles Center for Alcohol Studies,False
+Department of Anatomy and Cell Biology; University of Pennsylvania School of Dental Medicine; Philadelphia; PA; USA,n/a,True
+Department of Dental Research; University of North Carolina School of Dentistry; Chapel Hill; NC; USA,School of Dentistry,False
+Department of Pediatric Dentistry; University of North Carolina School of Dentistry; Chapel Hill; NC; USA,Department of Pediatric Dentistry,False
+Department of Family Medicine; University of California San Francisco; USA,n/a,True
+Department of Medicine; University of California San Francisco; USA,n/a,True
+Osher Center for Integrative Medicine; University of California San Francisco; USA,n/a,True
+Sheps Center for Health Service Research; University of North Carolina; Chapel Hill USA,Cecil G. Sheps Center for Health Services Research,False
+"University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA.",University of North Carolina at Chapel Hill,False
+"Wake Forest University School of Medicine, Winston-Salem, North Carolina, USA.",n/a,True
+"Cardiovascular Division, Lillehei Heart Institute, University of Minnesota Medical School, Minneapolis, MN, USA",n/a,True
+"Centre for Population Health Sciences, University of Edinburgh, Edinburgh, UK",n/a,True
+"Department of Biostatistics, University of North Carolina, Chapel Hill, NC, USA",Department of Biostatistics,False
+"Department of Clinical Sciences, Skane University Hospital, Lund University, Malmo, Sweden",n/a,True
+"Department of Epidemiology, Erasmus MC, Rotterdam, Netherlands",n/a,True
+"Department of Epidemiology, Graduate School of Public Health, University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"Department of General Practice/Family Medicine, CAPHRI School for Public Health and Primary Care, Maastricht University Medical Centre, Maastricht, Netherlands",n/a,True
+"Department of Geriatric Medicine, John A Burns School of Medicine, University of Hawaii, Honolulu,HI, USA",n/a,True
+"Department of Internal Medicine II – Cardiology, University of Ulm Medical Center, Ulm, Germany",n/a,True
+"Department of Internal Medicine, Maastricht University Medical Centre, Maastricht, Netherlands",n/a,True
+"Department of Medicine, Boston University School of Medicine, Boston, MA, USA",n/a,True
+"Department of Medicine, Northwestern University Feinberg School of Medicine, Chicago, IL, USA",n/a,True
+"Department of Medicine, University of Vermont, Burlington, VT, USA",n/a,True
+"Department of Public Health, Ghent University, Ghent, Belgium",n/a,True
+"Department of Surgical Sciences (Vascular Surgery), Uppsala University, Uppsala, Sweden",n/a,True
+"Diabetes Center, VU University Medical Center, Amsterdam, Netherlands",n/a,True
+"Division of Epidemiology and Community Health, University of Minnesota, Minneapolis, MN, USA",n/a,True
+"Executive Board, VU University Amsterdam, Amsterdam, Netherlands",n/a,True
+"Institute of Epidemiology II, Helmholtz Zentrum Munchen, Neuherberg, Germany",n/a,True
+"Mathematics and Statistics Department, Boston University, Boston, MA, USA",n/a,True
+"School of Public Health, Universite Libre de Bruxelles, Brussels, Belgium",n/a,True
+"School of Surgery, University of Western Australia, Perth, Australia",n/a,True
+"Section of Population Health, University of Aberdeen, Aberdeen, UK",n/a,True
+"Center for Health Studies, Group Health Cooperative, Seattle, WA 98101-1448, USA",n/a,True
+"Center for Integrative Medicine, University of Maryland School of Medicine, Baltimore, MD 21207-6697, USA",n/a,True
+"Chicken Soup Chinese Medicine, San Francisco, CA 94103-2961, USA",n/a,True
+"College of Pharmacy, University of Texas, Austin, TX 78712-0127, USA",n/a,True
+"Department of Anesthesiology, University of Michigan, Ann Arbor, MI 48106, USA",n/a,True
+"Department of Health Sciences, University of York, Heslington, York YO10 5DD, UK",n/a,True
+"Department of Neurology, University of Vermont, Burlington, VT 05405, USA",n/a,True
+"Department of Physiology and Biophysics, Georgetown University Medical Center, Washington, DC 20057-1460, USA",n/a,True
+"Department of Research, Oregon College of Oriental Medicine, Portland, OR 97216-2859, USA",n/a,True
+"Division for Research and Education in Complementary and Integrative Medical Therapies, Harvard Medical School, Boston, MA 02215-3326, USA",n/a,True
+"Martinos Center for Biomedical Imaging, Massachusetts General Hospital, Charlestown, MA 02129-2020, USA",n/a,True
+"Physical Medicine and Rehabilitation, University of North Carolina, Chapel Hill, NC 27599-7200, USA",Department of Physical Medicine and Rehabilitation,False
+"Department of Obstetrics & Gynecology, University of Virginia, P.O. Box 800712, Charlottesville, VA 22908-0712, USA",n/a,True
+"Asian Medicine and Acupuncture Research, Department of Physical Medicine and Rehabilitation, School of Medicine, University of North Carolina-Chapel Hill, Chapel Hill, NC 27514, USA",Department of Physical Medicine and Rehabilitation,False
+"Department of Neuroscience, Brown University, Providence, RI 02912, USA",n/a,True
+"Division of Biostatistics, Department of Public Health Sciences, University of California-Davis, Davis, CA 95616, USA",n/a,True
+"The Center for Musculoskeletal Care and Department of Rehabilitation Medicine, New York University School of Medicine, 333 East 38th Street, 5th Floor, Room 5-103, New York, NY 10016, USA",n/a,True
+"Department of Epidemiology, Mailman School of Public Health, Columbia University, 722 West 168th Street, New York, NY 10032, USA",n/a,True
+Department of Animal Physiology; Institute for Neurobiology; University of Tübingen; Auf der Morgenstelle 28 D-72076 Tübingen Germany,n/a,True
+"Department of Biology; CB# 3280, University of North Carolina; Chapel Hill NC 25799-3280 USA",Department of Biology,False
+"Biochemical Science Division, National Institute of Standards and Technology, 100 Bureau Drive, Mail Stop 8310, Gaithersburg, MD, 20899-8310.",n/a,True
+"Biomatters Ltd, Level 6, 220 Queen St, Auckland, New Zealand.",n/a,True
+"Burnham Institute for Medical Research, La Jolla, CA 92037, U.S.A.",n/a,True
+"Department of Biological Sciences, Hunter College, City University of New York, 695 Park Ave, New York, NY 10021, U.S.A.",n/a,True
+"Department of Biology, CB 3280, University of North Carolina, Chapel Hill, NC 27599.",Department of Biology,False
+"Department of Ecology and Evolutionary Biology, University of Connecticut, 75 North Eagleville Road, Unit 3043, Storrs, CT 06269-3043, U.S.A.",n/a,True
+"Department of Plant and Microbial Biology, University of California, Berkeley, CA 94720, U.S.A.",n/a,True
+"Department of Zoology, University of British Columbia, #2370-6270 University Blvd., Vancouver, B.C. V6T 1Z4, Canada.",n/a,True
+"Dunn Human Nutrition Unit, Medical Research Council, Hills Road, Cambridge CB2 0XY, United Kingdom.",n/a,True
+"EMBL—European Bioinformatics Institute, Wellcome Trust Genome Campus, Hinxton, Cambridge, CB10 1SD, United Kingdom.",n/a,True
+"Genome Information Research Center, Research Institute for Microbial Diseases, Osaka University, 3-1 Yamadaoka, Suita, Osaka 565–0871, Japan.",n/a,True
+"GlaxoSmithKline, 1250 S. Collegeville Road, Collegeville, PA 19426, U.S.A.",n/a,True
+"Human Genome Center, Institute of Medical Science, University of Tokyo, 4-6-1 Shirokanedai, Minato-ku, Tokyo 108–0071, Japan.",n/a,True
+"National Evolutionary Synthesis Center, 2024 W. Main St., Suite A200, Durham NC 27705, U.S.A.",n/a,True
+"Peabody Museum of Natural History, Yale University, 170 Whitney Ave., New Haven CT 06511, U.S.A.",n/a,True
+"School of Computational Science, 150-F Dirac Science Library, Florida State University, Tallahassee, Florida 32306–4120, U.S.A.",n/a,True
+"Section of Evolution and Ecology, Center for Population Biology, 3347 Storer Hall, University of California, Davis, CA 95616, U.S.A.",n/a,True
+"University of California, San Diego, Division of Comparative Pathology and Antiviral Research Center, 150 West Washington Street, San Diego, CA 92103.",n/a,True
+"ZBio LLC, Nyack, NY 10960, U.S.A.",n/a,True
+"Department of Biochemistry, University of Oxford, South Parks Road, Oxford, OX1 3QU, U.K.",n/a,True
+"Department of Pharmacology, University of North Carolina, 27599–7365, U.S.A.",Department of Pharmacology,False
+"Department of Statistics, University of Oxford, 1 South Parks Road, Oxford, OX1 3TG, U.K.",n/a,True
+"Department of Biological Science and the Immunomodulation Research Center, University of Ulsan, Ulsan 680-749, Korea.",n/a,True
+"Department of Biological Science and the Immunomodulation Research Center, University of Ulsan, Ulsan, 680-749, Korea.",n/a,True
+"Department of Medicine, University of North Carolina at Chapel Hill, North Carolina 27599-7248, USA.",Department of Medicine,False
+"Division of Cell and Immunobiology and R&D Center for Cancer Therapeutics, National Cancer Center, Ilsan 410-769, Korea.",n/a,True
+"Division of Endocrinology, The University of North Carolina at Chapel Hill, NC 27599-7170, USA",Division of Endocrinology and Metabolism,False
+"Division of Endocrinology, University of North Carolina, CB# 7170, 5030 Burnett Womack, Chapel Hill, NC 27599-7170, USA",Division of Endocrinology and Metabolism,False
+"Centre for Research in Childhood Health, Institute of Sports Science and Clinical Biomechanics, University of Southern Denmark, Campusvej 55, 5230 Odense M, Denmark",n/a,True
+"Department of Exercise and Sport Science, University of North Carolina, Fetzer Gym, South Road, Chapel Hill, NC 27599-8700, USA",Department of Exercise and Sport Science,False
+"Department of Infectious Diseases and Rheumatology, Institute for Inflammation Research, Rigshospitalet, Blegdamsvej 9, 2100 Copenhagen Ø, Denmark",n/a,True
+Department of Psychology; UNC Chapel Hill; Chapel Hill NC,Department of Psychology and Neuroscience,False
+Depertment of Psychology; University of Vermont; Burlington VT,n/a,True
+Rush University Medical Center; Chicago IL,n/a,True
+The Family Institute at Northwestern University; Evanston IL,n/a,True
+The University of North Carolina; Chapel Hill NC,University of North Carolina at Chapel Hill,False
+Wake Forest University; Winston-Salem NC,n/a,True
+School of Nursing; University of North Carolina at Chapel Hill; Chapel Hill NC,School of Nursing,False
+"Department of Nutrition, School of Public Health and Medicine, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Nutrition|Department of Medicine,False
+"BHF Cardiovascular Medicine, Imperial College, London, UK",n/a,True
+"Carolina Cardiovascular Biology Center, University of North Carolina, Chapel Hill, Chapel Hill, North Carolina, USA; and",UNC McAllister Heart Institute,False
+"Center of Ophthalmology, IBILI, Faculty of Medicine, University of Coimbra, Coimbra, Portugal;",n/a,True
+"Human Nutrition Research Center on Aging, Tufts University, Boston, Massachusetts, USA;",n/a,True
+"Center for Bioinformatics, and",n/a,True
+"Department of Nutrition, School of Public Health and School of Medicine,",n/a,True
+"Community and Preventive Medicine,",n/a,True
+"Department of Environmental Health Sciences, Columbia University, New York, New York, USA",n/a,True
+Department of Epidemiology and,n/a,True
+"Department of Microbiology,",n/a,True
+"Department of Nutrition, University of North Carolina, Chapel Hill, North Carolina, USA; and Department of",Department of Nutrition,False
+"Epidemiology,",n/a,True
+Department of Pharmacology; Lineberger Comprehensive Cancer Center; University of North Carolina at Chapel Hill; NC USA,Department of Pharmacology|UNC Lineberger Comprehensive Cancer Center,False
+Laboratory of Structural Biology; National Institute of Environmental Health Sciences; National Institutes of Health; Research Triangle Park; NC USA,n/a,True
+"College of Biotechnology and Food Engineering; Hefei University of Technology; Anhui, China",n/a,True
+"Department of Chemistry and Chemical Biology, Center for Biotechnology and Interdisciplinary Studies; Rensselaer Polytechnic Institute; Troy; NY; USA",n/a,True
+"Division of Chemical Biology and Medicinal Chemistry, Eshelman School of Pharmacy; University of North Carolina; Chapel Hill; NC; USA",Division of Chemical Biology and Medicinal Chemistry,False
+"Clinical Research Institute, Duke University MedicalrCenter",n/a,True
+Duke University School of Nursing,n/a,True
+Durham Veterans Affairs Medical Center and Duke UniversityrMedical Center,n/a,True
+The University of North Carolina at Chapel Hill Schoolrof Nursing,School of Nursing,False
+Chiang Mai Public Health Office,n/a,True
+Chris Hani Baragwanath Hospital,n/a,True
+Health Sciences Research Council,n/a,True
+International Center for Research on Women,n/a,True
+Muhimbili University of Health and Allied Science,n/a,True
+"University of California, San Francisco",n/a,True
+University of Zimbabwe,n/a,True
+"University of North Carolina at Greensboro, USA",n/a,True
+"Dept. of Nutrition; The Univ. of North Carolina at Chapel Hill; 2200 McGavran-Greenberg Hall, CB #7461; Chapel Hill; NC; 27599-7461; U.S.A.",Department of Nutrition,False
+"Department of Epidemiology, University of North Carolina, Chapel Hill, NC, USA",Department of Epidemiology,False
+"Hospital for Special Surgery, New York, NY, USA",n/a,True
+"Institute for Aging Research, Hebrew SeniorLife, Boston, MA, USA",n/a,True
+"Department of Surgery, University of Heidelberg, 69120, Heidelberg, Germany",n/a,True
+"Division of Gastroenterology and Hepatology, Department of Medicine, University of North Carolina, Chapel Hill, NC 27599, USA",Division of Gastroenterology and Hepatology,False
+"Centro de Intervención e Intervenciones en Salud, León, Nicaragua",n/a,True
+"Division of Gastroenterology and Hepatology, School of Medicine, University of North Carolina at Chapel Hill, Bioinformatics Building, Suite 4143, 130 Mason Farm Road, Chapel Hill, NC 27599-7080, USA",Division of Gastroenterology and Hepatology,False
+"School of Medicine, Universidad Nacional Autónoma de México (UNAM), Hospital General de México, Mexico City, DF, Mexico",n/a,True
+"School of Medicine, Universidad Nacional Autónoma de Nicaragua (UNAN), León, Nicaragua",n/a,True
+"Hospital General Regional Número 36, Instituto Mexicano del Seguro Social, CP 72090 Puebla-PUE, Mexico",n/a,True
+"Laboratory of Liver, Pancreas and Motility (HIPAM), Department of Experimental Medicine, Faculty of Medicine, Hospital General de México, Universidad Nacional Autónoma de México (UNAM), CP 06726 Mexico City, Mexico",n/a,True
+"Puebla Research Coordination, Instituto Mexicano del Seguro Social, CP 72000 Puebla-PUE, Mexico",n/a,True
+"School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599-7080, USA",School of Medicine,False
+"Department of Pathology and Laboratory Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Pathology and Laboratory Medicine,False
+Department of Genetics; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Genetics,False
+Department of Pharmacology and Toxicology; Virginia Commonwealth University; Richmond VA USA,n/a,True
+Laboratory of Neurosciences; Universidade do Extremo Sul Catarinense; Criciúma Brazil,n/a,True
+"Department of Biostatistics, Gillings School of Global Public Health; The University of North Carolina; Chapel Hill, NC USA",Department of Biostatistics,False
+"Department of Psychiatry, School of Medicine; University of North Carolina; Chapel Hill, NC USA",Department of Psychiatry,False
+"Division of Pharmacotherapy and Experimental Therapeutics; Chapel Hill, NC USA",Division of Pharmacotherapy and Experimental Therapeutics,False
+"The Jackson Laboratory; Bar Harbor, ME USA",n/a,True
+Bowles Alcohol Center; University of North Carolina at Chapel Hill; NC USA,Bowles Center for Alcohol Studies,False
+UNC Eating Disorders Program; University of North Carolina at Chapel Hill; NC USA,Department of Psychiatry,False
+"Centre for MEGA Epidemiology, School of Population & Global Health; The University of Melbourne; Melbourne VIC 3010 Australia",n/a,True
+Department of Preventive Oncology; National Center for Tumor Diseases and German Cancer Research Center; 69120 Heidelberg Germany,n/a,True
+Public Health Sciences Division; Fred Hutchinson Cancer Research Center; Seattle WA 98109,n/a,True
+University of North Carolina School of Medicine; Chapel Hill NC 27599,School of Medicine,False
+University of Southern California; Keck School of Medicine; Los Angeles CA 90089,n/a,True
+University of Texas Health Science Center at Houston; Houston TX 77030,n/a,True
+"Department of Molecular Biomedical Sciences; College of Veterinary Medicine, North Carolina State University; Raleigh North Carolina",n/a,True
+"Neuroscience Center, University of North Carolina School of Medicine; Chapel Hill North Carolina",UNC Neuroscience Center,False
+Department of Computer Science; University of North Carolina; Chapel Hill North Carolina,Department of Computer Science,False
+Department of Epidemiology; University of North Carolina; Chapel Hill North Carolina,Department of Epidemiology,False
+Department of Genetics; Rutgers University; Piscataway New Jersey,n/a,True
+Department of Genetics; University of North Carolina; Chapel Hill North Carolina,Department of Genetics,False
+Department of Molecular Physiology and Biophysics; Center for Human Genetics Research; Vanderbilt University; Nashville Tennessee,n/a,True
+Department of Statistics; Rutgers University; Piscataway New Jersey,n/a,True
+Epidemiology Program; University of Hawaii Cancer Center; Honolulu Hawaii,n/a,True
+Human Genetics Center; University of Texas Health Science Center at Houston,n/a,True
+Office of Population Genomics; National Human Genome Research Institute; National Institutes of Health; Bethesda Maryland,n/a,True
+Public Health Sciences; Fred Hutchinson Cancer Research Center; Seattle Washington,n/a,True
+Department of Genetics; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Department of Genetics,False
+Department of Statistics; North Carolina State University; Raleigh; North Carolina,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Biostatistics,False
+Department of Computer Science; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Computer Science,False
+Department of Psychiatry; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Psychiatry,False
+"Department of Genetics, and Lineberger Comprehensive Cancer Center; University of North Carolina at Chapel Hill, Chapel Hill; North Carolina",UNC Lineberger Comprehensive Cancer Center|Department of Genetics,False
+Department of Statistics and Operations Research; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Department of Statistics and Operations Research,False
+Department of Statistics; Oxford; United Kingdom,n/a,True
+Department of Biostatistics; University of North Carolina; Chapel Hill North Carolina United States of America,Department of Biostatistics,False
+Department of Epidemiology; University of North Carolina; Chapel Hill North Carolina United States of America,Department of Epidemiology,False
+Public Health Sciences Division; Fred Hutchinson Cancer Research Center; Seattle Washington United States of America,n/a,True
+Center for Health Sciences; SRI International; Menlo Park California United States of America,n/a,True
+"Department of Biological Psychology; VU University; Amsterdam, Amsterdam The Netherlands",n/a,True
+"Department of Clinical Chemistry, Fimlab Laboratories; Tampere University Hospital and University of Tampere School of Medicine; Tampere Finland",n/a,True
+Department of Epidemiology Research; American Cancer Society; Atlanta Georgia United States of America,n/a,True
+Department of Epidemiology and Public Health; University of Maryland; Baltimore Maryland United States of America,n/a,True
+Department of Epidemiology; MD Anderson; Houston Texas United States of America,n/a,True
+Department of Epidemiology; Michigan State University; East Lansing Michigan United States of America,n/a,True
+"Department of Epidemiology; Queensland Institute of Medical Research; Brisbane, Queensland Australia",n/a,True
+"Department of Genetic Epidemiology in Psychiatry, Central Institute of Mental Health; Clinical Faculty Mannheim / Heidelberg University; Mannheim Germany",n/a,True
+Department of Health Sciences; University of Leicester; Leicester United Kingdom,n/a,True
+Department of Human Genetics; University of Pittsburgh; Pittsburgh Pennsylvania United States of America,n/a,True
+Department of Psychiatry; University of Utah School of Medicine; Salt Lake City Utah United States of America,n/a,True
+Department of Psychiatry; VU University Medical Center; Amsterdam The Netherlands,n/a,True
+Department of Psychiatry; Virginia Commonwealth University; Richmond Virginia United States of America,n/a,True
+Department of Psychiatry; Washington University School of Medicine; St. Louis Missouri United States of America,n/a,True
+"Department of Public Health; Hjelt Institute, University of Helsinki; Helsinki Finland",n/a,True
+Department of Sociology; Brown University; Providence Rhode Island United States of America,n/a,True
+Department of Statistics; University of Oxford; Oxford United Kingdom,n/a,True
+Departments of Psychiatry; Yale University School of Medicine; New Haven Connecticut United States of America,n/a,True
+Division of Cancer Epidemiology and Genetics; National Institute of Health; Bethesda Maryland United States of America,n/a,True
+Division of Pulmonary and Critical Care Medicine; Johns Hopkins University; Baltimore Maryland United States of America,n/a,True
+Institute for Behavioral Genetics; University of Colorado; Boulder Colorado United States of America,n/a,True
+"Institute of Psychiatry, King's College London and Department of Mental Health; St George's University; London United Kingdom",n/a,True
+Karmanos Cancer Institute; Wayne State University; Detroit Michigan United States of America,n/a,True
+University Medicine Greifswald; University of Greifswald; Greifswald Germany,n/a,True
+Department of Biostatistics; Harvard School of Public Health; Boston; Massachusetts,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Department of Biostatistics,False
+Department of Epidemiology; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Department of Epidemiology,False
+Department of Stem Cell Transplantation and Cellular Therapy; MD Anderson Cancer Center; Houston; Texas,n/a,True
+Lineberger Comprehensive Cancer Center; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,UNC Lineberger Comprehensive Cancer Center,False
+Department of Biostatistics and Epidemiology; University of Pennsylvania; Philadelphia; Pennsylvania,n/a,True
+Department of Computer Science; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Department of Computer Science,False
+Department of Biostatistics and Epidemiology; University of Pennsylvania School of Medicine; Philadelphia; Pennsylvania,n/a,True
+Department of Genetics; University of North Carolina; Chapel Hill; North Carolina,Department of Genetics,False
+Department of Epidemiology and Biostatistics; Cancer Center; Nanjing Medical University; Nanjing; Jiangsu; China,n/a,True
+Department of Genetics; Department of Biostatistics; University of North Carolina; Chapel Hill; North Carolina,Department of Genetics|Department of Biostatistics,False
+Key Laboratory for Environment and Health (Ministry of Education); School of Public Health; Huazhong University of Sciences and Technology; Wuhan; Hubei; China,n/a,True
+Laboratory of Cancer Molecular Genetics; Medical College of Soochow University; Suzhou; Jiangsu; China,n/a,True
+Program in Molecular and Genetic Epidemiology; Harvard School of Public Health; Boston; Massachusetts,n/a,True
+Department of Biostatistics and Epidemiology; University of Pennsylvania School of Medicine; Philadelphia Pennsylvania,n/a,True
+Department of Biostatistics; University of North Carolina; Chapel Hill North Carolina,Department of Biostatistics,False
+Cancer Prevention Program; Fred Hutchinson Cancer Research Center; Seattle Washington United States of America,n/a,True
+Center for Public Health Genomics; Department of Public Health Sciences; University of Virginia; Charlottesville Virginia United States of America,n/a,True
+Department of Epidemiology; University of Washington; Seattle Washington United States of America,n/a,True
+Department of Genome Science; University of Washington; Seattle Washington United States of America,n/a,True
+Department of Pathology and Biochemistry; University of Vermont College of Medicine; Burlington Vermont United States of America,n/a,True
+Department of Physiology and Biophysics; University of Mississippi Medical Center; Jackson Mississippi United States of America,n/a,True
+Department of Statistics and Department of Genetics; Stanford University; Stanford California United States of America,n/a,True
+"Departments of Epidemiology, Genetics and Biostatistics; Bioinformatics and Computational Biology; University of North Carolina; Chapel Hill North Carolina United States of America",Department of Epidemiology|Department of Genetics|Department of Biostatistics|Curriculum in Bioinformatics and Computational Biology,False
+Division of Cardiovascular Medicine; Department of Internal Medicine; University of Michigan; Ann Arbor Michigan United States of America,n/a,True
+"Division of Endocrinology, Diabetes and Metabolism; Ohio State University; Columbus Ohio United States of America",n/a,True
+Division of Public Health Sciences; Fred Hutchinson Cancer Research Center; Seattle Washington United States of America,n/a,True
+Division of Pulmonary and Critical Care Medicine; University of Washington; Seattle Washington United States of America,n/a,True
+Montreal Heart Institute and Départment de Médecine; Université de Montréal; Montréal Quebec Canada,n/a,True
+"National Heart, Lung, and Blood Institute Center for Population Studies; The Framingham Heart Study; Framingham Massachusetts United States of America",n/a,True
+Research Institute; Puget Sound Blood Center; Seattle Washington United States of America,n/a,True
+Department of Biostatistics; The University of North Carolina at Chapel Hill; Chapel Hill North Carolina United States of America,Department of Biostatistics,False
+"Department of Biostatistics; University of North Carolina, Chapel Hill; North Carolina United States of America",Department of Biostatistics,False
+"Department of Genetics; University of North Carolina, Chapel Hill; North Carolina United States of America",Department of Genetics,False
+"Department of Psychiatry; University of North Carolina, Chapel Hill; North Carolina United States of America",Department of Psychiatry,False
+"School of Public Health; Harvard, Boston Massachusetts United States of America",n/a,True
+Department of Genetics; University of North Carolina at Chapel Hill; North Carolina United States of America,Department of Genetics,False
+Lineberger Comprehensive Cancer Center; University of North Carolina at Chapel Hill; North Carolina United States of America,UNC Lineberger Comprehensive Cancer Center,False
+Department of Biostatistics; University of North Carolina at Chapel Hill; North Carolina United States of America,Department of Biostatistics,False
+Department of Psychiatry; University of North Carolina at Chapel Hill; North Carolina United States of America,Department of Psychiatry,False
+Department of Biostatistics; UNC Gillings School of Global Public Health; Chapel Hill NC USA,Department of Biostatistics,False
+Department of Endodontics; School of Dentistry; University of North Carolina; Chapel Hill NC USA,Department of Endodontics,False
+Department of Epidemiology; UNC Gillings School of Global Public Health; Chapel Hill NC USA,Department of Epidemiology,False
+Bowles Center for Alcohol Studies; University of North Carolina School of Medicine; Chapel Hill; North Carolina,Bowles Center for Alcohol Studies,False
+Laboratory of Cell Pharmacology; School of Pharmaceutical Sciences; Hebei University; People's Republic of China,n/a,True
+Neuropharmacology Section; NIEHS; Research Triangle Park; North Carolina,n/a,True
+Australian Research Council Centre of Excellence for Coral Reef Studies; School of Biological Sciences; The University of Queensland; St. Lucia; QLD; 4072; Australia,n/a,True
+"CSIRO Mathematics, Informatics and Statistics; Ecosciences Precinct; Brisbane; QLD; 4001; Australia",n/a,True
+Climate Adaptation Flagship; CSIRO Marine and Atmospheric Research; Ecosciences Precinct; Brisbane; QLD; 4001; Australia,n/a,True
+Department of Biology; University of North Carolina; Chapel Hill; NC; 27566; USA,Department of Biology,False
+Farallon Institute for Advanced Ecosystem Research; PO Box 750756; Petaluma; CA; 94952; USA,n/a,True
+National Institute of Aquatic Resources; Technical University of Denmark; Charlottenlund Castle; DK-2920; Charlottenlund; Denmark,n/a,True
+Scottish Association for Marine Science; Scottish Marine Institute; Oban; Argyll; PA; 37 1QA; UK,n/a,True
+"  Department of Economics, University of North Carolina , Chapel Hill, USA",Department of Economics,False
+"  Department of Oncology, Hue Central Hospital , Hue city, Vietnam",n/a,True
+"  Faculty of Public Health and Board Committee of Research and Training Center for Enhancing Quality of Life of Working Age People (REQW), Khon Kaen University , Khon Kaen, Thailand",n/a,True
+"  Graduate School, Khon Kaen University , Khon Kaen, Thailand",n/a,True
+"  Institute of Health Policy, Management and Evaluation, University of Toronto , TorontorOntariorCanada",n/a,True
+"  MEASURE Evaluation, Carolina Population Center, University of North Carolina , Chapel Hill, NC, USA",Carolina Population Center,False
+"  MEASURE Evaluation, Futures Group , Chapel Hill, NC, USA",Carolina Population Center,False
+"  Department of Economics, University of North Carolina , Chapel Hill, NC, USA",Department of Economics,False
+"  Faculty of Public Health, Khon Kaen University , Khon Kaen, Thailand",n/a,True
+"n        Division of Chemical Biology and Medicinal Chemistry, Eshelman School of Pharmacy, Rm 303, Beard Hall",Division of Chemical Biology and Medicinal Chemistry,False
+"n        Division of Hematology/Oncology, Department of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Division of Hematology/Oncology,False
+Biopharm Research Unit; Novo Nordisk A/S; Maaloev; Denmark,n/a,True
+Department of Pathology and Laboratory Medicine; University of North Carolina; Chapel Hill; NC; USA,Department of Pathology and Laboratory Medicine,False
+A. Bianchi Bonomi Hemophilia and Thrombosis Centre; IRCCS Cà Granda Foundation Maggiore Policlinico Hospital and University of Milan; Milan; Italy,n/a,True
+"CHU Sainte-Justine Hospital, Hemophilia Treatment Centre; Montreal; Quebec, Canada",n/a,True
+"Department of Biostatistics; Rho, Inc; Chapel Hill; NC; USA",n/a,True
+Department of Cardiovascular Science; University of Sheffield; Sheffield; UK,n/a,True
+Department of Hematology; Erasmus University Medical Center; Rotterdam; The Netherlands,n/a,True
+Department of Medicine; Rochester General Hospital; Rochester; NY; USA,n/a,True
+Department of Medicine; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Medicine,False
+"Department of Paediatrics; Division of Haematology-Oncology; Hospital for Sick Children; Toronto; Ontario, Canada",n/a,True
+Dr. von Hauner's Children's University Hospital; University of Munich; Munich; Germany,n/a,True
+Haemostasis and Thrombosis Unit; La Paz University Hospital; Madrid; Spain,n/a,True
+Lund University; Malmö Centre for Thrombosis and Haemostasis; Skåne University Hospital; Malmö; Sweden,n/a,True
+"Medical Sciences Institute, BloodCenter of Wisconsin; Milwaukee; WI; USA",n/a,True
+Pediatric Hematology; Medical College of Wisconsin; Comprehensive Center for Bleeding Disorders; BloodCenter of Wisconsin; Milwaukee; WI; USA,n/a,True
+Scientific Direction; IRCCS Cà Granda Maggiore Policlinico Hospital Foundation; Milan; Italy,n/a,True
+Department of Biomedical Engineering University of North Carolina; Chapel Hill NC USA,UNC/NCSU Joint Department of Biomedical Engineering,False
+Gene Therapy Center University of North Carolina; Chapel Hill NC USA,Gene Therapy Center,False
+INSERM U957 Université de Nantes; Nantes France,n/a,True
+Department of Pediatrics; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Pediatrics,False
+Departments of Pediatrics and Hematology/Oncology; Emory University; Atlanta GA USA,n/a,True
+Division of Blood Disorders; National Center for Birth Defects and Developmental Disabilities; Centers for Disease Control and Prevention; Atlanta GA USA,n/a,True
+Division of Hematology/Oncology; Department of Pediatrics; Saint Louis University; St. Louis MO USA,n/a,True
+Department of Biostatistics; Washington University School of Medicine; St. Louis Missouri,n/a,True
+Department of Otolaryngology - Head and Neck Surgery; University of North Carolina; Chapel Hill North Carolina,Department of Otolaryngology/Head and Neck Surgery,False
+Department of Otolaryngology - Head and Neck Surgery; Washington University School of Medicine; St. Louis Missouri,n/a,True
+Broad Institute of Massachusetts Institute of Technology and Harvard; Cambridge Massachusetts,n/a,True
+Department of Medicine; University of California San Francisco; San Francisco California,n/a,True
+Department of Neurosurgery; Johns Hopkins University School of Medicine; Baltimore Maryland,n/a,True
+Department of Oncology; Johns Hopkins University School of Medicine; Baltimore Maryland,n/a,True
+Department of Otolaryngology-Head and Neck Surgery; Johns Hopkins University School of Medicine; Baltimore Maryland,n/a,True
+Department of Otolaryngology-Head and Neck Surgery; Ohio State University; Columbus Ohio,n/a,True
+Department of Otolaryngology-Head and Neck Surgery; University of California San Francisco; San Francisco California,n/a,True
+Department of Pathology; Johns Hopkins University; Baltimore Maryland,n/a,True
+Howard Hughes Medical Institute; Chevy Chase Maryland,n/a,True
+Milton J. Dance Head and Neck Center; Greater Baltimore Medical Center; Baltimore Maryland,n/a,True
+The Ludwig Center and the Howard Hughes Medical Institute at Johns Hopkins Kimmel Cancer Center; Baltimore Maryland,n/a,True
+"Johns Hopkins Bloomberg School of Public Health, Baltimore, Maryland",n/a,True
+"San Diego State University, California",n/a,True
+"Tulane University, New Orleans, Louisiana",n/a,True
+"University of Maryland, Baltimore",n/a,True
+"University of Maryland, College Park",n/a,True
+"University of Minnesota, Minneapolis",n/a,True
+"University of South Carolina, Columbia",n/a,True
+"Johns Hopkins University, Baltimore, Maryland",n/a,True
+"National Heart, Lung, and Blood Institute, Bethesda, Maryland",n/a,True
+"University of Arizona, Tucson",n/a,True
+"University of New Mexico, Albuquerque",n/a,True
+"Louisiana State University Health Sciences Center, New Orleans",n/a,True
+San Diego State University,n/a,True
+"Center for Health Promotion and Prevention Research, School of Public Health, University of Texas, Houston TX, USA",n/a,True
+"Center for Sexual Health Promotion, and School of Health, Physical Education &amp; Recreation, Indiana University, Bloomington, IN, USA",n/a,True
+"Department of Biostatistical Sciences, Division of Public Health Sciences, Wake Forest University School of Medicine, Winston Salem, NC, USA",n/a,True
+"Department of Counseling/Human Organizational Studies, The George Washington University, Washington, DC, USA",n/a,True
+"Department of Health Behavior and Health Education, University of North Carolina School of Public Health, Chapel Hill, NC, USA",Department of Health Behavior,False
+"Department of Internal Medicine, Wake Forest University School of Medicine, Winston Salem, NC, USA, The Maya Angelou Center for Health Equity, Wake Forest University School of Medicine, Winston Salem, NC, USA",n/a,True
+"Department of Internal Medicine, Wake Forest University School of Medicine, Winston Salem, NC, USA, and W.G. Hefner Veterans Affairs Medical Center, Salisbury, NC, USA",n/a,True
+"Department of Social Sciences and Health Policy, Division of Public Health Sciences, Wake Forest University School of Medicine, Winston Salem, NC, USA",n/a,True
+"Department of Social Sciences and Health Policy, Division of Public Health Sciences, Wake Forest University School of Medicine, Winston Salem, NC, USA, Department of Internal Medicine, Wake Forest University School of Medicine, Winston Salem, NC, USA, and The Maya Angelou Center for Health Equity, Wake Forest University School of Medicine, Winston Salem, NC, USA, ",n/a,True
+"Ellen Hendrix, LLC, Winston-Salem, NC, USA",n/a,True
+"Triad Health Project, Greensboro, NC, USA",n/a,True
+"Armstrong Center for Hope, Durham, NC, USA",n/a,True
+"Community Health Coalition and Healing with CAARE, Inc., Durham, NC, USA",n/a,True
+"Project Compassion, Durham, NC, USA",n/a,True
+"Shaw University, Raleigh, NC, USA",n/a,True
+"North Carolina Translational and Clinical Sciences Institute, Chapel Hill, NC, USA",North Carolina Translational and Clinical Sciences Institute,False
+"University of Texas School of Public Health at Houston, Houston, TX, USA",n/a,True
+"Project Compassion, Chapel Hill, NC, USA",n/a,True
+"AARP, Washington DC, USA",n/a,True
+"Centers for Disease Control and Prevention, Atlanta, GA, USA",n/a,True
+"Group Health Research Institute, Seattle, WA, USA",n/a,True
+"National Association of Chronic Disease Directors, Atlanta, GA, USA",n/a,True
+"University of California, Berkeley, Berkeley, CA, USA",n/a,True
+"University of California, San Francisco, CA, USA",n/a,True
+"University of South Carolina, Columbia, SC, USA",n/a,True
+"Washington University in St. Louis, St. Louis, MO, USA",n/a,True
+"West Virginia University, Morgantown, WV, USA",n/a,True
+"Western Carolina University, Cullowhee, NC, USA",n/a,True
+"Fred Hutchinson Cancer Research Center, Seattle, WA, USA",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC, USA",UNC Lineberger Comprehensive Cancer Center,False
+"The University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"Columbia University, New York, NY, USA",n/a,True
+"Division of Research, Kaiser Permanente, Oakland, CA, USA",n/a,True
+"Partnerships in Prevention Science Institute, Iowa State University, Ames, Iowa, USA",n/a,True
+"Prevention Research Center, Pacific Institute for Research and Evaluation, Berkeley, CA, USA",n/a,True
+"School of Public Health, University of North Carolina at Chapel Hill, USA",Gillings School of Global Public Health,False
+Division of Pharmaceutical Outcomes and Policy; Eshelman School of Pharmacy; University of North Carolina; Chapel Hill NC USA,Division of Pharmaceutical Outcomes and Policy,False
+Emory University School of Medicine; Atlanta GA USA,n/a,True
+Health Literacy and Learning Program; Division of General Internal Medicine; Feinberg School of Medicine at Northwestern University; Chicago IL USA,n/a,True
+Mercy Hospital and Medical Center; Chicago IL USA,n/a,True
+School of Public Health; Emory University; Atlanta GA USA,n/a,True
+Discipline of Surgery; University of Sydney; Sydney NSW Australia,n/a,True
+Sydney School of Public Health; University of Sydney; Sydney NSW Australia,n/a,True
+Westmead Clinical School; University of Sydney at Westmead Millennium Institute for Medical Research; Westmead NSW Australia,n/a,True
+"Cecil G. Sheps Center for Health Services Research, University of North Carolina, USA, ",Cecil G. Sheps Center for Health Services Research,False
+"UNC Gillings School of Global Public Health, University of North Carolina, USA",Gillings School of Global Public Health,False
+"Arizona State University, GeoDa Center for Geospatial Analysis and Computation; Tempe; AZ",n/a,True
+"RTI International, Social, Statistical, and Environmental Sciences; Waltham; MA",n/a,True
+RTI International; Research Triangle Park; NC,n/a,True
+"University of California, Economics Department; Santa Barbara; CA",n/a,True
+"University of North Carolina-Chapel Hill, Gillings School of Global Public Health; Chapel Hill; NC",Gillings School of Global Public Health,False
+Cecil G. Sheps Center for Health Services Research; University of North Carolina-Chapel Hill; NC,Cecil G. Sheps Center for Health Services Research,False
+Division of Health Management and Policy; Graduate School of Public Health; San Diego State University; 5500 Campanile Dr.; San Diego; CA; 92182-4162,n/a,True
+UNC Institute on Aging and Cecil G. Sheps Center for Health Services Research; University of North Carolina-Chapel Hill; Chapel Hill; NC,Cecil G. Sheps Center for Health Services Research|UNC Institute On Aging,False
+UNC Institute on Aging and Department of Allied Health Sciences; School of Medicine; University of North Carolina-Chapel Hill; Chapel Hill; NC,UNC Institute On Aging|Department of Allied Health Sciences,False
+Cecil G. Sheps Center for Health Services Research; Institute on Aging; University of North Carolina; Chapel Hill; NC,Cecil G. Sheps Center for Health Services Research|UNC Institute On Aging,False
+Department of Health Policy & Management; Cecil G. Sheps Center for Health Services Research; University of North Carolina; Chapel Hill; NC,Department of Health Policy and Management|Cecil G. Sheps Center for Health Services Research,False
+Department of Economics; Virginia Commonwealth University; Richmond; VA,n/a,True
+Department of Health Policy and Management; The University of North Carolina at Chapel Hill; Chapel Hill; NC,Department of Health Policy and Management,False
+School of Nursing; The University of North Carolina at Chapel Hill; Chapel Hill; NC,School of Nursing,False
+Center for Health Promotion and Disease Prevention; University of North Carolina at Chapel Hill; University of North Carolina; Chapel Hill; NC,UNC Center for Health Promotion and Disease Prevention,False
+Department of Epidemiology; UNC Gillings School of Global Public Health; Chapel Hill; NC,Department of Epidemiology,False
+Department of Pediatrics; Wake Forest University School of Medicine; Winston-Salem; NC,n/a,True
+Department of Psychiatry; University of Colorado at Denver and Health Sciences Center; Denver; CO,n/a,True
+Department of Health Policy and Management; University of North Carolina at; Chapel Hill; NC,Department of Health Policy and Management,False
+School of Nursing; University of North Carolina at Chapel Hill; Chapel Hill; NC,School of Nursing,False
+University of California San Francisco; San Francisco; CA,n/a,True
+Cecil G. Sheps Center for Health Services Research; University of North Carolina at Chapel Hill; Chapel Hill NC,Cecil G. Sheps Center for Health Services Research,False
+Department of Health Care Policy; Harvard Medical School; Boston MA,n/a,True
+Department of Health Policy and Administration; The Pennsylvania State University; University Park PA,n/a,True
+"Health Management Strategies, Inc.; Austin TX",n/a,True
+Institute for Clinical Outcomes Research; Salt Lake City UT,n/a,True
+Pioneer Network; Chicago IL,n/a,True
+Robert Wood Johnson Foundation; Princeton NJ,n/a,True
+School of Nursing; University of Wisconsin at Madison; Madison WI,n/a,True
+Department of Health Policy and Management; Gillings School of Global Public Health; The University of North Carolina at Chapel Hill; Chapel Hill NC,Department of Health Policy and Management,False
+"Division of Cardiothoracic Surgery; Department of Surgery, School of Medicine; The University of North Carolina at Chapel Hill; Chapel Hill NC",Division of Cardiothoracic Surgery|Department of Surgery,False
+Division of Health Policy and Management; School of Public Health; University of Minnesota; Minneapolis MN,n/a,True
+Mathematica Policy Research; Washington DC,n/a,True
+School of Medicine; The University of North Carolina at Chapel Hill; Chapel Hill NC,School of Medicine,False
+St. Vincent Medical Group; Indianapolis IN,n/a,True
+"Agency for Healthcare Research and Quality; Center for Delivery, Organization, and Markets; Rockville MD",n/a,True
+"Data and Analytic Solutions, Inc.; Rockville MD",n/a,True
+The University of North Carolina at Chapel Hill; Chapel Hill NC,University of North Carolina at Chapel Hill,False
+Center for Biomedical Informatics (CBMI); The Children's Hospital of Philadelphia; Philadelphia PA,n/a,True
+Department of Biostatistics and Epidemiology; Perelman School of Medicine of the University of Pennsylvania; Philadelphia PA,n/a,True
+Department of Epidemiology; Gillings School of Global Public Health; University of North Carolina-Chapel Hill; Chapel Hill NC,Department of Epidemiology,False
+Department of Pediatrics; Perelman School of Medicine of the University of Pennsylvania; Philadelphia PA,n/a,True
+Division of General Pediatrics; The Children's Hospital of Philadelphia; Philadelphia PA,n/a,True
+James M. Anderson Center for Health Systems Excellence and Division of Emergency Medicine; Cincinnati Children's Hospital Medical Center; Cincinnati OH,n/a,True
+"The Pediatric Research Consortium, PolicyLab; and the Center for Pediatric Clinical Effectiveness; The Children's Hospital of Philadelphia; Philadelphia PA",n/a,True
+Center for Health Services Research in Primary Care; Department of Veterans Affairs; Duke University Medical Center; Durham NC,n/a,True
+Division of Pharmaceutical Outcomes and Policy; UNC Eshelman School of Pharmacy; University of North Carolina at Chapel Hill; Chapel Hill NC,Division of Pharmaceutical Outcomes and Policy,False
+Baylor Scott and White Health; Center for Clinical Effectiveness; Dallas TX,n/a,True
+Baylor Scott and White Health; Office of Clinical Ethics; Dallas TX,n/a,True
+Department of Economics; Emory University; Atlanta GA,n/a,True
+Department of Pharmacology; University of North Carolina; Chapel Hill NC,Department of Pharmacology,False
+"Alcoholism Unit, Department of Internal Medicine; IBSAL-University Hospital of Salamanca; Salamanca Spain",n/a,True
+Genotyping and Genetic Diagnosis Unit; Research Foundation of Hospital Clínico; Valencia Spain,n/a,True
+"Laboratory of Liver Diseases; National Institute on Alcohol Abuse and Alcoholism, National Institutes of Health; Bethesda MD",n/a,True
+"Liver Unit; Hospital Clínic, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS), CIBER de Enfermedades Hepáticas y Digestivas (CIBERehd); Barcelona Catalonia Spain",n/a,True
+"Service d'Hépato-Gastroentérologie; Amiens University Hospital and Groupe de Recherche sur l'Alcool et les Pharmacodépendances (INSERM ERI 24, GRAP), Picardie University; Amiens France",n/a,True
+Cold Spring Harbor Laboratory; Cold Spring Harbor NY,n/a,True
+Department of Biostatistics; University of North Carolina; Chapel Hill NC,Department of Biostatistics,False
+Department of Genetics; University of North Carolina; Chapel Hill NC,Department of Genetics,False
+"Department of Pathology; University Health Network, University of Toronto; Toronto Ontario Canada",n/a,True
+"Department of Surgery; University Health Network, University of Toronto; Toronto Ontario Canada",n/a,True
+Genome Sequencing Analysis Program and Platform; Broad Institute; Cambridge MA,n/a,True
+Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill NC,UNC Lineberger Comprehensive Cancer Center,False
+Allgemeines Krankenhaus der Stadt Wien; Vienna Austria,n/a,True
+Hopital Beaujon; Clichy; Paris France,n/a,True
+Hospital Vall d'Hebron and Ciberehd del Instituto Carlos III; Barcelona Spain,n/a,True
+Janssen Global Services LLC; High Wycombe Buckinghamshire UK,n/a,True
+Janssen Infectious Diseases BVBA; Beerse Belgium,n/a,True
+"Janssen Research & Development, LLC; Titusville NJ",n/a,True
+Klinikum der Johann-Wolfgang-Goethe-Universität-Med. Klinik I; Frankfurt Germany,n/a,True
+Medical University of Bialystok; Bialystok Poland,n/a,True
+Medizinische Hochschule Hannover; Hannover Germany,n/a,True
+Russian State Medical University; Moscow Russia,n/a,True
+"St Vincent's Hospital, Sydney, Australia and Kirby Institute; University of New South Wales; Sydney Australia",n/a,True
+Toronto General Hospital; Toronto Ontario Canada,n/a,True
+University of North Carolina at Chapel Hill; NC,University of North Carolina at Chapel Hill,False
+University of Texas Health Science Center; San Antonio TX,n/a,True
+Weill Cornell Medical College; Cornell NY,n/a,True
+Carolinas Medical Center; Charlotte NC,n/a,True
+Duke Clinical Research Institute; Durham NC,n/a,True
+Indiana University; Indianapolis IN,n/a,True
+"Laboratory of Pathology; National Cancer Institute, National Institutes of Health; Bethesda MD",n/a,True
+"Liver Disease Research Branch, Division of Digestive Diseases and Nutrtion; National Institute of Diabetes and Digestive and Kidney Diseases, National Institutes of Health; Bethesda MD",n/a,True
+Mayo Clinic College of Medicine; Rochester MN,n/a,True
+Thomas Jefferson University Hospital; Philadelphia PA,n/a,True
+University of California San Francisco; San Francisco CA,n/a,True
+University of Michigan; Ann Arbor MI,n/a,True
+University of North Carolina; Chapel Hill NC,University of North Carolina at Chapel Hill,False
+University of Pennsylvania; Philadelphia PA,n/a,True
+University of Southern California; Los Angeles CA,n/a,True
+University of Texas Southwestern Medical Center; Dallas TX,n/a,True
+Departments of Medicine; Microbiology and Immunology; Division of Gastroenterology & Hepatology; University of North Carolina; Chapel Hill NC,Department of Microbiology and Immunology|Division of Gastroenterology and Hepatology,False
+Division of Cellular and Molecular Immunology; Cincinnati Children's Hospital Research Foundation; and the University of Cincinnati College of Medicine; Cincinnati OH,n/a,True
+Division of Gastroenterology; Hepatology and Clinical Nutrition; Cincinnati Children's Hospital Research Foundation; and the University of Cincinnati College of Medicine; Cincinnati OH,n/a,True
+Division of Pathology and Laboratory Medicine; Cincinnati Children's Hospital Research Foundation; and the University of Cincinnati College of Medicine; Cincinnati OH,n/a,True
+Institute of Cellular Medicine; Newcastle University; Newcastle upon Tyne UK,n/a,True
+"Joint Department of Biomedical Engineering; University of North Carolina, Chapel Hill and North Carolina State University; Raleigh NC",UNC/NCSU Joint Department of Biomedical Engineering,False
+Newcastle Magnetic Resonance Center; Newcastle University; Newcastle upon Tyne UK,n/a,True
+Northern Institute for Cancer Research; Newcastle University; Newcastle upon Tyne UK,n/a,True
+Philips Healthcare Clinical Science; Guildford UK,n/a,True
+"Departament de Biologia Cel·lular, Immunologia i Neurociències; Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS), Facultat de Medicina, Universitat de Barcelona; Barcelona Spain",n/a,True
+"Genomic Programming of Beta Cells Laboratory; Institut d'Investigacions Biomèdiques August Pi i Sunyer, Barcelona, Spain. CIBER de Diabetes y Enfermedades Metabólicas Asociadas (CIBERDEM); Barcelona Spain",n/a,True
+"Liver Cell Biology Lab, Department of Cell Biology; Vrije Universiteit Brussel; Brussels Belgium",n/a,True
+"Liver Unit, Hospital Clínic; Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS), University of Barcelona, Centro de Investigación Biomédica en Red de Enfermedades Hepáticas y Digestivas (CIBERehd); Barcelona Spain",n/a,True
+Department of Cell Biology and Physiology and Program in Molecular Biology and Biotechnology; UNC School of Medicine; Chapel Hill NC,Department of Cell Biology and Physiology,False
+Department of Gastroenterology; Kanazawa University Hospital; Kanazawa Japan,n/a,True
+"Genetics Branch; Center for Cancer Research, National Cancer Institute; Bethesda MD",n/a,True
+"Laboratory of Experimental Carcinogenesis, National Cancer Institute, National Institutes of Health; Bethesda MD",n/a,True
+"Laboratory of Human Carcinogenesis, Center for Cancer Research, National Cancer Institute; Bethesda MD",n/a,True
+"Life Sciences Institute, Zhejiang University; Hangzhou China",n/a,True
+"University of Hawaii Cancer Center, Cancer Biology Program (Ji), Epidemiology Program (Zheng); Honolulu HI",n/a,True
+Dow Chemical Company; Midland MI,n/a,True
+Institute for Chemical Safety Sciences; Hamner Institutes for Health Sciences; Research Triangle Park; NC,n/a,True
+"Program in Molecular Biology and Biotechnology, Department of Cell Biology and Physiology; UNC School of Medicine; Chapel Hill NC",Department of Cell Biology and Physiology,False
+Division of Gastroenterology; Department of Medicine; University of Alberta; Edmonton Alberta Canada,n/a,True
+INSERM U995; Université Lille Nord de France; Lille France,n/a,True
+"Institut d'Investigacions Biomèdiques August-Pi-Sunyer, University of Barcelona, Centro de Investigación Biomédica en Red de Enfermedades Hepáticas y Digestivas; Barcelona Spain",n/a,True
+Liver Unit; Hospital Clínic; Barcelona Spain,n/a,True
+Section of Digestive Diseases; Yale University; New Haven CT,n/a,True
+Servicio de Gastroenterología; Hospital Domingo Luciani; Caracas Venezuela,n/a,True
+"Curriculum in Neurobiology, University of North Carolina; Chapel Hill North Carolina",Neuroscience Curriculum,False
+"Neuroscience Center, University of North Carolina; Chapel Hill North Carolina",UNC Neuroscience Center,False
+"Baylor College of Medicine, Houston, TX, USA",n/a,True
+"University of Houston, Houston, TX, USA",n/a,True
+"University of Houston, Houston, TX, USA, ",n/a,True
+"University of North Carolina-Chapel Hill, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"University of Texas-Austin, Austin, TX, USA",n/a,True
+"Instituto Nacional de Salud Pública, Cuernavaca, Mexico",n/a,True
+" Beth Israel Medical Center, New York, New York",n/a,True
+" Center for Biostatistics in AIDS ResearchHarvard School of Public Health, Boston, Massachusetts",n/a,True
+" Frontier Science &amp; Technology Research FoundationInc, Amherst, New York",n/a,True
+" New York University School of Medicine, New York, New York",n/a,True
+" Northwestern University Feinberg School of Medicine, Chicago, Illinois",n/a,True
+" Rush University Medical CenterChicago, Illinois",n/a,True
+" Social and Scientific SystemsSilver Spring, Maryland",n/a,True
+" University of Colorado-AMC, Aurora, Colorado",n/a,True
+" University of North Carolina School of Medicine, Chapel Hill, North Carolina",School of Medicine,False
+School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,School of Medicine,False
+"School of Pharmacy and Pharmaceutical Sciences; State University of New York, University at Buffalo; Buffalo; NY; USA",n/a,True
+UNC Eshelman School of Pharmacy; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Eshelman School of Pharmacy,False
+"Department of Medicine, Cardiovascular Division; University of Minnesota; Minneapolis MN USA",n/a,True
+Department of Medicine; School of Medicine; University of North Carolina−Chapel Hill; Chapel Hill NC USA,Department of Medicine,False
+Department of Medicine; University of Wisconsin School of Medicine and Public Health; Madison WI USA,n/a,True
+"Division of Biostatistics, School of Public Health; University of Minnesota; Minneapolis MN USA",n/a,True
+EPIMED/Vivantes Auguste-Viktoria-Klinikum; Berlin Germany,n/a,True
+"Epidemiological Cardiology Research Center (EPICARE), Department of Epidemiology and Prevention, and Department of Internal Medicine−Cardiology; Wake Forest School of Medicine; Winston Salem NC USA",n/a,True
+Ospedale San Raffaele; Milan Italy,n/a,True
+Research Department of Infection & Population Health; University College London Medical School; London UK,n/a,True
+The Kirby Institute; University of New South Wales; Sydney Australia,n/a,True
+Alberta HIV Clinic; Sheldon M. Chumir Health Centre; Calgary AB Canada,n/a,True
+British Columbia Centre for Excellence in HIV/AIDS; Vancouver BC Canada,n/a,True
+Center for AIDS Research; University of Washington; Seattle WA USA,n/a,True
+Departments of Epidemiology and Medicine; Johns Hopkins University; Baltimore MD USA,n/a,True
+Departments of Medicine and Biostatistics; Vanderbilt University School of Medicine; Nashville TN USA,n/a,True
+Harvard Medical School; Boston MA USA,n/a,True
+Kaiser Permanente Northern California; Oakland CA USA,n/a,True
+"Cancer Biology Branch, ECD, NHEERL, US EPA, RTP, North Carolina ",n/a,True
+"Department of Nutrition, University of North Carolina, Chapel Hill, North Carolina",Department of Nutrition,False
+"Department of Nutrition, University of North Carolina, Chapel Hill, North Carolina; Center for Environmental Medicine, Asthma, and Lung Biology; University of North Carolina, Chapel Hill, North Carolina","Department of Nutrition|Center for Environmental Medicine, Asthma and Lung Biology",False
+"Inorganic Carcinogenesis, LCC, National Cancer Institute at NIEHS",n/a,True
+"Microarray Core, NIEHS, RTP, North Carolina",n/a,True
+"Pharmacokinetics Branch, ETD, NHEERL, US EPA, RTP, North Carolina",n/a,True
+Department of Radiology and BRIC; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Biomedical Research Imaging Center|Department of Radiology,False
+Biomedical Research Imaging Center (BRIC); Department of Radiology; University of North Carolina at Chapel Hill; North Carolina,Biomedical Research Imaging Center|Department of Radiology,False
+Department of Neurology; University of North Carolina at Chapel Hill; North Carolina,Department of Neurology,False
+Department of Pathology and Laboratory Medicine; University of North Carolina at Chapel Hill; North Carolina,Department of Pathology and Laboratory Medicine,False
+Department of Radiology; University of North Carolina at Chapel Hill; North Carolina,Department of Radiology,False
+Division of Neuroradiology; Department of Radiology; University of North Carolina at Chapel Hill; North Carolina,Department of Radiology,False
+Department of Radiology and BRIC; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Biomedical Research Imaging Center|Department of Radiology,False
+Med-X Research Institute; Shanghai Jiao Tong University; Shanghai,n/a,True
+"Department of Instrument Science and Engineering, School of EIEE, Shanghai Jiao Tong University, China",n/a,True
+"Department of Radiology and BRIC, IDEA Lab, University of North Carolina at Chapel Hill, North Carolina",Biomedical Research Imaging Center|Department of Radiology,False
+Department of Psychology; Harlow Center for Biological Psychology; University of Wisconsin; Madison Wisconsin,n/a,True
+"Department of Radiology; Center for In Vivo Microscopy, Duke University Medical Center; Durham North Carolina",n/a,True
+"School of Psychology; South China Normal University, Guangzhou, Guangdong; China",n/a,True
+Department of Radiology and BRIC; University of North Carolina at Chapel Hill; North Carolina,Biomedical Research Imaging Center|Department of Radiology,False
+Department of Psychiatry; University of North Carolina at Chapel Hill; North Carolina,Department of Psychiatry,False
+Department of Radiology and Biomedical Research Imaging Center; University of North Carolina at Chapel Hill; North Carolina,Biomedical Research Imaging Center|Department of Radiology,False
+Biomedical Imaging Technology Center; Emory University; Atlanta Georgia,n/a,True
+"Department of Neurology; University of California, Los Angeles; Los Angeles CA",n/a,True
+"Department of Psychiatry and Biobehavioral Sciences; University of California, Los Angeles; Los Angeles CA",n/a,True
+"Department of Psychiatry and Human Behavior; University of California, Irvine; Irvine CA",n/a,True
+Department of Psychiatry; Beth Israel Deaconess Medical Center and Harvard Medical School; Boston MA,n/a,True
+Department of Psychiatry; Emory University; Atlanta Georgia,n/a,True
+"Department of Psychiatry; University of California, San Diego; San Diego CA",n/a,True
+"Department of Psychiatry; University of California, San Francisco; San Francisco CA",n/a,True
+"Department of Psychiatry; University of North Carolina, Chapel Hill; Chapel Hill NC",Department of Psychiatry,False
+Department of Psychiatry; Yale University; New Haven CT,n/a,True
+Department of Psychiatry; Zucker Hillside Hospital; Great Neck NY,n/a,True
+Department of Psychology; Yale University; New Haven CT,n/a,True
+Department of Radiology; University of Calgary; Calgary Alberta Canada,n/a,True
+Departments of Diagnostic Radiology and Biomedical Engineering; Yale University; New Haven CT,n/a,True
+Department of Computer Science and Engineering; Nanjing University of Aeronautics and Astronautics; Nanjing China,n/a,True
+"CB#3367, Carolina Institute for Developmental Disabilities, UNC; Chapel Hill North Carolina",Carolina Institute for Developmental Disabilities,False
+"Center for Interdisciplinary Brain Sciences Research, Stanford University Medical School; Stanford California",n/a,True
+Department of Mathematics; Stanford University; Stanford California,n/a,True
+"Center for Cognition and Brain Disorders, Hangzhou Normal University; Hangzhou 311121 China",n/a,True
+"Depart of Anesthesiology; Xuanwu Hospital, Capital Medical University; Beijing 100053 China",n/a,True
+"Department of Radiology; Xuanwu Hospital, Capital Medical University; Beijing 100053 China",n/a,True
+"Biomedical Research Imaging Center, Department of Radiology, School of Medicine; University of North Carolina at Chapel Hill; North Carolina",Department of Radiology|Biomedical Research Imaging Center,False
+"The Guangdong Key Laboratory for Biomedical Measurements and Ultrasound Imaging, Department of Biomedical Engineering; Shenzhen University; China",n/a,True
+Department of Psychiatry Research; Zucker Hillside Hospital; Glen Oaks New York,n/a,True
+Department of Psychiatry and Human Behavior; University of California; Irvine California,n/a,True
+"Department of Psychiatry; Beth Israel Deaconess Medical Center, Harvard Medical School; Boston Massachusetts",n/a,True
+Department of Psychiatry; University of California; San Diego La Jolla California,n/a,True
+Department of Psychiatry; University of California; San Francisco California,n/a,True
+Department of Psychiatry; Yale University; New Haven Connecticut,n/a,True
+Department of Psychology; Emory University; Atlanta Georgia,n/a,True
+Departments of Psychology and Psychiatry; University of California; Los Angeles California,n/a,True
+"Department of Biomedical Engineering, The Guangdong Key Laboratory for Biomedical Measurements and Ultrasound Imaging; Shenzhen University; Shenzhen China",n/a,True
+Department of Computer Science and Bioimaging Research Center; The University of Georgia; Athens Georgia,n/a,True
+Department of Neurology; University of California; Los Angeles Los Angeles California,n/a,True
+"Department of Nutrition; Gillings School of Global Public Health, Nutrition Research Institute, The University of North Carolina; Chapel Hill North Carolina",Department of Nutrition|Nutrition Research Institute,False
+"Department of Pediatrics; Developmental Cognitive Neuroimaging Laboratory, Keck School of Medicine, USC/Children's Hospital of Los Angeles; Los Angeles California",n/a,True
+Department of Pediatrics; University of California; San Diego La Jolla California,n/a,True
+Department of Psychiatry and Mental Health; University of Cape Town; Cape Town South Africa,n/a,True
+Department of Psychology; San Diego State University; San Diego California,n/a,True
+Department of Radiology; University of Calgary; Calgary Canada,n/a,True
+"n        n        CR-UK Department of Oncology, Strangeways Research Laboratory, University of Cambridge, Cambridge, UK",n/a,True
+"n        n        Department of Cancer Genetics, Roswell Park Cancer Institute, Buffalo, NY, USA",n/a,True
+"n        n        Department of Gynaecological and Obstetrics, Skejby University Hospital, Århus, Denmark",n/a,True
+"n        n        Department of Health Research and Policy, Stanford University School of Medicine, Stanford, CA, USA",n/a,True
+"n        n        Department of Obstetrics and Gynaecology, University of Ulm, Ulm, Germany",n/a,True
+"n        n        Department of Viruses, Hormones and Cancer, Institute of Cancer Epidemiology, Danish Cancer Society, Copenhagen, Denmark",n/a,True
+"n        n        Division of Cancer Epidemiology, German Cancer Research Centre, Heidelberg, Germany",n/a,True
+"n        n        Epidemiology Program, Cancer Research Centre of Hawaii, University of Hawaii, Honolulu, HI, USA",n/a,True
+"n        n        Gynaecologic Clinic, The Juliane Marie Centre, Rigshospitalet, University of Copenhagen, Copenhagen, Denmark",n/a,True
+"n        n        Gynaecological Oncology Unit, UCL EGA Institute for Women's Health, University College London, UK",n/a,True
+"n        n        Keck School of Medicine, University of Southern California, Los Angeles, CA, USA",n/a,True
+"n        n        Mayo Clinic College of Medicine, Rochester, MN, USA",n/a,True
+"n        n        Program in Epidemiology, Fred Hutchinson Cancer Research Centre, Seattle, WA, USA",n/a,True
+"n        n        Roswell Park Cancer Centre, Buffalo, NY, USA",n/a,True
+"n        n        School of Public Health, The University of Texas, Houston, TX, USA",n/a,True
+"n        n        The Queensland Institute of Medical Research, Post Office Royal Brisbane Hospital, Australia",n/a,True
+"n        n        Broad Institute of MIT and Harvard, Cambridge, MA, USA,",n/a,True
+"n        n        Center for Research on Genomics and Global Health, National Human Genome Research Institute, Bethesda, MA, USA,",n/a,True
+n        n        Department of Epidemiology and Biostatistics and,n/a,True
+"n        n        Department of Epidemiology and Preventive Medicine, Stritch School of Medicine, Loyola University, Maywood, IL, USA,",n/a,True
+"n        n        Department of Epidemiology, University of Michigan School of Public Health, Ann Arbor, MI, USA,",n/a,True
+"n        n        Department of Genetics, Children's Hospital Boston, Boston, MA, USA,",n/a,True
+n        n        Department of Medicine and,n/a,True
+"n        n        Department of Medicine,",n/a,True
+"n        n        Department of Medicine, Boston University School of Medicine, Framingham, MA, USA,",n/a,True
+"n        n        Department of Medicine, Columbia University, New York, NY, USA,",n/a,True
+"n        n        Department of Medicine, University of Pennsylvania School of Medicine, Philadelphia, PA, USA,",n/a,True
+"n        n        Department of Preventive Medicine, Northwestern University Feinberg School of Medicine, Chicago, IL, USA,",n/a,True
+"n        n        Department of Radiology, Tufts-New England Medical Center, Boston, MA, USA,",n/a,True
+"n        n        Division of Cardiovascular Medicine, University of Michigan Health System, Ann Arbor, MI, USA,",n/a,True
+"n        n        Division of Clinical Epidemiology, Case Western Reserve University, Cleveland, OH, USA,",n/a,True
+n        n        Division of Epidemiology and Clinical Applications and,n/a,True
+"n        n        Division of Epidemiology, Human Genetics and Environmental Sciences, The University of Texas at Houston, Houston, TX, USA,",n/a,True
+"n        n        Medical College of Georgia, Agusta, GA, USA,",n/a,True
+"n        n        Medical Genetics Institute, Cedars-Sinai Medical Center, Los Angeles, CA, USA,",n/a,True
+"n        n        School of Nursing, University of Mississippi Medical Center, Jackson, MS, USA,",n/a,True
+n        n        The Institute for Translational Medicine and Therapeutics and,n/a,True
+"n        n        UNC Gillings School of Global Public Health, The University of North Carolina at Chapel Hill, Chapel Hill, NC, USA,",Gillings School of Global Public Health,False
+"n        n        Cancer Bioimmunotherapy Unit, Centro di Riferimento Oncologico, IRCCS, Aviano (PN), Italy,",n/a,True
+"n        n        Cancer Care Ontario, Toronto, ON, Canada,",n/a,True
+n        n        Cancer Genomics Laboratory and,n/a,True
+"n        n        Centre Hospitalier Universitaire de Lyon/Centre Léon Bérard, Unité Mixte de Génétique Constitutionnelle des Cancers Fréquents, Lyon, France,",n/a,True
+"n        n        Clinical Genetics Branch, Division of Cancer Epidemiology and Genetics, US National Cancer Institute, Rockville MD, USA,",n/a,True
+"n        n        Clinical Genetics, Aarhus University Hospital, Aarhus, Denmark,",n/a,True
+"n        n        Clinical Genetics, Odense University Hospital, Odense C, Denmark,",n/a,True
+"n        n        Clinical Genetics, Rigshospital, Copenhagen, Denmark,",n/a,True
+"n        n        Clinical Genetics, Vejle Hospital, Vejle, Denmark,",n/a,True
+"n        n        Cogentech, Consortium for Genomics Technology, Milan, Italy,",n/a,True
+"n        n        Department of Clinical Physiopathology, University of Florence, Florence, Italy,",n/a,True
+"n        n        Department of Experimental Medicine, University La Sapienza, Rome, Italy,",n/a,True
+"n        n        Department of Genetics, Biology and Biochemistry, University of Turin, Turin, Italy,",n/a,True
+"n        n        Department of Public Health and Primary Care, Centre for Cancer Genetic Epidemiology and",n/a,True
+"n        n        Division of Cancer Prevention and Genetics, Istituto Europeo di Oncologia (IEO), Milan, Italy,",n/a,True
+"n        n        Queensland Institute of Medical Research, Brisbane, Australia,",n/a,True
+"n        n        Samuel Lunenfeld Research Institute, Mount Sinai Hospital, Toronto, ON, Canada,",n/a,True
+"n        n        Section of Genetic Oncology, Department of Laboratory Medicine, University and University Hospital of Pisa, Pisa, Italy,",n/a,True
+"n        n        The Susanne Levy Gertner Oncogenetics Unit, Sheba Medical Center, Tel Hashomer, Israel,",n/a,True
+"n        n        Unit of Hereditary Cancer, Department of Epidemiology, Prevention and Special Functions, Istituto Nazionale per la Ricerca sul Cancro (IST), Genoa, Italy,",n/a,True
+"n        n        Unit of Medical Genetics, Department of Preventive and Predicted Medicine, Fondazione IRCCS Istituto Nazionale Tumori (INT), Milan, Italy,",n/a,True
+"n        n        Unit of Molecular Bases of Genetic Risk and Genetic Testing, Department of Preventive and Predictive Medicine and",n/a,True
+"n        n        Australian Breast Cancer Tissue Bank, Westmead Millennium Institute and",n/a,True
+"n        n        Brigham and Women's Hospital and Harvard Medical School, Boston, MA, USA,",n/a,True
+"n        n        Centre for Cancer Genetic Epidemiology, Department of Public Health and Primary Care and",n/a,True
+"n        n        Centre for Molecular, Environmental, Genetic, and Analytic Epidemiology, Melbourne School of Population Health and",n/a,True
+"n        n        Consortium for Biomedical Research in Epidemiology and Public Health (CIBERESP), Madrid, Spain,",n/a,True
+"n        n        Department of Cancer Prevention and Control, Roswell Park Cancer Institute, Buffalo, NY, USA,",n/a,True
+n        n        Department of Clinical Genetics and,n/a,True
+"n        n        Department of Epidemiology, Gillings School of Global Public Health, and Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC, USA,",UNC Lineberger Comprehensive Cancer Center|Department of Epidemiology,False
+"n        n        Department of Gynecology and Obstetrics, Friedrich-Alexander University Erlangen-Nuremberg, University Hospital Erlangen, University Breast Center Franconia, Erlangen, Germany,",n/a,True
+"n        n        Department of Health Sciences Research,",n/a,True
+"n        n        Department of Oncology, Helsinki University Central Hospital, Helsinki, Finland,",n/a,True
+n        n        Department of Preventive Medicine and,n/a,True
+"n        n        Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, MD, USA,",n/a,True
+"n        n        Division of Cancer Epidemiology, German Cancer Research Center and",n/a,True
+"n        n        Division of Cancer Etiology, Department of Population Science, Beckman Research Institute, City of Hope, CA, USA,",n/a,True
+"n        n        Division of Preventive Medicine, Brigham and Women's Hospital and Harvard Medical School, Boston, MA, USA,",n/a,True
+n        n        Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology and,n/a,True
+"n        n        Early Detection Research Group, Division of Cancer Prevention and",n/a,True
+"n        n        Faculty of Medicine, University of Southampton, Southampton, UK,",n/a,True
+n        n        Genomic Epidemiology Group and,n/a,True
+"n        n        Huntsman Cancer Institute, University of Utah, Salt Lake City, UT, USA,",n/a,True
+"n        n        INSERM UMR 1018, Team 9: Nutrition, Hormones et Santé desfemmes, Centre de Recherche en Epidémiologie et Santé des Populations, Hôpital Paul Brousse, Villejuif, France,",n/a,True
+"n        n        Institute for Cancer Studies, Department of Oncology and",n/a,True
+"n        n        Institute for Quality and Efficiency in Health Care, IQWiG, Cologne, Germany,",n/a,True
+n        n        Program in Molecular and Genetic Epidemiology and,n/a,True
+"n        n        The Cancer Institute of New Jersey, New Brunswick, NJ, USA,",n/a,True
+"n        n        Centre for Population Health Sciences, University of Edinburgh, Scotland, UK,",n/a,True
+"n        n        Centre for Research in Environmental Epidemiology (CREAL), Barcelona, Spain,",n/a,True
+n        n        Department for Research in Biomedicine and Health and,n/a,True
+"n        n        Department of Biological Psychology, VU University Amsterdam, Amsterdam, The Netherlands,",n/a,True
+n        n        Department of Epidemiology and,n/a,True
+"n        n        Department of Epidemiology, University of North Carolina, Chapel Hill, NC, USA,",Department of Epidemiology,False
+"n        n        Department of Medical Genetics, University of Lausanne, Switzerland,",n/a,True
+"n        n        Department of Prosthetic Dentistry, Gerostomatology and Dental Materials and",n/a,True
+"n        n        Department of Psychiatry, Washington University School of Medicine, St. Louis, MO 63110, USA,",n/a,True
+"n        n        Division of Genetics and Cell Biology, San Raffaele Scientific Institute, Milan, Italy,",n/a,True
+n        n        Estonian Genome Center and,n/a,True
+"n        n        Genetics of Complex Traits, Peninsula Medical School, University of Exeter, UK,",n/a,True
+"n        n        Geriatric Unit, Azienda Sanitaria di Firenze, Florence, Italy,",n/a,True
+"n        n        Human Genetics Center, University of Texas Health Science Center at Houston, Houston, TX, USA,",n/a,True
+"n        n        Institute for Community Medicine, University Medicine Greifswald, Greifswald, Germany,",n/a,True
+"n        n        Institute for Maternal and Child Health - IRCCS ‘Burlo Garofolo’ – Trieste, University of Trieste, Italy,",n/a,True
+"n        n        Institute of Genetic Epidemiology, Helmholtz Zentrum München – German Research Center for Environmental Health, Neuherberg, Germany,",n/a,True
+"n        n        Laboratory of Epidemiology, Demography, and Biometry, National Institute on Aging, National Institutes of Health, Bethesda, MD, USA,",n/a,True
+"n        n        MRC Epidemiology Unit, Institute of Metabolic Science, Addenbrooke's Hospital, Cambridge, UK,",n/a,True
+"n        n        Public Health and Gender Studies, Institute of Epidemiology and Preventive Medicine, Regensburg University Medical Center, Regensburg, Germany,",n/a,True
+"n        n        Queensland Institute of Medical Research, Brisbane, Queensland 4006, Australia,",n/a,True
+"n        n        School of Women's and Infants’ Health, The University of Western Australia, Perth, Western Australia, Australia,",n/a,True
+"n        n        Universität zu Lübeck, Medizinische Klinik II, Lübeck, Germany,",n/a,True
+n        n        Wellcome Trust Centre for Human Genetics and,n/a,True
+"n        n        Wellcome Trust Sanger Institute, Wellcome Trust Genome Campus, Hinxton, Cambridge, UK,",n/a,True
+"n        n        Center for Applied Genomics, Children's Hospital of Philadelphia, 3615 Civic Center Boulevard, Abramson Research Center, Suite 1014H, Philadelphia 19104, PA, USA,",n/a,True
+"n        n        Department of Epidemiology and Population Health, School of Public Health and Information Sciences, University of Louisville, Louisville, KY 40292, USA and",n/a,True
+"n        n        Genetics, The University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Genetics,False
+"n        n        Center for Craniofacial and Dental Genetics, Department of Oral Biology and",n/a,True
+"n        n        Center for Statistical Genetics, Department of Biostatistics, University of Michigan, Ann Arbor, MI, USA",n/a,True
+"n        n        Department of Biostatistics, Boston University School of Public Health, Boston, MA, USA",n/a,True
+"n        n        Department of Epidemiology, University of Texas M. D. Anderson, Houston, TX, USA",n/a,True
+"n        n        Department of Human Genetics, University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"n        n        Department of Nutrition, Harvard School of Public Health, Boston, MA, USA",n/a,True
+"n        n        Department of Periodontics, West Virginia University, Morgantown, WV, USA",n/a,True
+"n        n        Division of Cancer Epidemiology and Genetics, National Cancer Institute, National Institutes of Health, Bethesda, MD, USA",n/a,True
+"n        n        Institute for Clinical Chemistry and Laboratory Medicine, University Medicine Greifswald, Greifswald, Germany",n/a,True
+n        n        Institute for Community Medicine and,n/a,True
+"n        n        Interfaculty Institute for Genetics and Functional Genomics, Ernst-Moritz-Arndt-University Greifswald, Greifswald, Germany",n/a,True
+"n        n        Intramural Research Program, National Institute on Aging, Baltimore, MD, USA",n/a,True
+"n        n        Istituto di Ricerca Genetica e Biomedica, Consiglio Nazionale delle Ricerche, Cagliari, Italy",n/a,True
+"n        n        NHLBI's Framingham Heart Study, Framingham, MA, USA",n/a,True
+"n        n        New York University Medical Center, New York, NY 10016, USA",n/a,True
+"n        n        Saw Swee Hock School of Public Health and Yong Loo Lin School of Medicine, National University of Si ngapore, Singapore",n/a,True
+"n        n        School of Public Health, University of Minnesota, Minneapolis, MN, USA",n/a,True
+"n        n        Wright State University School of Medicine, Dayton, OH, USA",n/a,True
+"n        n        Center for Applied Genomics, Abramson Research Center and",n/a,True
+"n        n        Department of Epidemiology, Erasmus MC, University Medical Center Rotterdam, Rotterdam, The Netherlands",n/a,True
+"n        n        Department of Genetics and Genomic Sciences, Institute of Genomics and Multiscale Biology",n/a,True
+"n        n        Department of Genetics, Harvard Medical School, Cambridge, MA, USA",n/a,True
+"n        n        Department of Genetics, University of North Carolina, Chapel Hill, NC 27599, USA",Department of Genetics,False
+"n        n        Department of Medicine, The Johns Hopkins University School of Medicine, Baltimore, MD, USA",n/a,True
+"n        n        Department of Medicine, University of California, San Francisco, CA 94143, USA",n/a,True
+"n        n        Department of Preventive Medicine, Northwestern University Feinberg School of Medicine, Chicago, IL, USA",n/a,True
+"n        n        Department of Statistics and Department of Genetics, Stanford University, Stanford, CA 94305, USA",n/a,True
+"n        n        Division of Cardiology, University of Michigan Health System, Ann Arbor, MI 48109, USA",n/a,True
+"n        n        Division of Cardiovascular Sciences, National Heart, Lung, and Blood Institute (NHLBI), Bethesda, MD, USA",n/a,True
+"n        n        Division of Epidemiology and Biostatistics, Mel and Enid Zuckerman College of Public Health and",n/a,True
+"n        n        Division of Nutrition, Mel and Enid Zuckerman College of Public Health, University of Arizona, Tucson, AZ 85724, USA",n/a,True
+"n        n        Division of Psychiatric Genomics, Department of Psychiatry and",n/a,True
+"n        n        Division of Public Health Sciences, Fred Hutchinson Cancer Research Center, Seattle, WA 98195, USA",n/a,True
+"n        n        Division of Rheumatology, Immunology, and Allergy and",n/a,True
+"n        n        GeneSTAR Research Program, Division of General Internal Medicine, Johns Hopkins School of Medicine, Baltimore, MD 21287, USA",n/a,True
+"n        n        Health Disparities Research Section, Clinical Research Branch, National Institute on Aging, National Institutes of Health, Baltimore, MD 21225, USA",n/a,True
+"n        n        Laboratory for Genotyping Development, CGM, RIKEN, Yokohama, Japan",n/a,True
+n        n        Laboratory of Neurogenetics and,n/a,True
+"n        n        Laboratory of Personality and Cognition, National Institute on Aging, National Institutes of Health, Baltimore, MD 21224, USA",n/a,True
+"n        n        Molecular Genetics Section, Laboratory of Neurogenetics, National Institute on Aging, Bethesda, MD 20892, USA",n/a,True
+"n        n        Program in Medical and Population Genetics, Broad Institute of MIT and Harvard, Cambridge, MA 02141, USA",n/a,True
+"n        n        Program in Medical and Population Genetics, Broad Institute, Cambridge, MA, USA",n/a,True
+"n        n        The Charles Bronfman Institute for Personalized Medicine, Institute of Child Health and Development, The Genetics of Obesity and Related Metabolic Traits Program, Mount Sinai School of Medicine, New York, NY 10029, USA",n/a,True
+"n        n        The Charles Bronfman Institute for Personalized Medicine, The Genetics of Obesity and Related Metabolic Traits Programn      ",n/a,True
+n        n        The Charles Bronfman Institute for Personalized Medicinen      ,n/a,True
+"n        n        Center for Applied Genomics, Children's Hospital of Philadelphia, 3615 Civic Center Boulevard, Abramson Research Center, Philadelphia, PA 19104, USA",n/a,True
+"n        n        Center for Nn        utrition, Prevention and Health Services, National Institute for Public Health and the Environment, 3720 BA Bilthoven, The Netherlands",n/a,True
+"n        n        Clinical Pharmacology and The Genome Centre, William Harvey Research Institute, Barts,",n/a,True
+"n        n        Department of Cardiovascular Science, University of Leicester, Leicester LE3 9QP, UK",n/a,True
+"n        n        Department of Epidemiology, Tulane University, New Orleans, LA 70112, USA",n/a,True
+"n        n        Department of Genetic Epidemiology, Institute of Epidemiology and Preventive Medicine, University of Regensburg, 93053 Regensburg, Germany",n/a,True
+"n        n        Department of Genetics and Genomic Sciences, Icahn School of Medicine at Mount Sinai, New York, NY 10029, USA",n/a,True
+n        n        Department of Medicinen      ,n/a,True
+"n        n        Department of Neurology,",n/a,True
+"n        n        Department of Pharmacotherapy and Translational Research,",n/a,True
+"n        n        Department of Social and Preventive Medicine, SUNY-Buffalo School of Public Health and Health Professions, Buffalo, NY 14214, USA",n/a,True
+"n        n        Division of Endocrinology, Diabetes and Nutrition,",n/a,True
+"n        n        Division of General Medicine, Center for Behavioral Cardiovascular Health, Columbia University Medical Center, New York, NY 10032, USA",n/a,True
+"n        n        Division of Public Health Sciences,",n/a,True
+"n        n        Division of Sleep Medicine, Harvard Medical School, Boston, MA 02115, USA",n/a,True
+"n        n        Gillings School of Global Public Health,",Gillings School of Global Public Health,False
+"n        n        Institute of Cardiovascular and Medical Sciences,",n/a,True
+"n        n        Institute of Epidemiology II,",n/a,True
+"n        n        Institute of Genetic Epidemiology,",n/a,True
+"n        n        Julius Center for Health Sciences and Primary Care, UMC Utrecht, PO Box 85500, 3508 GA, Utrecht, The Netherlands",n/a,True
+"n        n        MRC Integrative Epidemiology Unit, School of Social and Community Medicine, Bristol BS8 2BN, UK",n/a,True
+"n        n        National Institute for Health Biomedical Research Unit,",n/a,True
+"n        n        Nutrition and Genomics Laboratory, Tufts University, Boston, MA 02111, USA",n/a,True
+"n        n        Stanford University School of Medicine, Stanford, CA 94305, USA",n/a,True
+"Cancer Epidemiology Centre; Cancer Council Victoria, Melbourne; Victoria; Australia",n/a,True
+Cancer Prevention Program; Fred Hutchinson Cancer Research Center; Seattle; Washington,n/a,True
+"Centre for Molecular, Environmental; Genetic and Analytic Epidemiology; The University of Melbourne; Parkville; Victoria; Australia",n/a,True
+"Conjoint Gastroenterology Laboratory, Royal Brisbane and Women's Hospital Research Foundation; Clinical Research Centre and Queensland Institute of Medical Research; Brisbane; Queensland; Australia",n/a,True
+Department of Colorectal Medicine and Genetics; The Royal Melbourne Hospital; Parkville; Victoria; Australia,n/a,True
+Department of Laboratory Medicine and Pathology; Mayo Clinic; Rochester; Minnesota,n/a,True
+Department of Medical Genetics; Mayo Clinic; Rochester; Minnesota,n/a,True
+Department of Medicine; University of Colorado School of Medicine and Denver VA Medical Center; Denver; Colorado,n/a,True
+Department of Medicine; University of North Carolina; Chapel Hill; North Carolina,Department of Medicine,False
+Department of Preventive Medicine; University of Southern California; Los Angeles; California,n/a,True
+Familial Cancer Centre; Peter MacCallum Cancer Centre; Victoria; Australia,n/a,True
+Familial Cancer Centres; Cabrini Health and Southern Health; Victoria; Australia,n/a,True
+Familial Cancer Laboratory; Queensland Institute of Medical Research; Brisbane; Queensland; Australia,n/a,True
+Flinders University Centre for Cancer Prevention and Control; Bedford Park; South Australia; Australia,n/a,True
+"Genetic Services and Familial Cancer Program of Western Australia, Perth, School of Paediatrics and Child Health; University of Western Australia; Australia",n/a,True
+Mount Sinai Hospital; University of Toronto; Toronto; Ontario; Canada,n/a,True
+New Zealand Familial Gastrointestinal Cancer Registry; Auckland City Hospital; Auckland; New Zealand,n/a,True
+Queensland Clinical Genetics Service; Royal Children's Hospital; Herston; Queensland; Australia,n/a,True
+University of Hawaii Cancer Research Center; Honolulu; Hawaii,n/a,True
+"Department of Biosciences and Nutrition; Center for Biosciences, Karolinska Institutet; Huddinge; Sweden",n/a,True
+Department of Medicine; UNC School of Medicine; Chapel Hill; North Carolina,Department of Medicine,False
+Department of Pathology & Laboratory Medicine; UNC School of Medicine; Chapel Hill; North Carolina,Department of Pathology and Laboratory Medicine,False
+Department of Pediatrics; The Hospital for Sick Children; University of Toronto; Toronto; Ontario; Canada,n/a,True
+Department of Pediatrics; UNC School of Medicine; Chapel Hill; North Carolina,Department of Pediatrics,False
+National Human Genome Research Institute; NIH; Bethesda; Maryland,n/a,True
+Department of Child Neurology; VU University Medical Centre; Amsterdam; The Netherlands,n/a,True
+Department of Dentistry; Royal Children's Hospital Parkville; Victoria; Australia,n/a,True
+Department of Genetics; University Medical Center Groningen; Groningen; The Netherlands,n/a,True
+Department of Genome Sciences and Howard Hughes Medical Institute; University of Washington; Seattle; Washington,n/a,True
+Department of Medicine; University of Melbourne; Australia,n/a,True
+"Department of Molecular Neuroscience; Reta Lila Weston Research Laboratories and MRC Centre for Neuromuscular Diseases, UCL Institute of Neurology; London; UK",n/a,True
+"Department of Neurological; Neurosurgical and Behavioural Sciences, Siena University; Siena; Italy",n/a,True
+Department of Neurology; Oasi Institute for Research on Mental Retardation and Brain Aging (IRCCS); Troina; EN; Italy,n/a,True
+Department of Neurology; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,Department of Neurology,False
+Department of Pediatrics; Academic Medical Centre; Amsterdam; The Netherlands,n/a,True
+Department of Pediatrics; Division of Genetic Medicine; University of Washington; Seattle; Washington,n/a,True
+Division of Human Genetics; Medical University Innsbruck; Innsbruck; Austria,n/a,True
+Epilepsy Centre Kork; Kehl-Kork; Germany,n/a,True
+"Genetic Medicine, Manchester Academic Health Sciences Centre; Central Manchester University Hospitals; Manchester; UK",n/a,True
+Institute of Human Genetics; Tübingen University; Germany,n/a,True
+"Laboratory of Neurogenetics; National Institute of Aging, National Institutes of Health; Bethesda; Maryland",n/a,True
+Mitteldeutscher Praxisverbund Humangenetik; Dresden; Germany,n/a,True
+"Núcleo de Investigação Molecular Avançada, Programa de Pós-Graduação em Ciências da Saúde, Centro de Ciencias Biológicas e da Saúde; Pontif icia Universidade Catolica do Paraná; Curitiba; PR; Brazil",n/a,True
+University College London (UCL) Genetics Institute (UGI); London; UK,n/a,True
+Children's Hospital and Regional Medical Center; Seattle; Washington,n/a,True
+"Department of Clinical Genetics, Nottingham City Hospital; Nottingham; UK",n/a,True
+"Department of Infection, Immunity and Inflammation; University of Leicester, Leicester Royal Infirmary; Leicester; UK",n/a,True
+"Department of Medicine, UNC School of Medicine; Chapel Hill; North Carolina",Department of Medicine,False
+Department of Paediatric Respiratory Medicine and Electron Microscopy Unit; Royal Brompton and Harefield NHS Trust; London; UK,n/a,True
+Department of Pathology and Laboratory Medicine; UNC School of Medicine; Chapel Hill; North Carolina,Department of Pathology and Laboratory Medicine,False
+Department of Pediatrics and Adolescent Medicine; University Hospital Muenster; Muenster; Germany,n/a,True
+"Department of Pediatrics, UNC School of Medicine; Chapel Hill; North Carolina",Department of Pediatrics,False
+"Department of Pediatrics, University of Colorado School of Medicine; Aurora; Colorado",n/a,True
+"Department of Pediatrics, Washington University School of Medicine; St. Louis; Missouri",n/a,True
+General and Adolescent Paediatric Unit; University College London (UCL) Institute of Child Health; London; UK,n/a,True
+Molecular Medicine Unit and Birth Defects Research Centre; University College London (UCL) Institute of Child Health; London; UK,n/a,True
+"Primary Ciliary Dyskinesia Group, University of Southampton Faculty of Medicine; Southampton NIHR Respiratory Biomedical Research Unit, Southampton General Hospital; Southampton; UK",n/a,True
+"Respiratory Medicine, Royal Brompton and Harefield NHS Trust; London; UK",n/a,True
+"School of Veterinary Medicine and Science, University of Nottingham; Leicestershire; UK",n/a,True
+"University Hospitals Leuven, Department of Otorhinolaryngology; Leuven; Belgium",n/a,True
+Department of Genetics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Genetics,False
+"Biomarkers and Susceptibility Unit; Catalan Institute of Oncology (ICO-IDIBELL), L'Hospitalet de Llobregat, CIBER de Epidemiologia y Salud Pública (CIBERESP); Instituto de Salud Carlos III; Barcelona Spain",n/a,True
+Department of Genetics; Hospital de la Santa Creu i Sant Pau; Barcelona Spain,n/a,True
+Department of Genetics; University of Chicago; Chicago Illinois,n/a,True
+Department of Medicine; University of Chicago; Chicago Illinois,n/a,True
+"Eshelman School of Pharmacy; Institute for Pharmacogenomics and Individualized Therapy, Lineberger Comprehensive Cancer Center, School of Medicine; University of North Carolina at Chapel Hill; North Carolina",Center of Pharmacogenomics and Individualized Therapy|UNC Lineberger Comprehensive Cancer Center,False
+School of Medicine; Ningbo University; Zhejiang 315211 China,n/a,True
+Center for Rare Diseases; Clinica Las Condes; Santiago Chile,n/a,True
+Chaim Sheba Medical Center; Tel Hashomer Israel,n/a,True
+"Department of Biochemistry; Hospital Universitario Gregorio Marañón, Institute of Health Research (IiSGM), Madrid; Spain",n/a,True
+Department of Clinical Genetics and Metabolism; Children's Hospital; University of Colorado; Denver-Aurora Colorado,n/a,True
+Department of Clinical Genetics; All Children's Hospital; John Hopkins Medicine and Department of Pediatrics; John Hopkins University School of Medicine; Baltimore Maryland,n/a,True
+Department of Genetics; Medical Genomics Laboratory; University of Alabama at Birmingham; Birmingham Alabama,n/a,True
+Department of Medicine; Division of Genetics; New York Methodist Hospital; Brooklyn New York,n/a,True
+Department of Neurology; Veterans Administration Hospital of Pittsburgh and University of Pittsburgh; Pittsburgh Pennsylvania,n/a,True
+Department of Neuropediatrics; Hospital Infantil Universitario Niño Jesús; Madrid Spain,n/a,True
+Department of Pediatrics; Division of Genetic Medicine; University of Washington; and Seattle Children's Hospital; Seattle Washington,n/a,True
+Department of Pediatrics; North Shore LIJ Health System; Manhasset New York,n/a,True
+Department of Pediatrics; Tufts University School of Medicine; Springfield Massachusetts,n/a,True
+Division of Medical Genetics; AI duPont Hospital for Children; Wilmington Delaware,n/a,True
+Institute of Medical Genetics; University Hospital of Wales; Cardiff UK,n/a,True
+Institute of Pathology and Genetics (IPG); Gosselies Belgium,n/a,True
+Kaiser Permanente Oakland; Oakland California,n/a,True
+Medical Genetics and Neurodevelopment Center; St Vincent Children's Hospital; Indianapolis Indiana,n/a,True
+Medical Genetics; Mayo Clinic College of Medicine; Rochester Minnesota,n/a,True
+Pediatric and Reproductive Genetics; SA Clinical Genetics Service; Women's and Children's Hospital/SA Pathology; North Adelaide; South Australia and Discipline of Pediatrics; University of Adelaide; Adelaide Australia,n/a,True
+Raphael Recanati Genetics Institute; Beilinson Campus and Schneider Children's Medical Center of Israel/Felsenstein Medical Research Center; Rabin Medical Center; Petach Tikva; Israel and Sackler Faculty of Medicine; Tel Aviv University; Tel Aviv Israel,n/a,True
+Section of Genetics; Department of Pediatrics; Medical College of Wisconsin; Milwaukee Wisconsin,n/a,True
+Section of Molecular and Human Genetics; Nationwide Children's Hospital; Columbus Ohio,n/a,True
+Sutter Memorial Hospital; Sacramento California,n/a,True
+The Genetic Institute; Tel-Aviv Sourasky Medical Center and Sackler Faculty of Medicine; Tel-Aviv Israel,n/a,True
+Department of Biochemistry and Biophysics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Biochemistry and Biophysics,False
+Department of Clinical Genetics; CHU Rennes; UMR 6290 CNRS; Université of Rennes; Rennes France,n/a,True
+Department of Human Genetics; Creteil France,n/a,True
+Department of Human Genetics; Radboud Institute for Molecular Life Sciences and Donders Institute for Brain; Cognition and Behaviour; Radboud university medical center; Nijmegen The Netherlands,n/a,True
+Department of Human Genetics; Regional Maternity University Adolphe Pinard; Nancy France,n/a,True
+Department of Human Molecular Genetics; Max Planck Institute for Molecular Genetics; Berlin Germany,n/a,True
+Department of Medical Genetics; Institute of Mother and Child; Warsaw Poland,n/a,True
+Department of Medical Genetics; University of Cambridge; Cambridge United Kingdom,n/a,True
+Department of Medical Genetics; University of Helsinki; Helsinki Finland,n/a,True
+Department of Pediatric Neurology; Radboud university medical center; Nijmegen The Netherlands,n/a,True
+"Departments of Radiology; Neurology, Pediatrics and Neurosurgery; University of California San Francisco; San Francisco California",n/a,True
+"Institut Cochin, Université Paris-Descartes; CNRS (UMR 8104); Paris France",n/a,True
+Institute of Medical Genetics; University of Zurich; Schlieren Switzerland,n/a,True
+"n        n        Australian Demographic and Social Research Institute, The Australian National University, Coombs Building (#9), Canberra ACT 0200, Australia",n/a,True
+"n        n        Department of Public Health, Erasmus UC, University Medical Center Rotterdam, PO Box 2040, 3000 CA Rotterdam, The Netherlands",n/a,True
+"n        n        Department of Sociology/ICS, University of Groningen, Grote Rozenstraat 31, 9712 TG Groningen, The Netherlands",n/a,True
+"n        n        Population and Health Program, East-West Center, 1601 East-West Rd, Honolulu, HI 96848, USA",n/a,True
+Department of Nutrition; Gillings School of Global Public Health and School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Nutrition|School of Medicine,False
+Center for Comparative Medicine and Translational Research; North Carolina State University; Raleigh NC USA,n/a,True
+Department of Microbiology and Immunology; Center for Gastrointestinal Biology and Disease; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Microbiology and Immunology|Center for Gastrointestinal Biology and Disease,False
+"Department of Genetics, University of North Carolina at Chapel Hill; Chapel Hill NC USA",Department of Genetics,False
+"Department of Medicine, Division of Pulmonary and Critical Care, University of North Carolina at Chapel Hill; Chapel Hill NC USA",Division of Pulmonary Diseases and Critical Care Medicine,False
+Epidemiology Department; Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Epidemiology,False
+Maintenance Operations Department; New Hanover County Schools; Wilmington NC USA,n/a,True
+North Carolina Division of Public Health; Department of Health and Human Services; Raleigh NC USA,n/a,True
+Support Services; Chapel Hill-Carrboro City Schools; Chapel Hill NC USA,n/a,True
+Center for Developmental Science; University of North Carolina-Chapel Hill,Center for Developmental Science,False
+Department of Psychology; The Pennsylvania State University,n/a,True
+Department of Psychology; University of Pittsburgh,n/a,True
+Oregon Research Institute,n/a,True
+School of Psychological Sciences; University of Melbourne,n/a,True
+3-C Institute for Social Development; Cary; NC; USA,n/a,True
+Center for Developmental Science; University of North Carolina; Chapel Hill; NC; USA,Center for Developmental Science,False
+Department of Psychology; University of North Carolina; Chapel Hill; NC; USA,Department of Psychology and Neuroscience,False
+Family Studies and Human Development; University of Arizona; Tucson; AZ; USA,n/a,True
+University of Maryland,n/a,True
+"Department of Medicine/Dermatology, University of California San Diego, La Jolla, California, USA",n/a,True
+"Department of Medicine/Endocrinology, University of California San Diego, La Jolla, California, USA",n/a,True
+"Department of Medicine/Rheumatology, Allergy and Immunology, University of California San Diego, La Jolla, California, USA",n/a,True
+"Department of Pediatrics/Allergy, Immunology, Rheumatology, and Infectious Diseases, University of North Carolina at Chapel Hill School of Medicine, North Carolina, USA",School of Medicine,False
+"Department of Surgery/Otolaryngology, University of California San Diego, La Jolla, California, USA",n/a,True
+"Department of Surgery/Otolaryngology, University of California San Diego, La Jolla, California, USA, ",n/a,True
+"Department of Surgery/Otolaryngology, University of California San Diego, La Jolla, California, USA, Department of Otolaryngology, University of Bonn, Bonn, Germany",n/a,True
+"Department of Otolaryngology, University of Lübeck, Lübeck, Germany",n/a,True
+"Departments of Medicine/Endocrinology, University of California, San Diego, and San Diego Veterans Administration Medical Center, La Jolla, California, USA",n/a,True
+"Departments of Medicine/Rheumatology, Allergy and Immunology",n/a,True
+Departments of Surgery/Otolaryngology,n/a,True
+"Department of Endodontics, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Endodontics,False
+"Department of Periodontology, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Periodontology,False
+"Department of Biostatistics, CB 7420",Department of Biostatistics,False
+"Department of Chemistry, CB 3290",Department of Chemistry,False
+Institute of Computational Medicine,n/a,True
+Center for Environmental Medicine,n/a,True
+Bioengineering College; Chongqing University; Chongqing China,n/a,True
+Department of Mathematics; University of North Carolina; Chapel Hill NC USA,Department of Mathematics,False
+Institute of Cardiovascular and Medical Sciences; University of Glasgow; Glasgow UK,n/a,True
+School of Mathematics and Statistics; University of Glasgow; Glasgow UK,n/a,True
+Department of Biostatistics; Gillings School of Global Public Health; University of North Carolina; Chapel Hill; NC,Department of Biostatistics,False
+Department of Epidemiology; Gillings School of Global Public Health; University of North Carolina; Chapel Hill; NC,Department of Epidemiology,False
+Division of Cancer Epidemiology; McGill University; Montreal; Canada,n/a,True
+Infections and Immunoepidemiology Branch; Division of Cancer Epidemiology and Genetics; National Cancer Institute; National Institutes of Health; Bethesda; MD,n/a,True
+"Worldwide Epidemiology, GlaxoSmithKline; Stockley Park; United Kingdom",n/a,True
+British Columbia Cancer Agency; Vancouver; BC; Canada,n/a,True
+Center for Disease Control and Prevention; Atlanta; GA,n/a,True
+Division of Cancer Epidemiology; McGill University; Montreal; QC; Canada,n/a,True
+"Gillings School of Global Public Health, University of North Carolina; Chapel Hill; NC",Gillings School of Global Public Health,False
+Public Health Ontario; Toronto; ON; Canada,n/a,True
+"Department of Epidemiology; Gillings School of Global Public Health, University of North Carolina at Chapel Hill; Chapel Hill NC",Department of Epidemiology,False
+Department of Epidemiology; Johns Hopkins Bloomberg School of Public Health; Baltimore MD,n/a,True
+"Department of Nutrition; Gillings School of Global Public Health, University of North Carolina at Chapel Hill; Chapel Hill NC",Department of Nutrition,False
+"Surveillance and Health Services Research Program, American Cancer Society; Atlanta GA",n/a,True
+BIPS-Institute for Epidemiology and Prevention Research; Bremen Germany,n/a,True
+Brown University; Providence Rhode Island,n/a,True
+Cancer Registry of Norway; Oslo Norway,n/a,True
+Department of Clinical Sciences and Community Health; University of Milan; Italy,n/a,True
+"Department of Epidemiology; IRCCS-Istituto di Ricerche Farmacologiche “Mario Negri,”; Milan Italy",n/a,True
+"Division of Epidemiology; New York University, School of Medicine; NY",n/a,True
+"Epidemiology and Biostatistics Unit, Centro di Riferimento Oncologico IRCCS; Aviano Italy",n/a,True
+"Escola Nacional de Saude Publica, Fundacao Oswaldo Cruz; Rio de Janeiro Brazil",n/a,True
+"First Faculty of Medicine, Institute of Hygiene and Epidemiology; Charles University; Prague Czech Republic",n/a,True
+Fred Hutchinson Cancer Research Center; Seattle WA,n/a,True
+German Cancer Research Center; Heidelberg Germany,n/a,True
+"Glasgow Dental School, College of Medical, Veterinary and Life Sciences; University of Glasgow; Glasgow United Kingdom",n/a,True
+Hospital Heliopolis; Sao Paulo Brazil,n/a,True
+Hospital de Clinicas de Porto Alegre; Porto Alegre Brazil,n/a,True
+"Institut Catala d'Oncologia (ICO), IDIBELL, CIBER-ESP, L'Hospitalet de Llobregat; Barcelona Catalonia Spain",n/a,True
+Institute of Oncology and Radiobiology; Havana Cuba,n/a,True
+Instituto do Cancer Arnaldo Viera de Carvalho; Sao Paulo Brazil,n/a,True
+International Agency for Research on Cancer; Lyon France,n/a,True
+International Prevention Research Institute; Lyon France,n/a,True
+Johns Hopkins Bloomberg School of Public Health; Baltimore MD,n/a,True
+"Prevention and Implementation Group, International Agency for Research on Cancer; Lyon France",n/a,True
+Regional Authority of Public Health; Banska Bystrica Slovakia,n/a,True
+Roswell Park Cancer Institute; Buffalo NY,n/a,True
+"The Ohio State University, Comprehensive Cancer Center; Columbus OH",n/a,True
+Trinity College School of Dental Science; Dublin Ireland,n/a,True
+"Unit of Nutrition, Environment and Cancer Epidemiology Research Program, Catalan Institute of Oncology-ICO, L'Hospitalet de Llobregat; Barcelona Spain",n/a,True
+University of Athens School of Medicine; Athens Greece,n/a,True
+Washington State University College of Pharmacy; Spokane WA,n/a,True
+Cellular and Molecular Pathology Branch; National Institute of Environmental Health Sciences and National Toxicology Program; Research Triangle Park NC,n/a,True
+Department of Environmental Sciences and Engineering; University of North Carolina; Chapel Hill NC,Department of Environmental Sciences and Engineering,False
+Division of Biochemical Toxicology; National Center for Toxicological Research; Jefferson AR,n/a,True
+"Bobby R. Alford Department of Otolaryngology Head and Neck Surgery; Baylor College of Medicine, University of Texas School of Dentistry at Houston; Houston TX",n/a,True
+"Cancer Epidemiology Unit; Institute for Social and Preventive Medicine (IUMSP), Lausanne University Hospital; Lausanne Switzerland",n/a,True
+Department of Cancer Prevention and Control; Roswell Park Cancer Institute; Buffalo NY,n/a,True
+Department of Clinical Sciences and Community Health; University of Milan; Milan Italy,n/a,True
+Department of Environmental Health; Boston University School of Public Health; Boston MA,n/a,True
+Department of Epidemiology; Brown University; Providence RI,n/a,True
+Department of Epidemiology; IRCCS-Istituto di Ricerche Farmacologiche Mario Negri; Milan Italy,n/a,True
+"Department of Epidemiology; School of Public Health and Comprehensive Cancer Center, University of Michigan; Ann Arbor MI",n/a,True
+Department of Epidemiology; UCLA School of Public Health; Los Angeles CA,n/a,True
+Department of Epidemiology; University of North Carolina School of Public Health; Chapel Hill NC,Department of Epidemiology,False
+"Department of Family and Preventive Medicine; Huntsman Cancer Institute, University of Utah School of Medicine; Salt Lake City UT",n/a,True
+Department of Family and Preventive Medicine; University of Utah School of Medicine; Salt Lake City UT,n/a,True
+"Department of Medical and Biological Sciences; Unit of Hygiene and Epidemiology, University of Udine; Udine Italy",n/a,True
+Department of Otolaryngology; New York Eye and Ear Infirmary; New York NY,n/a,True
+"Department of Preventive Medicine; Faculty of Medical Sciences, Kyushu University; Kyushu Japan",n/a,True
+Division of Cancer Control and Population Sciences; National Cancer Institute; Bethesda MD,n/a,True
+Medical Informatics Center; Peking University; Beijing China,n/a,True
+"Section of Hygiene; Institute of Public Health, Department of Public Health, Università Cattolica del Sacro Cuore; Rome Italy",n/a,True
+The Tisch Cancer Institute and Institute for Translational Epidemiology; Icahan School of Medicine at Mount Sinai; New York NY,n/a,True
+Unit of Epidemiology and Biostatistics; Aviano Cancer Centre; Aviano Italy,n/a,True
+British Columbia Cancer Agency; Vancouver BC Canada,n/a,True
+"Cancer Epidemiology and Services Research; Sydney School of Public Health, University of Sydney; Sydney NSW Australia",n/a,True
+Center for Clinical Epidemiology and Biostatistics; Perelman School of Medicine at the University of Pennsylvania; Philadelphia PA,n/a,True
+Department of Cancer Epidemiology; H. Lee Moffitt Cancer Center and Research Institute; Tampa FL,n/a,True
+"Department of Dermatology; Lineberger Comprehensive Cancer Center, University of North Carolina; Chapel Hill NC",UNC Lineberger Comprehensive Cancer Center|Department of Dermatology,False
+Department of Epidemiology and Biostatistics; Memorial Sloan-Kettering Cancer Center; New York NY,n/a,True
+Department of Epidemiology; University of California; Irvine CA,n/a,True
+Department of Pathology; Memorial Sloan-Kettering Cancer Center; New York NY,n/a,True
+"Departments of Internal Medicine; Division of Epidemiology; Biostatistics and Preventive Medicine, University of New Mexico; Albuquerque NM",n/a,True
+International Agency for Cancer Research; Lyon France,n/a,True
+"Keck School of Medicine; University of Southern California, Norris Comprehensive Cancer Center; Los Angeles CA",n/a,True
+Piedmont Tumor Registry; Turin Italy,n/a,True
+Women's College Hospital; Toronto ON Canada,n/a,True
+" Tisch Cancer Institute, Mount Sinai School of Medicine; New York NY",n/a,True
+"Cancer Epidemiology Unit, Institute for Social and Preventive Medicine (IUMSP), Lausanne University Hospital; Lausanne Switzerland",n/a,True
+Department of Cancer Prevention and Control and Department of Immunology; Roswell Park Cancer Institute; Buffalo NY,n/a,True
+"Department of Epidemiology and Environmental Health Sciences, School of Public Health and Comprehensive Cancer Center; University of Michigan; Ann Arbor MI USA",n/a,True
+"Department of Epidemiology, Gillings School of Global Public Health, and Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill NC USA",Department of Epidemiology|UNC Lineberger Comprehensive Cancer Center,False
+Department of Otolaryngology/Head and Neck Surgery; University of North Carolina at Chapel Hill; Chapel Hill NC,Department of Otolaryngology/Head and Neck Surgery,False
+"Department of Otolaryngology; New York Eye and Ear Infirmary; New York, NY",n/a,True
+Department of Pathology and Laboratory Medicine and Department of Epidemiology; Brown University; Providence RI,n/a,True
+Department of Preventive Medicine; Kyushu University Faculty of Medical Sciences; Kyushu Japan,n/a,True
+"Dipartimento di Scienze Cliche e di Comunità Sezione Di Statistica Medica E Biometria “Giulio A. Maccacaro,”; Università degli Studi di Milano; Milan Italy",n/a,True
+"Division of Public Health, Department of Family and Preventive Medicine and Huntsman Cancer Institute; University of Utah School of Medicine; Salt Lake City USA",n/a,True
+"Division of Public Health, Department of Family and Preventive Medicine; University of Utah School of Medicine; Salt Lake City UT",n/a,True
+"Institute of Hygiene and Epidemiology, Department of Medical and Biological Sciences; University of Udine; Udine Italy",n/a,True
+"Institute of Population Health Sciences, National Health Research Institutes; Miaoli Taiwan",n/a,True
+"Medical Informatics Center, Peking University; Peking China",n/a,True
+Unit of Epidemiology and Biostatistics; CRO Aviano National Cancer Institute; IRCCS Aviano Italy,n/a,True
+Department of Genetic Epidemiology; Queensland Institute of Medical Research; Brisbane Queensland Australia,n/a,True
+Department of Psychiatry; Washington University; St Louis Missouri,n/a,True
+School of Psychology; Flinders University; Adelaide South Australia Australia,n/a,True
+Bradley Hasbro Children's Research Center; Alpert Medical School of Brown University; Providence Rhode Island,n/a,True
+Stanford University; Stanford California,n/a,True
+University of North Carolina; Chapel Hill North Carolina,University of North Carolina at Chapel Hill,False
+Center for Developmental Science; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Center for Developmental Science,False
+Abo Akademi University; Turku Finland,n/a,True
+Department of Nutrition; University of North Carolina; Chapel Hill North Carolina,Department of Nutrition,False
+Department of Pediatrics; University of North Carolina; Chapel Hill North Carolina,Department of Pediatrics,False
+Department of Psychiatry; Duke University; Durham North Carolina,n/a,True
+Department of Psychology; University of North Carolina; Chapel Hill North Carolina,Department of Psychology and Neuroscience,False
+Department of Psychology; Virginia Commonwealth University; Richmond Virginia,n/a,True
+School of Nursing; University of North Carolina; Chapel Hill North Carolina,School of Nursing,False
+Department of Psychiatry and Behavioral Sciences; Duke University Medical Center; Durham North Carolina,n/a,True
+Department of Psychology and Division of Mental Health and Well-Being; University of Warwick; Coventry United Kingdom,n/a,True
+Department of Medical Epidemiology and Biostatistics; Karolinska Institutet; Stockholm Sweden,n/a,True
+University of Extremadura Medical School; Badajoz Spain,n/a,True
+Department of Psychiatry and Behavioral Sciences; Duke University School of Medicine; Durham North Carolina,n/a,True
+"Department of Psychiatry, UNC School of Medicine; University of North Carolina; Chapel Hill North Carolina",Department of Psychiatry,False
+Department of Psychology and Neuroscience; Duke University; Durham North Carolina,n/a,True
+Department of Clinical Neuroscience; Karolinska Institutet; Stockholm Sweden,n/a,True
+Department of Clinical Sciences; University of Lund; Lund Sweden,n/a,True
+"National Centre for Register-Based Research, Aarhus University; Aarhus Denmark",n/a,True
+"Division of Pulmonary and Critical Care Medicine and the School of Medicine, The University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Division of Pulmonary Diseases and Critical Care Medicine,False
+"CMRU/NHLI, Imperial College of Science, Technology and Medicine, University of London, London SW3 6NP, UK",n/a,True
+"Department of Biological and Agricultural Engineering, North Carolina State University, NC 27695, USA",n/a,True
+"Diabetes New Zealand, Rotorua, New Zealand",n/a,True
+"Shodor Education Foundation, Durham, NC 27701, USA",n/a,True
+Frank Porter Graham Child Development Institute; University of North Carolina at Chapel Hill; NC; USA,Frank Porter Graham Child Development Institute,False
+The Roxelyn and Richard Pepper Department of Communication Sciences and Disorders; Northwestern University; Evanston; IL; USA,n/a,True
+"Department of Psychiatry and Behavioral Sciences, Duke University School of Medicine; Duke University Medical Center; Durham; NC; USA",n/a,True
+"Department of Psychiatry, School of Medicine; University of Pennsylvania and Treatment Research Institute; Philadelphia; PA; USA",n/a,True
+Gillings School of Global Public Health; University of North Carolina at Chapel Hill; NC; USA,Gillings School of Global Public Health,False
+Social Science Research Institute; Duke University; Durham; NC; USA,n/a,True
+Veterans Health Administration; Washington; DC; USA,n/a,True
+North Carolina Translational and Clinical Sciences Institute; University of North Carolina at Chapel Hill; Chapel Hill NC USA,North Carolina Translational and Clinical Sciences Institute,False
+University of North Carolina at Chapel Hill School of Dentistry; Chapel Hill NC USA,School of Dentistry,False
+"  Department of Health Behavior and Health Education Gillings School of Global Public Health, University of North Carolina at Chapel Hill  Chapel Hill North Carolina USA",Department of Health Behavior,False
+"  Division of Pharmaceutical Outcomes and Policy Eshelman School of Pharmacy, University of North Carolina at Chapel Hill  Chapel Hill North Carolina USA",Division of Pharmaceutical Outcomes and Policy,False
+"Exercise and Sport Science, University of North Carolina at Chapel Hill, Chapel Hill, United States",Department of Exercise and Sport Science,False
+"Community Health, Muhimbili University of Health and Allied Sciences, Dar es Salaam, Tanzania",n/a,True
+"Department of Epidemiology, Johns Hopkins University Bloomberg School of Public Health, Baltimore, MD",n/a,True
+"Department of Obstetrics and Gynaecology, Drexel University, Philadelphia, PA",n/a,True
+"Departments of Nutrition and Epidemiology, Harvard School of Public Health, Boston, MA, USA",n/a,True
+"Family Health International, Research Triangle Park, NC",n/a,True
+"Fred Hutchinson Cancer Research Center (FHCRC), Seattle, WA",n/a,True
+"Pediatric, Adolescent, and Maternal AIDS Branch, NICHD, NIH, DHHS, Bethesda, MD",n/a,True
+"Prevention Sciences Program, NIAID, NIH, Bethesda, MD",n/a,True
+"School of Public Health, University of Alabama, Birmingham, AL",n/a,True
+Statistical Center for HIV/AIDS Research and Prevention (SCHARP),n/a,True
+"University of North Carolina, Chapel Hill, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"Department of Health Behavior, College of Public Health, University of Kentucky, Lexington, KY, USA",n/a,True
+"Department of Psychology, University of North Carolina, Chapel Hill, NC, USA",Department of Psychology and Neuroscience,False
+"Division of General Medicine and Epidemiology, School of Medicine, University of North Carolina, Chapel Hill, NC, USA",Division of General Medicine and Clinical Epidemiology,False
+"School of Journalism and Mass Communication, University of North Carolina, Chapel Hill, NC, USA",Hussman School of Journalism and Media,False
+"Department of Epidemiology, Johns Hopkins Bloomberg School of Public Health, Baltimore, USA",n/a,True
+"Faculty of Health Science Department of Medicine, University of Witwatersrand, Johannesburg, South Africa",n/a,True
+"Gillings School of Global Public Health, University of North Carolina, Chapel Hill, USA",Gillings School of Global Public Health,False
+"Centre for Public Health Research, Kenya Medical Research Institute, Nairobi, Kenya",n/a,True
+"Department of Epidemiology, Johns Hopkins University, Baltimore, MD, USA",n/a,True
+"Department of Epidemiology, University of Washington, Seattle, WA, USA",n/a,True
+"Department of Global Health, University of Washington, Seattle, WA, USA",n/a,True
+"Department of Medicine, University of Washington, Seattle, WA, USA",n/a,True
+"Department of Obstetrics and Gynecology, University of Nairobi, Nairobi, Kenya",n/a,True
+"School of Medicine, Virginia Commonwealth University, Richmond, VA, USA",n/a,True
+"School of Public Health, Kenyatta University, Nairobi, Kenya",n/a,True
+"Carolina Population Center and Department of Epidemiology, University of North Carolina, NC, USA",Carolina Population Center|Department of Epidemiology,False
+"Department of Community Health and Psychiatry, University of the West Indies, Mona, Kingston, Jamaica",n/a,True
+"Departments of Medicine and Microbiology &amp; Immunology, University of North Carolina, NC, USA",Department of Microbiology and Immunology|Department of Medicine,False
+"Kingston &amp; St. Andrew Health Department, Kingston, Jamaica",n/a,True
+"Ministry of Health, Kingston, Jamaica",n/a,True
+" Department of Emergency Medicine, Gillings School of Global Medicine, University of North Carolina, Chapel Hill, NC, USA",Department of Emergency Medicine|Gillings School of Global Public Health,False
+" Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC, USA",Department of Epidemiology,False
+" CHUV Lausanne, Lausanne, Switzerland",n/a,True
+" Department of Neurology, Massachusetts General Hospital, Boston, MA, USA",n/a,True
+" Department of Neurology, UCLA, Los Angeles, CA, USA",n/a,True
+" Department of Neurology, University of Calgary, Calgary, AB, Canada",n/a,True
+" Department of Neurology, University of NC, Chapel Hill, NC, USA",Department of Neurology,False
+" Department of Neurology, University of Pittsburgh Medical Center, Pittsburgh, PA, USA",n/a,True
+" Department of Neurology, University of Rochester, Rochester, NY, USA",n/a,True
+" Department of Neurology, Universitätsklinikum Duisburg-Essen, Essen, Germany",n/a,True
+" Department of Neurology, Universitätsklinikum-Erlangen, Erlangen, Germany",n/a,True
+" Department of Radiology, UCSF, San Francisco, CA, USA",n/a,True
+" Stroke Program, University of Alberta, Edmonton, AB, Canada",n/a,True
+"Clarient, Inc, Aliso Viejo, CA, USA",n/a,True
+"Cleveland Clinic, Cleveland, OH, USA",n/a,True
+"Johns Hopkins University Medical Center, Baltimore, MD, USA",n/a,True
+"MD Anderson Cancer Center, Houston, TX, USA",n/a,True
+"Massachusetts General Hospital, Boston, MA, USA",n/a,True
+"Mayo Clinic, Rochester, MN, USA",n/a,True
+"Ruffolo Hooper &amp; Associates, Tampa, FL, USA",n/a,True
+"SA Pathology, Adelaide, South Australia, Australia",n/a,True
+"Vanderbilt University Medical Center, Nashville, TN, USA",n/a,True
+University of North Carolina,University of North Carolina at Chapel Hill,False
+"Department of Neuroradiology, University of North Carolina; Chapel Hill, North Carolina, USA",Department of Radiology,False
+Department of Biology; Winthrop University; Rock Hill South Carolina 29733 USA,n/a,True
+Department of Natural Resources and the Environment; University of New Hampshire; Durham New Hampshire 03824 USA,n/a,True
+Institute of Marine Sciences; University of North Carolina; Morehead City North Carolina 28557 USA,Institute of Marine Sciences,False
+South Carolina Governor's School for Science and Mathematics; Hartsville South Carolina 29550 USA,n/a,True
+"From the Department of Ophthalmology, Mayo Clinic College of Medicine, Rochester, Minnesota.",n/a,True
+"Center for Cell and Gene Therapy, Baylor College of Medicine, Houston, Texas.",n/a,True
+"Department of Internal Medicine, Wake Forest University, Winston-Salem, North Carolina; and the",n/a,True
+"From the Department of Ophthalmology, University of North Carolina School of Medicine, Chapel Hill, North Carolina; the",Department of Ophthalmology,False
+"Department of Ophthalmology, University of North Carolina, Chapel Hill, North Carolina.",Department of Ophthalmology,False
+"From the Department of Ophthalmology, Showa University, Tokyo, Japan; and the",n/a,True
+"Beetham Eye Institute, Joslin Diabetes Center, Harvard Medical School, Boston, Massachusetts;",n/a,True
+"Casey Eye Institute, Oregon Health and Science University, Portland, Oregon; the",n/a,True
+"Charlotte Eye, Ear, Nose and Throat Associates, Charlotte, North Carolina;",n/a,True
+"Department of Ophthalmology and Public Health Sciences, Penn State College of Medicine, Hershey, Pennsylvania.",n/a,True
+"Department of Ophthalmology and Visual Sciences, University of Texas Medical Branch School of Medicine, Galveston, Texas; and the",n/a,True
+"Department of Ophthalmology, Kaiser Permanente Southern California, Baldwin Park, California; the7Department of Research and Evaluation, Kaiser Permanente Southern California, Pasadena, California; the",n/a,True
+"Department of Ophthalmology, University of North Carolina School of Medicine, Chapel Hill, North Carolina; the",Department of Ophthalmology,False
+"Department of Ophthalmology, Weill Cornell Medical College at The Methodist Hospital, Houston, Texas; the9Department of Physics, The University of Houston, Houston, Texas; the",n/a,True
+"From the Department of Ophthalmology and Visual Sciences, University of Wisconsin, Madison, Wisconsin; the",n/a,True
+"Jaeb Center for Health Research, Tampa, Florida; the",n/a,True
+"Wilmer Eye Institute, Johns Hopkins University, Baltimore, Maryland; the",n/a,True
+"Biology and the2Carolina Cardiovascular Biology Center, The University of North Carolina, Chapel Hill, North Carolina.",Department of Biology,False
+From the Departments of Ophthalmology and,n/a,True
+"From the Departments of Ophthalmology and2Carolina Cardiovascular Biology Center, The University of North Carolina, Chapel Hill, North Carolina.",Department of Ophthalmology|UNC McAllister Heart Institute,False
+"From the Ophthalmic Epidemiology and Genetics Service, Department of Ophthalmology, Tufts University School of Medicine, Tufts Medical Center, Boston, Massachusetts;",n/a,True
+"the Channing Laboratory, Brigham and Women's Hospital, Harvard Medical School, Boston, Massachusetts.",n/a,True
+"the Department of Medicine, Division of Rheumatology, Washington University, St. Louis, Missouri;",n/a,True
+"the Department of Ophthalmology, University of North Carolina School of Medicine, Chapel Hill, North Carolina;",Department of Ophthalmology,False
+"the Pediatrics Department, Allergy and Immunology Division, National Jewish Health, Denver, Colorado; and",n/a,True
+"From the Departamento de Oftalmología, UNNE, Corrientes, Argentina;",n/a,True
+"the Department of Ophthalmology, Mount Sinai School of Medicine, New York, New York.",n/a,True
+"the Department of Ophthalmology, University of North Carolina, Chapel Hill, North Carolina; and",Department of Ophthalmology,False
+"Cell and Developmental Biology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina;",Department of Cell Biology and Physiology,False
+"From the Departments of Ophthalmology and 4Department of Ophthalmology, Moran Eye Center, University of Utah, Salt Lake City, Utah.",n/a,True
+"Schepens Eye Research Institute, Boston, Massachusetts; and",n/a,True
+"Department of Ophthalmology, John Moran Eye Center, University of Utah, Salt Lake City, Utah.",n/a,True
+"From the Department of Cell and Developmental Biology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina; and",Department of Cell Biology and Physiology,False
+"From Vance Thompson Vision, University of South Dakota Medical Center, Sioux Falls, South Dakota;",n/a,True
+"the Department of Ophthalmology, Mayo Clinic, Rochester, Minnesota; and",n/a,True
+"the Department of Ophthalmology, University of North Carolina, Chapel Hill, North Carolina;",Department of Ophthalmology,False
+"the Duke University Eye Center, Durham, North Carolina.",n/a,True
+"Channing Laboratory, Brigham and Women's Hospital, Harvard Medical School, Boston, Massachusetts; the",n/a,True
+"Channing Laboratory, Brigham and Women's Hospital, Harvard Medical School, Boston, Massachusetts; the 11Department of Ophthalmology, Harvard Medical School, Massachusetts Eye and Ear Infirmary, Boston, Massachusetts; the",n/a,True
+"Department of Genetics, Stanford University, Palo Alto, California; the",n/a,True
+"Department of Human Genetics, University of Miami School of Medicine, Miami, Florida; the",n/a,True
+"Department of Human Genetics, University of Michigan, Ann Arbor, Michigan; the",n/a,True
+"Department of Ophthalmology, Duke University School of Medicine, Durham, North Carolina.",n/a,True
+"Department of Ophthalmology, Harvard Medical School, Massachusetts Eye and Ear Infirmary, Boston, Massachusetts; the",n/a,True
+"Department of Ophthalmology, Johns Hopkins University School of Medicine, Baltimore, Maryland; the",n/a,True
+"Department of Ophthalmology, Stanford University, Palo Alto, California; the",n/a,True
+"Department of Ophthalmology, University of California, San Diego, California; and the",n/a,True
+"Department of Ophthalmology, University of Miami, Miami, Florida; the",n/a,True
+"Department of Ophthalmology, University of Pittsburgh, Pittsburgh, Pennsylvania; the",n/a,True
+"Department of Ophthalmology, West Virginia University School of Medicine, Morgantown, West Virginia; the",n/a,True
+"Eye Doctors of Washington DC, Washington, DC; the",n/a,True
+"From the 1Duke University Center for Human Genetics, Durham, North Carolina; theDepartment of Ophthalmology, Duke University School of Medicine, Durham, North Carolina.",n/a,True
+Ophthalmology and Visual Sciences and,n/a,True
+"Ophthalmology and Visual Sciences and 5Epidemiology, University of Michigan, Ann Arbor, Michigan; the",n/a,True
+"Vanderbilt University School of Medicine, Center for Human Genetics Research, Nashville, Tennessee; the Departments of",n/a,True
+"Department of Medicine, University of North Carolina, Chapel Hill, North Carolina.",Department of Medicine,False
+"From the Research Division, Joslin Diabetes Center, Harvard Medical School, Boston, Massachusetts; and the",n/a,True
+"Bascom Palmer Eye Institute, University of Miami Miller School of Medicine, Miami, Florida; and the",n/a,True
+"Department of Ophthalmology, University of North Carolina School of Medicine, Chapel Hill, North Carolina.",Department of Ophthalmology,False
+"Department of Biomedical Engineering, Duke University, Durham, North Carolina",n/a,True
+"Department of Ophthalmology, Duke University Eye Center, Durham, North Carolina",n/a,True
+"Department of Ophthalmology, Duke University Eye Center, Durham, North Carolina 3Department of Biomedical Engineering, Duke University, Durham, North Carolina",n/a,True
+"Department of Ophthalmology, Duke University Eye Center, Durham, North Carolina 5Department of Pediatrics, Duke University School of Medicine, Durham, North Carolina",n/a,True
+"Department of Ophthalmology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Ophthalmology,False
+"Duke University School of Medicine, Durham, North Carolina",n/a,True
+"Department of Ophthalmology, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Ophthalmology,False
+"Department of Cell Biology and Physiology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Cell Biology and Physiology,False
+"Department of Ophthalmology, The John Moran Eye Center, University of Utah, Salt Lake City, Utah",n/a,True
+"Gene Therapy Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Gene Therapy Center,False
+"Helen Wills Neuroscience Institute, University of California, Berkeley, Berkeley, California",n/a,True
+"Bascom Palmer Eye Institute, Department of Ophthalmology, University of Miami, Miami, Florida, United States",n/a,True
+"Department of Biostatistics, Yale School of Public Health, Yale University, New Haven, Connecticut, United States",n/a,True
+"Department of Ophthalmology University of North Carolina, Chapel Hill, North Carolina, United States",Department of Ophthalmology,False
+"Department of Ophthalmology and Visual Sciences, University of Iowa, Iowa City, Iowa, United States",n/a,True
+"Department of Ophthalmology and Visual Sciences, Washington University, St. Louis, Missouri, United States",n/a,True
+"Department of Ophthalmology, University of North Carolina, Chapel Hill, North Carolina, United States",Department of Ophthalmology,False
+"Division of Biostatistics, Washington University, St. Louis, Missouri, United States 7Department of Ophthalmology and Visual Sciences, Washington University, St. Louis, Missouri, United States",n/a,True
+"Stephen A. Wynn Institute for Vision Research, University of Iowa, Iowa City, Iowa, United States 2Department of Biomedical Engineering, University of Iowa, Iowa City, Iowa, United States",n/a,True
+"Stephen A. Wynn Institute for Vision Research, University of Iowa, Iowa City, Iowa, United States 2Department of Biomedical Engineering, University of Iowa, Iowa City, Iowa, United States 3Department of Electrical and Computer Engineering, University of I",n/a,True
+"Stephen A. Wynn Institute for Vision Research, University of Iowa, Iowa City, Iowa, United States 2Department of Biomedical Engineering, University of Iowa, Iowa City, Iowa, United States 4Department of Ophthalmology and Visual Sciences, University of Iow",n/a,True
+"Stephen A. Wynn Institute for Vision Research, University of Iowa, Iowa City, Iowa, United States 4Department of Ophthalmology and Visual Sciences, University of Iowa, Iowa City, Iowa, United States",n/a,True
+"Department of Health Policy and Management, University of North Carolina Gillings School of Global Public Health, Chapel Hill",Department of Health Policy and Management,False
+"Department of Health Policy and Management, University of North Carolina Gillings School of Global Public Health, Chapel Hill3Sheps Center for Health Services Research, University of North Carolina, Chapel Hill",Cecil G. Sheps Center for Health Services Research|Department of Health Policy and Management,False
+"Division of Cardiology, University of North Carolina, Chapel Hill",Division of Cardiology,False
+"Broad Institute of Harvard and Massachusetts Institute of Technology, Cambridge",n/a,True
+"Cardiovascular Research Institute, Morehouse School of Medicine, Atlanta, Georgia",n/a,True
+"Center for Human Genetic Research, Boston and Broad Institute, Program in Medical and Population Genetics, Massachusetts General Hospital, Cambridge",n/a,True
+"Center for Public Health Genomics, University of Virginia, Charlottesville",n/a,True
+"Department of Biostatistics, Zilber School of Public Health, University of Wisconsin-Milwaukee",n/a,True
+"Department of Epidemiology, Johns Hopkins Bloomberg School of Public Health, Baltimore, Maryland",n/a,True
+"Department of Epidemiology, University of North Carolina Gillings School of Global Public Health, Chapel Hill",Department of Epidemiology,False
+"Department of Epidemiology, University of Washington School of Public Health, Seattle",n/a,True
+"Department of Genome Sciences, University of Washington, Seattle",n/a,True
+"Department of Medicine and Pediatrics, University of Mississippi Medical Center, Jackson",n/a,True
+"Department of Obstetrics and Gynecology, School of Medicine and Public Health, University of Wisconsin, Madison",n/a,True
+"Department of Physiology and Biophysics, University of Mississippi Medical Center, Jackson",n/a,True
+"Division of Epidemiology and Community Health, School of Public Health, University of Minnesota, Minneapolis",n/a,True
+"Division of General Internal Medicine, Department of Medicine, University of California, San Francisco",n/a,True
+"Division of Hematology and Oncology, Department of Medicine, University of North Carolina at Chapel Hill",Division of Hematology/Oncology,False
+"Division of Hematology, Department of Medicine, Johns Hopkins University, Baltimore, Maryland",n/a,True
+"Division of Nephrology and Hypertension, Department of Medicine, University of North Carolina Kidney Center, University of North Carolina at Chapel Hill",Division of Nephrology and Hypertension|UNC Kidney Center,False
+"Division of Nephrology, Department of Medicine, Johns Hopkins University, Baltimore, Maryland",n/a,True
+"Division of Nephrology, Department of Medicine, University of California, San Francisco",n/a,True
+"Division of Nephrology, Department of Medicine, Veterans Affairs Puget Sound Health Care System, University of Washington, Seattle",n/a,True
+"Human Genetics Center, School of Public Health, University of Texas School Health Science Center at Houston",n/a,True
+"Kidney Research Institute, University of Washington, Seattle",n/a,True
+"Montreal Heart Institute and Université de Montréal, Montréal, Québec, Canada",n/a,True
+"Stroke Center, Department of Neuroscience, Medical University of South Carolina, Charleston",n/a,True
+"Department of Pediatrics, Children's Mercy Hospital, Kansas City School of Medicine, University of Missouri",n/a,True
+"Department of Pediatrics, Emory University School of Medicine, Children’s Healthcare of Atlanta, Atlanta, Georgia",n/a,True
+"Department of Pediatrics, Indiana University School of Medicine, Indianapolis",n/a,True
+"Department of Pediatrics, Nationwide Children’s Hospital, Ohio State University, Columbus",n/a,True
+"Department of Pediatrics, Perelman School of Medicine, Children's Hospital of Philadelphia, University of Pennsylvania",n/a,True
+"Department of Pediatrics, Rainbow Babies and Children’s Hospital, Case Western Reserve University, Cleveland, Ohio",n/a,True
+"Department of Pediatrics, University at Buffalo, Buffalo, New York",n/a,True
+"Department of Pediatrics, University of California, Los Angeles",n/a,True
+"Department of Pediatrics, University of Iowa, Iowa City",n/a,True
+"Department of Pediatrics, University of Texas Medical School at Houston",n/a,True
+"Department of Pediatrics, University of Texas Southwestern Medical Center, Dallas",n/a,True
+"Department of Pediatrics, Wayne State University, Detroit, Michigan",n/a,True
+"Department of Pediatrics, Women and Infants Hospital, Brown University, Providence, Rhode Island",n/a,True
+"Department of Pediatrics, Yale University School of Medicine, New Haven, Connecticut",n/a,True
+"Division of Neonatal and Developmental Medicine, Department of Pediatrics, Lucile Packard Children's Hospital, Stanford University School of Medicine, Palo Alto, California",n/a,True
+"Division of Neonatal/Perinatal Medicine, Department of Pediatrics, University of North Carolina, Chapel Hill",Department of Pediatrics,False
+"Division of Neonatology, University of Alabama at Birmingham",n/a,True
+"Perinatal Institute, Cincinnati Children’s Hospital Medical Center, Cincinnati, Ohio",n/a,True
+"Pregnancy and Perinatology Branch, Eunice Kennedy Shriver National Institute of Child Health and Human Development, National Institutes of Health, Bethesda, Maryland",n/a,True
+"Social, Statistical, and Environmental Sciences Unit, RTI International, Research Triangle Park, North Carolina",n/a,True
+"Social, Statistical, and Environmental Sciences Unit, RTI International, Rockville, Maryland",n/a,True
+"University of New Mexico Health Sciences Center, Albuquerque, New Mexico",n/a,True
+"Dallas Medical Center, Dallas, Texas",n/a,True
+"Indiana University, Indianapolis",n/a,True
+"Medical University of South Carolina, Charleston",n/a,True
+"Medical University of South Carolina, Charleston12Florida Hospital, Orlando",n/a,True
+"Midwest Therapeutic Endoscopy Consultants, St Louis, Missouri",n/a,True
+"National Institute of Diabetes and Digestive and Kidney Diseases, Bethesda, Maryland",n/a,True
+"Ralph H. Johnson VA Medical Center, Charleston, South Carolina",n/a,True
+"University of Alabama, Birmingham",n/a,True
+"University of Minnesota Medical School, Minneapolis",n/a,True
+"University of North Carolina and Drossman Gastroenterology PLLC, Chapel Hill",University of North Carolina at Chapel Hill,False
+"Virginia Mason Medical Center, Seattle, Washington",n/a,True
+"Yale University, New Haven, Connecticut",n/a,True
+"Carolina Population Center, University of North Carolina at Chapel Hill",Carolina Population Center,False
+"Department of Health Policy and Management, Gillings School of Global Public Health, University of North Carolina at Chapel Hill",Department of Health Policy and Management,False
+"Department of Health Policy and Management, Gillings School of Global Public Health, University of North Carolina at Chapel Hill2Carolina Population Center, University of North Carolina at Chapel Hill",Carolina Population Center|Department of Health Policy and Management,False
+"FHI 360, Durham, North Carolina",n/a,True
+"Impact Research and Development Organization, Kisumu, Kenya",n/a,True
+"Department of Biostatistics, Gillings School of Public Health, University of North Carolina, Chapel Hill",Department of Biostatistics,False
+"Department of Psychiatry and Health Behavior, Georgia Regents University, Augusta",n/a,True
+"Department of Psychiatry, College of Physicians and Surgeons, Columbia University, New York, New York8New York State Psychiatric Institute, New York, New York",n/a,True
+"Department of Psychiatry, Division of Social and Community Psychiatry, Duke University, Durham, North Carolina",n/a,True
+"Department of Psychiatry, School of Medicine and Dentistry, University of Rochester, Rochester, New York",n/a,True
+"Department of Psychiatry, UT Southwestern Medical Center, Dallas",n/a,True
+"Yale School of Medicine, Yale University, and Northeast Program Evaluation Center, West Haven, Connecticut",n/a,True
+"Childhood Diabetes Research Division of Diabetes, Endocrinology and Metabolic Diseases, National Institute of Diabetes and Digestive and Kidney Diseases, Bethesda, Maryland",n/a,True
+"Department of Biostatistical Sciences, Wake Forest School of Medicine, Winston-Salem, North Carolina",n/a,True
+"Department of Endocrinology, Children's Hospital Medical Center, Cincinnati, Ohio",n/a,True
+"Department of Epidemiology and Biostatistics, Arnold School of Public Health, Columbia, South Carolina",n/a,True
+"Department of Epidemiology and Prevention, Wake Forest School of Medicine, Winston-Salem, North Carolina",n/a,True
+"Department of Epidemiology, Colorado School of Public Health, Aurora",n/a,True
+"Department of Nutrition, University of North Carolina, Chapel Hill",Department of Nutrition,False
+"Department of Pediatric Endocrinology and Diabetes, Children’s Hospital and Regional Medical Center, Seattle, Washington",n/a,True
+"Department of Pediatrics, University of Washington, and Seattle Children’s Hospital, Seattle",n/a,True
+"Department of Research and Evaluation, Kaiser Permanente Southern California, Pasadena",n/a,True
+"Division of Diabetes Translation, Centers for Disease Control and Prevention, Atlanta, Georgia",n/a,True
+"Department of Biostatistics, School of Public Health, University of Washington, Seattle",n/a,True
+"Department of Biostatistics, University of Pittsburgh, Pittsburgh, Pennsylvania7Department of Medicine, School of Medicine, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Department of Critical Care Medicine, The Clinical Research, Investigation, and Systems Modeling of Acute Illness (CRISMA) Center, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Department of Critical Care Medicine, The Clinical Research, Investigation, and Systems Modeling of Acute Illness (CRISMA) Center, University of Pittsburgh, Pittsburgh, Pennsylvania15Veterans Affairs Pittsburgh Healthcare System, Pittsburgh, Pennsylvania",n/a,True
+"Department of Critical Care Medicine, The Clinical Research, Investigation, and Systems Modeling of Acute Illness (CRISMA) Center, University of Pittsburgh, Pittsburgh, Pennsylvania4Department of Biostatistics, University of Pittsburgh, Pittsburgh, Pennsy",n/a,True
+"Department of Epidemiology, University of North Carolina Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill",Department of Epidemiology,False
+"Department of Epidemiology, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Department of Medicine, University of Ottawa, Ottawa Ontario, Canada2Clinical Epidemiology Program, The Ottawa Hospital Research Institute, Ottawa, Ontario, Canada",n/a,True
+"Department of Medicine, Wake Forest University, Winston-Salem, North Carolina",n/a,True
+"Department of Neurology, College of Physicians and Surgeons, Columbia University, New York, New York12Department of Epidemiology, Mailman School of Public Health, Columbia University, New York, New York",n/a,True
+"Division of Cardiology, University of Pennsylvania, Philadelphia6Division of Cardiology, Philadelphia Veterans Affairs Medical Center, Philadelphia, Pennsylvania",n/a,True
+"Channing Division of Network Medicine, Department of Medicine, Brigham and Women’s Hospital, Harvard Medical School, Boston, Massacusetts",n/a,True
+"Department of Epidemiology, Richard M. Fairbanks School of Public Health, Indiana University, Indianapolis2Indiana University Melvin and Bren Simon Cancer Center, Indianapolis",n/a,True
+"Department of Health Sciences Research, Mayo Clinic, Scottsdale, Arizona",n/a,True
+"Department of Medical Biophysics, University of Toronto, Toronto, Ontario, Canada22Ontario Institute for Cancer Research, Toronto, Ontario, Canada",n/a,True
+"Department of Medical Oncology, Dana Farber Cancer Institute, Boston, Massachusetts",n/a,True
+"Department of Preventive Medicine, Keck School of Medicine, University of Southern California, Los Angeles",n/a,True
+"Division of Cancer Epidemiology and Genetics, National Cancer Institute, National Institutes of Health, Bethesda, Maryland",n/a,True
+"Division of Cancer Epidemiology, German Cancer Research Center, Heidelberg, Germany",n/a,True
+"Division of Clinical Epidemiology and Aging Research, German Cancer Research Center (DKFZ), Heidelberg, Germany",n/a,True
+"Division of Clinical Epidemiology and Aging Research, German Cancer Research Center (DKFZ), Heidelberg, Germany11German Cancer Consortium (DKTK), Heidelberg, Germany",n/a,True
+"Division of Epidemiology, Department of Population Health, New York University School of Medicine, New York, New York",n/a,True
+"Division of Gastroenterology and Hepatology, University of North Carolina School of Medicine, Chapel Hill",Division of Gastroenterology and Hepatology,False
+"Division of Research, Kaiser Permanente Medical Care Program of Northern California, Oakland",n/a,True
+"Epidemiology Research Program, American Cancer Society, Atlanta, Georgia",n/a,True
+"Genetic Basis of Human Disease Division, Translational Genomics Research Institute (TGen), Phoenix, Arizona",n/a,True
+"Melbourne School of Population Health, University of Melbourne, Victoria, Australia",n/a,True
+"National Human Genome Research Institute, National Institutes of Health, Bethesda, Maryland",n/a,True
+"Ontario Institute for Cancer Research, Toronto, Ontario, Canada",n/a,True
+"Prevention and Cancer Control, Cancer Care Ontario, Toronto, Ontario, Canada",n/a,True
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, Washington",n/a,True
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, Washington6Huntsman Cancer Institute, University of Utah, Salt Lake City",n/a,True
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, Washington7Department of Epidemiology, University of Washington School of Public Health, Seattle",n/a,True
+"Centre for Epidemiology and Biostatistics, Melbourne School of Population and Global Health, The University of Melbourne, Parkville, Victoria, Australia",n/a,True
+"Centre for Epidemiology and Biostatistics, Melbourne School of Population and Global Health, The University of Melbourne, Parkville, Victoria, Australia20Department of Epidemiology and Institute of Health and Environment, School of Public Health, Seoul Na",n/a,True
+"Centre for Epidemiology and Biostatistics, Melbourne School of Population and Global Health, The University of Melbourne, Parkville, Victoria, Australia2Oncogenomics Group, Genetic Epidemiology Laboratory, Department of Pathology, The University of Melbou",n/a,True
+"Department of Health Science Research, Mayo Clinic Arizona, Scottsdale",n/a,True
+"Department of Medicine, The University of Melbourne7Genetic Medicine, The Royal Melbourne Hospital, Parkville, Victoria, Australia",n/a,True
+"Department of Medicine, University of Colorado School of Medicine, Denver",n/a,True
+"Department of Medicine, University of North Carolina, Chapel Hill",Department of Medicine,False
+"Department of Preventive Medicine, Keck School of Medicine and Norris Comprehensive Cancer Center, University of Southern California, Los Angeles",n/a,True
+"Departments of Haematology and Oncology, The Queen Elizabeth Hospital, Woodville, South Australia, Australia4SAHMRI Colorectal Node, Basil Hetzel Institute for Translational Research, Woodville, South Australia5School of Medicine, University of Adelaide,",n/a,True
+"Division of Oncology, Department of Medicine, Stanford Cancer Institute, Stanford University, Stanford, California",n/a,True
+"Lunenfeld Tanenbaum Research Institute, Mount Sinai Hospital, University of Toronto, Toronto, Ontario, Canada",n/a,True
+"Molecular Genetics Laboratory, Department of Laboratory Medicine and Pathology, Mayo Clinic, Rochester, Minnesota",n/a,True
+"New Zealand Familial Gastrointestinal Cancer Service, Auckland, New Zealand",n/a,True
+"Oncogenomics Group, Genetic Epidemiology Laboratory, Department of Pathology, The University of Melbourne",n/a,True
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, Washington17School of Public Health, University of Washington, Seattle",n/a,True
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, Washington17School of Public Health, University of Washington, Seattle18Centre for Public Health Research, Massey University, Wellington, New Zealand",n/a,True
+"University of Hawaii Cancer Center, Honolulu",n/a,True
+"British Columbia Cancer Research Centre, Vancouver, British Columbia, Canada",n/a,True
+"Cancercare Ontario, Toronto, Ontario, Canada",n/a,True
+"Department of Biostatistics and Epidemiology, University of Pennsylvania, Philadelphia18Now with Moffitt Cancer Center, Tampa, Florida",n/a,True
+"Department of Dermatology, University of North Carolina, Chapel Hill",Department of Dermatology,False
+"Department of Dermatology, University of North Carolina, Chapel Hill2Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill",UNC Lineberger Comprehensive Cancer Center|Department of Dermatology,False
+"Department of Dermatology, University of North Carolina, Chapel Hill4Now with the Department of Dermatology, University of California, Irvine",Department of Dermatology,False
+"Department of Epidemiology and Biostatistics, Memorial Sloan-Kettering Cancer Center, New York, New York",n/a,True
+"Department of Epidemiology, University of California, Irvine",n/a,True
+"Department of Medicine, University of North Carolina, Chapel Hill6Now with the Department of Medicine, University of Virginia, Charlottesville",Department of Medicine,False
+"Department of Pathology and Laboratory Medicine, University of North Carolina, Chapel Hill",Department of Pathology and Laboratory Medicine,False
+"Department of Pathology, Memorial Sloan-Kettering Cancer Center, New York, New York",n/a,True
+"Division of Epidemiology, Departments of Internal Medicine and Dermatology, University of New Mexico, Albuquerque",n/a,True
+"International Agency for Research on Cancer, Lyon, France",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill",UNC Lineberger Comprehensive Cancer Center,False
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill21Department of Surgery, University of North Carolina, Chapel Hill",UNC Lineberger Comprehensive Cancer Center|Department of Surgery,False
+"Menzies Research Institute, Tasmania, Australia",n/a,True
+"Piedmont Cancer Registry, Centre for Epidemiology and Prevention in Oncology in Piedmont, Turin, Italy",n/a,True
+"Sydney School of Public Health, The University of Sydney, Sydney, New South Wales, Australia",n/a,True
+"USC Norris Comprehensive Cancer Center, University of Southern California, Los Angeles",n/a,True
+"Women’s College Hospital, Toronto, Ontario, Canada",n/a,True
+"Department of Otolaryngology and Communication Sciences, Medical College of Wisconsin, Milwaukee",n/a,True
+"Department of Otolaryngology and Communication Sciences, Medical College of Wisconsin, Milwaukee2Biotechnology and Bioengineering Center, Medical College of Wisconsin, Milwaukee",n/a,True
+"Department of Otolaryngology–Head and Neck Surgery, University of North Carolina School of Medicine, Chapel Hill",Department of Otolaryngology/Head and Neck Surgery,False
+"Department of Otolaryngology–Head and Neck Surgery, University of North Carolina, Chapel Hill",Department of Otolaryngology/Head and Neck Surgery,False
+"Division of Otolaryngology–Head and Neck Surgery, Duke University Medical Center, Durham, North Carolina",n/a,True
+"Meridian Plastic Surgeons, Indianapolis, Indiana",n/a,True
+"Cabarrus Family Medicine, Kannapolis, North Carolina",n/a,True
+"Cecil G. Sheps Center for Health Services Research, University of North Carolina, Chapel Hill5Department of Family Medicine, School of Medicine, University of North Carolina, Chapel Hill",Department of Family Medicine|Cecil G. Sheps Center for Health Services Research,False
+"Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill",UNC Center for Health Promotion and Disease Prevention,False
+"Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill11Department of Biostatistics, Gillings School of Global Public Health, University of North Carolina, Chapel Hill",UNC Center for Health Promotion and Disease Prevention|Department of Biostatistics,False
+"Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill5Department of Family Medicine, School of Medicine, University of North Carolina, Chapel Hill6Department of Nutrition, Gillings School of Global Public Health, Un",Department of Family Medicine|Department of Nutrition|UNC Center for Health Promotion and Disease Prevention,False
+"Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill6Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill",UNC Center for Health Promotion and Disease Prevention|Department of Nutrition,False
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina, Chapel Hill",Department of Epidemiology,False
+"Department of Health Policy and Management, Gillings School of Global Public Health, University of North Carolina, Chapel Hill",Department of Health Policy and Management,False
+"Department of Laboratory Medicine and Pathology, University of Minnesota, Minneapolis",n/a,True
+"Division of General Medicine and Clinical Epidemiology, School of Medicine, University of North Carolina, Chapel Hill2Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill",Division of General Medicine and Clinical Epidemiology|UNC Center for Health Promotion and Disease Prevention,False
+"Division of General Medicine and Clinical Epidemiology, School of Medicine, University of North Carolina, Chapel Hill2Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill3Cecil G. Sheps Center for Health Services R",Division of General Medicine and Clinical Epidemiology|UNC Center for Health Promotion and Disease Prevention|Cecil G. Sheps Center for Health Services Research,False
+"Division of General Medicine and Clinical Epidemiology, School of Medicine, University of North Carolina, Chapel Hill3Cecil G. Sheps Center for Health Services Research, University of North Carolina, Chapel Hill",Cecil G. Sheps Center for Health Services Research|Division of General Medicine and Clinical Epidemiology,False
+"Health Services and Systems Research Program, Duke–National University of Singapore Graduate Medical School, Singapore",n/a,True
+"Center for Statistical Science, Brown University School of Medicine, Providence, Rhode Island",n/a,True
+"Dartmouth Institute for Health Policy and Clinical Practice and Norris Cotton Cancer Center, Geisel School of Medicine at Dartmouth, Lebanon, New Hampshire",n/a,True
+"Department of Radiology, Medical University of South Carolina, Charleston",n/a,True
+"Department of Radiology, University of California at Davis",n/a,True
+"Department of Radiology, University of North Carolina at Chapel Hill",Department of Radiology,False
+"Departments of Population Sciences and Industrial and Systems Engineering, University of Wisconsin at Madison",n/a,True
+"Department of Community and Family Medicine, Norris Cotton Cancer Center, Dartmouth Medical School, Hanover, New Hampshire",n/a,True
+"Department of Family Medicine, University of Vermont, Burlington9Department of Radiology, University of Vermont, Burlington",n/a,True
+"Department of Medicine, University of California, San Francisco",n/a,True
+"Department of Radiology, University of North Carolina, Chapel Hill",Department of Radiology,False
+"Department of Radiology, University of Washington, Seattle Cancer Care Alliance, Seattle",n/a,True
+"General Internal Medicine Section, Department of Veterans Affairs, San Francisco, California5Department of Medicine, University of California, San Francisco6Department of Epidemiology and Biostatistics, University of California, San Francisco",n/a,True
+"Group Health Research Institute, Seattle, Washington",n/a,True
+"Department of Economics, University of North Carolina, Chapel Hill3Carolina Population Center, University of North Carolina, Chapel Hill",Carolina Population Center|Department of Economics,False
+"Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill",Department of Nutrition,False
+"Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill3Carolina Population Center, University of North Carolina, Chapel Hill",Department of Nutrition|Carolina Population Center,False
+"Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill4Department of Human Nutrition, Foods, and Exercise, Virginia Polytechnic Institute and State University, Blacksburg",n/a,True
+"Department of Quantitative Health Sciences, University of Massachusetts Medical School, Worcester",n/a,True
+"Division of Epidemiology and Community Health, University of Minnesota, Minneapolis",n/a,True
+"Division of Preventive Medicine, University of Alabama at Birmingham, Birmingham",n/a,True
+"Department of Medicine and Public Health Sciences, Wake Forest University School of Medicine, Winston-Salem, North Carolina",n/a,True
+"Department of Medicine, University of Mississippi Medical Center, Jackson",n/a,True
+"Departments of Medicine and Epidemiology, Johns Hopkins University, Baltimore, Maryland",n/a,True
+"Departments of Medicine and Epidemiology, University of North Carolina at Chapel Hill",Department of Medicine|Department of Epidemiology,False
+"Division of General Medical Disciplines, Department of Medicine, Stanford University School of Medicine, Palo Alto, California",n/a,True
+"Division of Nephrology, Department of Medicine, Stanford University School of Medicine, Palo Alto, California2Department for Health Research and Policy, Stanford University School of Medicine, Palo Alto, California",n/a,True
+"Department of Epidemiology, Boston University School of Public Health, Lexington, Massachusetts",n/a,True
+"Department of Epidemiology, The University of North Carolina at Chapel Hill",Department of Epidemiology,False
+"Department of Medicine, The University of North Carolina at Chapel Hill",Department of Medicine,False
+"Department of Pharmaceutical Sciences, Basel University, Basel, Switzerland",n/a,True
+"Diabetes Unit, Massachusetts General Hospital, Boston3Harvard Medical School, Boston, Massachusetts",n/a,True
+"Division of General Internal Medicine, Massachusetts General Hospital, Boston2Diabetes Unit, Massachusetts General Hospital, Boston3Harvard Medical School, Boston, Massachusetts",n/a,True
+"Division of General Internal Medicine, Massachusetts General Hospital, Boston3Harvard Medical School, Boston, Massachusetts",n/a,True
+"Division of General Internal Medicine, University of California, San Francisco6Center for Vulnerable Populations, San Francisco General Hospital and Trauma Center, San Francisco, California",n/a,True
+"Division of General Medicine and Clinical Epidemiology, University of North Carolina School of Medicine, Chapel Hill",Division of General Medicine and Clinical Epidemiology,False
+"currently an undergraduate in the Community Health Program, Tufts University, Medford, Massachusetts",n/a,True
+"currently an undergraduate in the Community Health Program, Tufts University, Medford, Massachusetts8currently an undergraduate in the Biology Program, Tufts University, Medford, Massachusetts",n/a,True
+"Center for Learning Health Care, Duke Clinical Research Institute, Duke University School of Medicine, Durham, North Carolina",n/a,True
+"Department of Biostatistics and Bioinformatics, Duke University Medical Center, Durham, North Carolina",n/a,True
+"Department of Biostatistics and Informatics, Colorado School of Public Health, Denver",n/a,True
+"Department of Health Sciences Research, Mayo Clinic, Rochester, Minnesota",n/a,True
+"Department of Hospice and Palliative Medicine, OhioHealth, Columbus",n/a,True
+"Department of Medicine, Feinberg School of Medicine, Northwestern University, Chicago, Illinois",n/a,True
+"Department of Medicine, Mayo Clinic, Rochester, Minnesota",n/a,True
+"Department of Medicine, Phoenix Veterans Affairs Health Care System, Phoenix, Arizona",n/a,True
+"Department of Medicine, University of Colorado School of Medicine, Aurora",n/a,True
+"Department of Medicine, Washington University in St Louis, St Louis, Missouri",n/a,True
+"Department of Nursing Research, City of Hope Medical Center, City of Hope, California",n/a,True
+"Discipline, Palliative, and Supportive Services, Flinders University, Adelaide, Australia",n/a,True
+"Division of Geriatric Medicine, University of North Carolina, Chapel Hill",Division of Geriatric Medicine,False
+"Division of Hematology/Oncology, Department of Medicine, University of Wisconsin School of Medicine and Public Health, Madison",n/a,True
+"Four Seasons Compassion for Life, Flat Rock, North Carolina",n/a,True
+"Frances Payne Bolton School of Nursing, Case Western Reserve University, Cleveland, Ohio",n/a,True
+"Hospice Analytics, Denver, Colorado",n/a,True
+"Metropolitan Jewish Health System, Hospice and Palliative Care, New York, New York",n/a,True
+"National Institute of Nursing Research, National Institutes of Health, Bethesda, Maryland",n/a,True
+"San Francisco Veterans Affairs Medical Center, Center for Research on Aging, Jewish Home of San Francisco, San Francisco, California5Division of Geriatrics, Department of Medicine, University of California, San Francisco",n/a,True
+"Sanford School of Public Policy, Duke University, Durham, North Carolina",n/a,True
+"The Denver Hospice, Denver, Colorado",n/a,True
+"Veterans Affairs Geriatric Research, Education, and Clinical Center, Birmingham Veterans Affairs Medical Center, Birmingham, Alabama17Division of Gerontology, Geriatrics, and Palliative Care, University of Alabama at Birmingham",n/a,True
+"Department of Biostatistics, Johns Hopkins Bloomberg School of Public Health, Baltimore, Maryland",n/a,True
+"Department of Biostatistics, University of North Carolina at Chapel Hill",Department of Biostatistics,False
+"Department of Neurology, Johns Hopkins University School of Medicine, Baltimore, Maryland",n/a,True
+"Department of Neurology, Johns Hopkins University School of Medicine, Baltimore, Maryland2Department of Epidemiology, Johns Hopkins Bloomberg School of Public Health, Baltimore, Maryland",n/a,True
+"Department of Neurology, Mayo Clinic, Rochester, Minnesota",n/a,True
+"Division of Public Health Sciences, Wake Forest School of Medicine, Winston-Salem, North Carolina",n/a,True
+"Computational Biology Core, Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Porter Neuroscience Research Center, Bethesda, Maryland",n/a,True
+"Department of Neurology, Johns Hopkins School of Medicine, Baltimore, Maryland",n/a,True
+"Department of Neurology, Ohio State University Medical Center, Columbus",n/a,True
+"Department of Neurology, University of Illinois College of Medicine, Chicago",n/a,True
+"Department of Neurology, University of Kansas Medical Center, Kansas City",n/a,True
+"Department of Neurology, University of Miami, Miami, Florida",n/a,True
+"Department of Neuroscience, Cisanello Hospital, University of Pisa, Pisa, Italy",n/a,True
+"Genomics Technology Group, Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Porter Neuroscience Research Center, Bethesda, Maryland",n/a,True
+"Institute of General Pathology, Catholic University, Rome, Italy",n/a,True
+"Institute of Neurology, Catholic University, Rome, Italy",n/a,True
+"Molecular Genetics Section, Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Porter Neuroscience Research Center, Bethesda, Maryland",n/a,True
+"Molecular Genetics Unit, Department of Clinical Pathology, ASO OIRM-S Anna, Turin, Italy",n/a,True
+"Neuromuscular Diseases Research Unit, Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Porter Neuroscience Research Center, Bethesda, Maryland",n/a,True
+"Neuromuscular Diseases Research Unit, Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Porter Neuroscience Research Center, Bethesda, Maryland6Institute of Medical Genetics, Catholic University, Rome, Italy",n/a,True
+"Neuromuscular Diseases Research Unit, Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Porter Neuroscience Research Center, Bethesda, Maryland9Rita Levi Montalcini Department of Neuroscience, University of Turin, Tu",n/a,True
+"Rita Levi Montalcini Department of Neuroscience, University of Turin, Turin, Italy",n/a,True
+"Department of Biostatistics, Boston University School of Public Health, Boston, Massachusetts",n/a,True
+"Department of Biostatistics, University of Washington, Seattle",n/a,True
+"Department of Genetics, University of North Carolina, Chapel Hill",Department of Genetics,False
+"Department of Internal Medicine, The Ohio State University, Columbus",n/a,True
+"Department of Medicine, University of Washington, Seattle",n/a,True
+"Department of Neurology, Boston University School of Medicine, Boston, Massachusetts",n/a,True
+"Department of Neurology, George Washington University Hospital, Washington, DC",n/a,True
+"Department of Neurology, Mayo Clinic, Jacksonville, Florida",n/a,True
+"Department of Neurology, University of Minnesota, Minneapolis",n/a,True
+"Department of Neurology, University of Virginia, Charlottesville",n/a,True
+"Department of Neurology, University of Washington, Seattle",n/a,True
+"Department of Neuroscience, Reta Lila Weston Institute, University College London, London, England",n/a,True
+"Division of Public Health Sciences, Fred Hutchinson Cancer Research Center, Seattle, Washington",n/a,True
+"Institute for Molecular Medicine, University of Texas Health Science Center, Houston",n/a,True
+"Joseph J. Zilber School of Public Health, University of Wisconsin, Milwaukee2Division of Public Health Sciences, Fred Hutchinson Cancer Research Center, Seattle, Washington",n/a,True
+"Laboratory of Neurogenetics, National Institute on Aging, National Institutes of Health, Bethesda, Maryland",n/a,True
+"British Columbia Cancer Agency, Vancouver, British Columbia, Canada",n/a,True
+"Cancer Care Ontario, Toronto, Ontario, Canada",n/a,True
+"Department of Cancer Epidemiology, H. Lee Moffitt Cancer Center & Research Institute, Tampa, Florida",n/a,True
+"Department of Epidemiology and Biostatistics, Memorial Sloan Kettering Cancer Center, New York, New York",n/a,True
+"Department of Epidemiology, School of Medicine, University of California, Irvine, California",n/a,True
+"Department of Pathology, Memorial Sloan Kettering Cancer Center, New York, New York",n/a,True
+"Department of Surgery, University of North Carolina, Chapel Hill",Department of Surgery,False
+"Division of Epidemiology, Department of Medicine, University of New Mexico, Albuquerque",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill12Department of Surgery, University of North Carolina, Chapel Hill",UNC Lineberger Comprehensive Cancer Center|Department of Surgery,False
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill18Department of Epidemiology, University of North Carolina, Chapel Hill",UNC Lineberger Comprehensive Cancer Center|Department of Epidemiology,False
+"The George Institute for Global Health, Oxford Martin School, Oxford, England17Nuffield Department of Population Health, Oxford University, Oxford, England",n/a,True
+"Cancer Control Science Department, American Cancer Society, Atlanta, Georgia",n/a,True
+"Department of Biomedical Data Science, Geisel School of Medicine at Dartmouth, Lebanon, New Hampshire8Department of Epidemiology, Geisel School of Medicine at Dartmouth, Lebanon, New Hampshire",n/a,True
+"Department of Radiology, The University of North Carolina, Chapel Hill",Department of Radiology,False
+"Department of Surgery, Office of Health Promotion Research, University of Vermont College of Medicine, Burlington6University of Vermont Cancer Center, University of Vermont College of Medicine, Burlington",n/a,True
+"Departments of Medicine and Epidemiology and Biostatistics, University of California–San Francisco, San Francisco,4General Internal Medicine Section, Department of Veterans Affairs, University of California–San Francisco, San Francisco",n/a,True
+"Division of Biostatistics, Department of Public Health Sciences, University of California Davis School of Medicine, Davis2Group Health Research Institute, Group Health Cooperative, Seattle, Washington",n/a,True
+"Group Health Research Institute, Group Health Cooperative, Seattle, Washington",n/a,True
+"Department of Epidemiology and Environmental Health, University at Buffalo, Buffalo, New York",n/a,True
+"Department of Medicine, Brigham and Women’s Hospital, Harvard Medical School, Boston, Massachusetts",n/a,True
+"Department of Medicine, George Washington University School of Medicine, Washington, DC",n/a,True
+"Department of Obstetrics and Gynecology, University of North Carolina, Chapel Hill",Department of Obstetrics and Gynecology,False
+"Division of Health Promotion Sciences, University of Arizona, Tucson/Phoenix",n/a,True
+"Division of Public Health Sciences, Cancer Prevention Program, Fred Hutchinson Cancer Research Center, Seattle, Washington",n/a,True
+"Division of Reproductive Endocrinology and Fertility, University of Texas Health Science Center, San Antonio",n/a,True
+"Division of Research, Kaiser Permanente, Oakland, California",n/a,True
+"Los Angeles Biomedical Research Institute at Harbor-UCLA, David Geffen School of Medicine, University of California, Los Angeles",n/a,True
+"Center for Cancer Prevention and Treatment, St. Joseph Hospital of Orange, Orange, California",n/a,True
+"Department of Clinical Research, Cancer Program of Our Lady of the Lake and Mary Bird Perkins, Baton Rouge, Louisiana",n/a,True
+"Department of Medicine, Duke University Medical Center, Durham, North Carolina",n/a,True
+"Department of Psychiatry and Behavioral Sciences, Memorial Sloan Kettering Cancer Center, New York, New York",n/a,True
+"Department of Symptom Research, University of Texas MD Anderson Cancer Center, Houston",n/a,True
+"Division of Cancer Control and Population Sciences, National Cancer Institute, Rockville, Maryland",n/a,True
+"Division of Cancer Prevention, National Cancer Institute, Rockville, Maryland",n/a,True
+"Division of Cancer Treatment and Diagnosis, National Cancer Institute, Rockville, Maryland",n/a,True
+"Division of Population Sciences, Dana-Farber Cancer Institute, Boston, Massachusetts",n/a,True
+"Gibbs Cancer Center and Research Institute, Spartanburg, South Carolina",n/a,True
+"Helen F. Graham Cancer Center and Research Institute, Christiana Care Health System, Newark, Delaware",n/a,True
+"Helen and Harry Gray Cancer Center, Hartford Hospital, Hartford, Connecticut",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill5Department of Epidemiology and Biostatistics, Memorial Sloan Kettering Cancer Center, New York, New York",n/a,True
+"Nell Hodgson Woodruff School of Nursing, Emory University, Atlanta, Georgia",n/a,True
+"patient advocate and cancer survivor, Brooklyn, New York",n/a,True
+"Department of Ophthalmology, University of North Carolina at Chapel Hill School of Medicine",Department of Ophthalmology,False
+"Collaborative Studies Coordinating Center, Department of Biostatistics, University of North Carolina Gillings School of Global Public Health, Chapel Hill",Department of Biostatistics,False
+"College of Health and Human Services, San Diego State University, San Diego, California10School of Speech, Language, and Hearing Sciences, San Diego State University, San Diego, California",n/a,True
+"Department of Ophthalmology and Visual Sciences, University of Wisconsin School of Medicine and Public Health, Madison",n/a,True
+"Department of Ophthalmology and Visual Sciences, University of Wisconsin School of Medicine and Public Health, Madison2Department of Population Health Sciences, University of Wisconsin School of Medicine and Public Health, Madison",n/a,True
+"Department of Otorhinolaryngology–Head and Neck Surgery, Montefiore Medical Center, University Hospital for Albert Einstein College of Medicine, Bronx, New York",n/a,True
+"Department of Public Health Sciences, University of Miami Miller School of Medicine, Miami, Florida",n/a,True
+"Epidemiology and Statistics Program, National Institute on Deafness and Other Communication Disorders, National Institutes of Health, Bethesda, Maryland",n/a,True
+"Mailman Center for Child Development, Department of Pediatrics, University of Miami Miller School of Medicine, Miami, Florida",n/a,True
+"Roxelyn and Richard Pepper Department of Communication Sciences and Disorders, Northwestern University, Evanston, Illinois",n/a,True
+"School of Speech, Language, and Hearing Sciences, San Diego State University, San Diego, California",n/a,True
+"Department of Pediatrics, University of North Carolina at Chapel Hill, Chapel Hill",Department of Pediatrics,False
+"Duke Clinical Research Institute and Duke University Medical Center, Durham, North Carolina",n/a,True
+"Food and Drug Administration, Rockville, Maryland",n/a,True
+"Pediatrix Center for Research and Education, Sunrise, Florida",n/a,True
+"Department of Clinical Pharmacology and Therapeutics, Children’s Hospital of Philadelphia, Philadelphia, Pennsylvania",n/a,True
+"Department of Pediatrics, Duke University, Durham, North Carolina2Duke Clinical Research Institute, Duke University, Durham, North Carolina",n/a,True
+"Department of Pediatrics, Duke University, Durham, North Carolina2Duke Clinical Research Institute, Duke University, Durham, North Carolina3Academic Medical Center, Department of Public Health, Amsterdam, the Netherlands",n/a,True
+"Department of Pediatrics, Duke University, Durham, North Carolina2Duke Clinical Research Institute, Duke University, Durham, North Carolina4Division of Pharmacotherapy and Experimental Therapeutics, University of North Carolina Eshelman School of Pharmacy",n/a,True
+"Eunice Kennedy Shriver National Institute of Child Health and Human Development, Bethesda, Maryland",n/a,True
+"Center for Child and Family Health, Durham, North Carolina",n/a,True
+"Center for Child and Family Health, Durham, North Carolina8Department of Psychiatry and Behavioral Sciences, Duke University School of Medicine, Durham, North Carolina",n/a,True
+"Child and Family Research Institute, University of British Columbia, Vancouver, British Columbia, Canada11Canadian Institute for Advanced Research, Toronto, Ontario, Canada",n/a,True
+"Department of Family Medicine, University of North Carolina at Chapel Hill2Injury Prevention Research Center, University of North Carolina at Chapel Hill",Injury Prevention Research Center|Department of Family Medicine,False
+"Department of Pediatrics, Kempe Center, University of Colorado, Aurora",n/a,True
+"Department of Public Policy, University of North Carolina at Chapel Hill",Department of Public Policy,False
+"Division of Violence Prevention, Centers for Disease Control and Prevention, Atlanta, Georgia",n/a,True
+"Injury Prevention Research Center, University of North Carolina at Chapel Hill",Injury Prevention Research Center,False
+"Injury Prevention Research Center, University of North Carolina at Chapel Hill4Department of Maternal and Child Health, University of North Carolina at Chapel Hill",Injury Prevention Research Center|Department of Maternal and Child Health,False
+"National Center on Shaken Baby Syndrome, Farmington, Utah",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill2Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill",UNC Center for Health Promotion and Disease Prevention|UNC Lineberger Comprehensive Cancer Center,False
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill3Department of Health Behavior, Gillings School of Global Public Health, University of North Carolina, Chapel Hill",UNC Lineberger Comprehensive Cancer Center|Department of Health Behavior,False
+"Department of Economics, Clemson University, Clemson, South Carolina",n/a,True
+"Division of Neonatal-Perinatal Medicine, The University of North Carolina at Chapel Hill",Department of Pediatrics,False
+"Division of Neonatology, Children’s Hospital of Philadelphia, Philadelphia, Pennsylvania",n/a,True
+"Division of Pediatric Infectious Diseases, Duke University School of Medicine, Durham, North Carolina",n/a,True
+"Duke Clinical Research Institute, Duke University School of Medicine, Durham, North Carolina2Division of Pediatric Infectious Diseases, Duke University School of Medicine, Durham, North Carolina",n/a,True
+"University of Southern California, Los Angeles",n/a,True
+"Washington University in St. Louis, Missouri",n/a,True
+"Center for Biomarker Research and Personalized Medicine, Virginia Commonwealth University, Richmond",n/a,True
+"Department of Biostatistics, Virginia Commonwealth University, Richmond",n/a,True
+"Department of Medical Epidemiology and Biostatistics, Karolinska Institutet, Stockholm, Sweden",n/a,True
+"Department of Medical Epidemiology and Biostatistics, Karolinska Institutet, Stockholm, Sweden4Departments of Genetics and Psychiatry, University of North Carolina at Chapel Hill",n/a,True
+"Department of Child Psychiatry, School of Medicine, New York University, New York",n/a,True
+"Department of Psychiatry and Behavioral Neuroscience, Wayne State University, Detroit, Michigan",n/a,True
+"Department of Psychiatry, The Ohio State University, Columbus",n/a,True
+"Department of Psychiatry, Western Psychiatric Institute and Clinic, University of Pittsburgh Medical Center, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Department of Psychiatry, Western Psychiatric Institute and Clinic, University of Pittsburgh Medical Center, University of Pittsburgh, Pittsburgh, Pennsylvania10Department of Psychological Medicine, Cardiff University, Cardiff, United Kingdom",n/a,True
+"Department of Psychology, University of North Carolina, Chapel Hill",Department of Psychology and Neuroscience,False
+"Division of Child and Adolescent Psychiatry, University Hospitals Case Medical Center/Case Western Reserve University, Cleveland, Ohio",n/a,True
+"Division of Child and Adolescent Psychiatry, University Hospitals Case Medical Center/Case Western Reserve University, Cleveland, Ohio9Department of Psychiatry, Johns Hopkins University, Baltimore, Maryland",n/a,True
+"Division of Pediatric Radiology, Cincinnati Children’s Hospital Medical Center, University of Cincinnati, Cincinnati, Ohio",n/a,True
+"Research Institute, Nationwide Children’s Hospital, Columbus, Ohio",n/a,True
+"Center for Developmental Science, University of North Carolina at Chapel Hill2Department of Psychology & Neuroscience, Duke University, Durham, North Carolina3Institute for Genome Sciences & Policy, Duke University, Durham, North Carolina4Department of Ps",n/a,True
+"Department of Preventive and Social Medicine, University of Otago, Dunedin, New Zealand",n/a,True
+"Department of Psychology & Neuroscience, Duke University, Durham, North Carolina3Institute for Genome Sciences & Policy, Duke University, Durham, North Carolina4Department of Psychiatry & Behavioral Sciences, Duke University Medical Center, Durham, North",n/a,True
+"Dunedin Multidisciplinary Health and Development Research Unit, Department of Preventive and Social Medicine, University of Otago, Dunedin, New Zealand",n/a,True
+"Behavioral Neurogenetics Center, The Edmond and Lily Safra Children’s Hospital, Sheba Medical Center, Tel Hashomer, Israel19Sackler Faculty of Medicine, Tel Aviv University, Tel Aviv, Israel",n/a,True
+"Center for Human Genetics, KU Leuven, Leuven, Belgium",n/a,True
+"Child Neuropsychiatry Unit, Department of Neuroscience, Bambino Gesù Children’s Hospital, Rome, Italy",n/a,True
+"Clinical Genetics Research Program, Centre for Addiction and Mental Health, Toronto, Ontario, Canada10Department of Psychiatry, University of Toronto, Toronto, Ontario, Canada",n/a,True
+"Clinical Genetics Research Program, Centre for Addiction and Mental Health, Toronto, Ontario, Canada10Department of Psychiatry, University of Toronto, Toronto, Ontario, Canada11Dalglish Family Hearts and Minds Clinic for Adults With 22q11.2 Deletion Syndr",n/a,True
+"Clinical Genetics Research Program, Centre for Addiction and Mental Health, Toronto, Ontario, Canada14Institute of Medical Science, University of Toronto, Toronto, Ontario, Canada",n/a,True
+"Department of Pediatric Psychology, Wilhelmina Children’s Hospital, University Medical Center, Utrecht, the Netherlands",n/a,True
+"Department of Pediatrics, Duke University Medical Center, Durham, North Carolina",n/a,True
+"Department of Psychiatry and Behavioral Sciences, Upstate Medical University, State University of New York, Syracuse",n/a,True
+"Department of Psychiatry and Behavioral Sciences, Upstate Medical University, State University of New York, Syracuse24Department of Psychology, Syracuse University, Syracuse, New York",n/a,True
+"Department of Psychiatry and Biobehavioral Sciences, Semel Institute for Neuroscience and Human Behavior, University of California, Los Angeles4Department of Psychology, University of California, Los Angeles",n/a,True
+"Department of Psychiatry and Psychology, Maastricht University, Maastricht, the Netherlands",n/a,True
+"Department of Psychiatry, Brain Center Rudolf Magnus, University Medical Center Utrecht, Utrecht, the Netherlands",n/a,True
+"Department of Psychiatry, Perelman School of Medicine, University of Pennsylvania, Philadelphia",n/a,True
+"Department of Psychiatry, University of North Carolina School of Medicine, Chapel Hill8Department of Allied Health Sciences, University of North Carolina School of Medicine, Chapel Hill",Department of Psychiatry|Department of Allied Health Sciences,False
+"Division of Human Genetics, The Children’s Hospital of Philadelphia, Philadelphia, Pennsylvania",n/a,True
+"Emory Autism Center, Department of Psychiatry and Behavioral Sciences, Emory University School of Medicine, Atlanta, Georgia",n/a,True
+"MIND (Medical Investigation of Neurodevelopmental Disorders) Institute and Department of Psychiatry and Behavioral Sciences, University of California, Davis",n/a,True
+"Office Médico-Pédagogique Research Unit, Department of Psychiatry, University of Geneva School of Medicine, Geneva, Switzerland",n/a,True
+"Sackler Faculty of Medicine, Tel Aviv University, Tel Aviv, Israel20Felsenstein Medical Research Center, Petah Tikva, Israel21Geha Mental Health Center, Petah Tikva, Israel",n/a,True
+"Center for Developmental Epidemiology, Department of Psychiatry and Behavioral Sciences, Duke University Medical Center, Durham, North Carolina",n/a,True
+"Department of Psychology and Division of Mental Health and Wellbeing, University of Warwick, Coventry, Warwickshire, England",n/a,True
+"Department of Psychology, University of North Carolina, Chapel Hill, North Carolina",Department of Psychology and Neuroscience,False
+"Center for Neural Science, New York University, New York",n/a,True
+"Department of Diagnostic Radiology and Magnetic Resonance Research Center, Yale University, New Haven, Connecticut",n/a,True
+"Department of Psychiatry and Human Behavior, University of California, Irvine",n/a,True
+"Department of Psychiatry, Beth Israel Deaconess Medical Center, Boston, Massachusetts15Massachusetts General Hospital, Boston16Department of Psychiatry, Harvard Medical School, and Massachusetts Mental Health Center Public Psychiatry Division, Beth Israel",n/a,True
+"Department of Psychiatry, University of Calgary, Calgary, Alberta, Canada",n/a,True
+"Department of Psychiatry, University of California, San Diego, La Jolla",n/a,True
+"Department of Psychiatry, University of California, San Francisco",n/a,True
+"Department of Psychiatry, University of North Carolina, Chapel Hill",Department of Psychiatry,False
+"Department of Psychiatry, Yale University School of Medicine, New Haven, Connecticut",n/a,True
+"Department of Psychiatry, Yale University School of Medicine, New Haven, Connecticut2National Institute of Alcohol Abuse and Alcoholism Center for the Translational Neuroscience of Alcoholism, New Haven, Connecticut3Abraham Ribicoff Research Facilities, C",n/a,True
+"Department of Psychiatry, Yale University School of Medicine, New Haven, Connecticut3Abraham Ribicoff Research Facilities, Connecticut Mental Health Center, New Haven5Interdepartmental Neuroscience Program, Yale University, New Haven, Connecticut",n/a,True
+"Department of Psychiatry, Yale University School of Medicine, New Haven, Connecticut4Department of Psychology, Yale University, New Haven, Connecticut",n/a,True
+"Department of Psychiatry, Zucker Hillside Hospital, Glen Oaks, New York",n/a,True
+"Department of Psychology, University of Ljubljana, Ljubljana, Slovenia",n/a,True
+"Department of Psychology, Yale University, New Haven, Connecticut",n/a,True
+"Departments of Psychiatry and Biobehavioral Sciences and Psychology, University of California, Los Angeles",n/a,True
+"Departments of Psychology and Radiology, Emory University, Atlanta, Georgia",n/a,True
+"Department of Child and Adolescent Psychiatry, School of Medicine, New York University, New York",n/a,True
+"Department of Psychiatry, Cincinnati Children’s Hospital Medical Center, University of Cincinnati, Cincinnati, Ohio",n/a,True
+"Department of Psychiatry, University Hospitals Case Medical Center, Case Western Reserve University, Cleveland, Ohio",n/a,True
+"Department of Psychiatry, University Hospitals Case Medical Center, Case Western Reserve University, Cleveland, Ohio12Department of Psychiatry, The Johns Hopkins University, Baltimore, Maryland",n/a,True
+"Department of Psychology, University of North Carolina at Chapel Hill",Department of Psychology and Neuroscience,False
+"Image Sciences Institute, University Medical Center Utrecht, Utrecht, the Netherlands",n/a,True
+"Medical Science Training Program, School of Medicine, University of Pittsburgh, Pittsburgh, Pennsylvania",n/a,True
+"Pediatric Institute, Cleveland Clinic, Cleveland, Ohio",n/a,True
+"Research Institute at Nationwide Children’s Hospital, Columbus, Ohio",n/a,True
+Department of Sociology; University of Missouri-Kansas City,n/a,True
+Department of Sociology; University of North Carolina,Department of Sociology,False
+School of Public Health; University of Alabama at Birmingham,n/a,True
+"University of North Carolina, Chapel Hill, ",University of North Carolina at Chapel Hill,False
+University of North Carolina at Chapel Hill School of Nursing & Department of Biostatistics; Chapel Hill; North Carolina; USA,Department of Biostatistics|School of Nursing,False
+University of North Carolina at Chapel Hill School of Nursing; Chapel Hill; North Carolina; USA,School of Nursing,False
+"Institute for Health &amp; Aging, University of California, San Francisco, San Francisco, CA, USA",n/a,True
+"Perelman School of Medicine at the University of Pennsylvania, Philadelphia, PA, USA",n/a,True
+"University of North Carolina Gillings School of Global Public Health, Chapel Hill, NC, USA",Gillings School of Global Public Health,False
+"Vietnam Era Twin Registry, Seattle VA and the University of Washington School of Public Health, Seattle, WA, USA",n/a,True
+"Centerrfor Excellence in Post-Harvest Technologies, North Carolina Agricultural and Technical State University, North Carolina Research Campus, 500 Laureate Way, Kannapolis, North Carolina 28081, United States",n/a,True
+"Department of Environmental and Occupational Health, School of Public Health, Emory University, Atlanta, GA, USA",n/a,True
+"Department of Epidemiology, School of Medicine, University of California-Irvine, Irvine, CA, USA",n/a,True
+"Department of Neurology, School of Medicine, Emory University, Atlanta, GA, USA",n/a,True
+"School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",School of Medicine,False
+"Biomedical Research Imaging Center, University of North Carolina, Chapel Hill, NC, USA",Biomedical Research Imaging Center,False
+"Department of Radiology, University of Pennsylvania, Philadelphia, Pennsylvania, USA",n/a,True
+"Department of Statistics, University of North Carolina, Chapel Hill, NC, USA",Department of Statistics and Operations Research,False
+"Departments of Psychiatry and Duke Institute for Brain Sciences, Duke University, Durham, NC, USA",n/a,True
+"School of Computing, Informatics and Decision Systems Engineering, Arizona State University, Tempe, AZ, USA",n/a,True
+Cecil G. Sheps Center for Health Services Research; University of North Carolina; Chapel Hill; North Carolina,Cecil G. Sheps Center for Health Services Research,False
+Division of Geriatrics; Department of Family Medicine; Brody School of Medicine; East Carolina University; Greenville; North Carolina,n/a,True
+Division of Women's Primary Healthcare; Department of Obstetrics and Gynecology; University of North Carolina; Chapel Hill; North Carolina,Department of Obstetrics and Gynecology,False
+Hebrew SeniorLife Institute for Aging Research; Boston; Massachusetts,n/a,True
+School of Nursing; University of Pennsylvania; Philadelphia; Pennsylvania,n/a,True
+Epidemiology and Public Health,n/a,True
+Orthopedics; School of Medicine; University of Maryland; Baltimore; Maryland,n/a,True
+School of Nursing; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,School of Nursing,False
+University of Pennsylvania School of Medicine; Department of Medicine; Philadelphia; Pennsylvania,n/a,True
+Department of Epidemiology; Bloomberg School of Public Health; Johns Hopkins University; Baltimore; Maryland,n/a,True
+Department of Epidemiology; Gillings School of Global Public Health; University of North Carolina; Chapel Hill; North Carolina,Department of Epidemiology,False
+Department of Medicine; University of Mississippi Medical Center; Jackson; Mississippi,n/a,True
+Department of Neurology; School of Medicine; Johns Hopkins University; Baltimore; Maryland,n/a,True
+Division of Epidemiology and Community Health; School of Public Health; University of Minnesota; Minneapolis; Minnesota,n/a,True
+Department of Health Policy and Management; University of North Carolina; Chapel Hill; North Carolina,Department of Health Policy and Management,False
+Department of Emergency Medicine; University of North Carolina; Chapel Hill; North Carolina,Department of Emergency Medicine,False
+Department of Family Medicine; University of North Carolina; Chapel Hill; North Carolina,Department of Family Medicine,False
+Department of Health Management and Informatics; University of Central Florida; Orlando; Florida,n/a,True
+"Mathematica Policy Research, Inc.; Washington; District of Columbia",n/a,True
+Cecil G. Sheps Center for Health Services Research; University of North Carolina; Chapel Hill North Carolina,Cecil G. Sheps Center for Health Services Research,False
+Center for Health Equity Research and Promotion; Philadelphia Veterans Affairs Medical Center; Philadelphia Pennsylvania,n/a,True
+Department of Biostatistics; School of Public Health; University of North Carolina; Chapel Hill North Carolina,Department of Biostatistics,False
+Division of Geriatric Medicine; University of North Carolina; Chapel Hill North Carolina,Division of Geriatric Medicine,False
+Department of Anesthesiology; University of North Carolina; Chapel Hill; North Carolina,Department of Anesthesiology,False
+Department of Biostatistics; University of North Carolina; Chapel Hill; North Carolina,Department of Biostatistics,False
+Department of Social Medicine; University of North Carolina; Chapel Hill; North Carolina,Department of Social Medicine,False
+School of Medicine; University of North Carolina; Chapel Hill; North Carolina,School of Medicine,False
+Department of Epidemiology; Harvard School of Public Health; Boston; Massachusetts,n/a,True
+Department of Social and Behavioral Sciences; Harvard School of Public Health; Boston; Massachusetts,n/a,True
+"Department of Emergency Medicine; University of California at San Francisco-Fresno, and University Medical Center; Fresno California",n/a,True
+Department of Emergency Medicine; University of North Carolina Chapel Hill; Chapel Hill North Carolina,Department of Emergency Medicine,False
+Division of Geriatrics; Department of Medicine; University of North Carolina Chapel Hill; Chapel Hill North Carolina,School of Medicine,False
+Cecil G. Sheps Center for Health Services Research; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Cecil G. Sheps Center for Health Services Research,False
+Center for Health Services Research in Primary Care; Durham Veterans Affairs Medical Center; Durham North Carolina,n/a,True
+Department of Basic and Social Sciences; Albany College of Pharmacy and Health Sciences; Albany New York,n/a,True
+Department of Behavioral and Social Sciences; University of the Sciences; Philadelphia Pennsylvania,n/a,True
+Department of Medicine; Duke University; Durham North Carolina,n/a,True
+Dartmouth Institute; Geisel School of Medicine; Dartmouth University; Lebanon New Hampshire,n/a,True
+Department of Health Care Policy; Harvard Medical School; Boston Massachusetts,n/a,True
+Department of Health Policy; School of Medicine; Vanderbilt University; Nashville Tennessee,n/a,True
+Division of General Medicine and Clinical Epidemiology; School of Medicine; Chapel Hill North Carolina,Division of General Medicine and Clinical Epidemiology,False
+Hebrew SeniorLife; Institute for Aging Research; Boston Massachusetts,n/a,True
+"Omnicare, Inc.; Livonia Michigan",n/a,True
+Center for Gerontology and Health Care Research; School of Public Health; Brown University; Providence Rhode Island,n/a,True
+Department of Family Medicine; University of North Carolina; Chapel Hill North Carolina,Department of Family Medicine,False
+"Department of Health Services, Policy and Practice; School of Public Health; Brown University; Providence Rhode Island",n/a,True
+Center for Aging Studies; University of Maryland; Baltimore County Baltimore Maryland,n/a,True
+Department of Sociology; University of Maryland; Baltimore County Baltimore Maryland,n/a,True
+School of Nursing; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,School of Nursing,False
+"Cognitive Neuroscience Division; Department of Neurology; Taub Institute for Research on Alzheimer's Disease and the Aging Brain; College of Physicians and Surgeons, Columbia University; New York",n/a,True
+Department of Epidemiology; Johns Hopkins Bloomberg School of Public Health; Baltimore Maryland,n/a,True
+Department of Medicine; State University of New York Upstate Medical University; Syracuse New York,n/a,True
+Division of General Medicine; Department of Medicine; School of Medicine; Columbia University; New York,n/a,True
+Research Division; Hebrew Home for the Aged at Riverdale; Riverdale New York,n/a,True
+Department of Chemistry; Johns Hopkins University; Baltimore Maryland,n/a,True
+Department of Emergency Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Emergency Medicine,False
+Department of Family Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Family Medicine,False
+Department of Health Care Science; Wayne State University; Detroit Michigan,n/a,True
+Department of Sociology; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Sociology,False
+School of Medicine; University of Virginia; Charlottesville Virginia,n/a,True
+"Carolinas Center for Medical Excellence, Inc.; Cary North Carolina",n/a,True
+School of Medicine Duke University; Durham North Carolina,n/a,True
+School of Nursing; Duke University; Durham North Carolina,n/a,True
+School of Nursing; University of Pennsylvania; Philadelphia Pennsylvania,n/a,True
+University of North Carolina at Chapel Hill; Chapel Hill North Carolina,University of North Carolina at Chapel Hill,False
+Department of Epidemiology; School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Epidemiology,False
+Division of Cardiology; School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Division of Cardiology,False
+Division of Geriatric Medicine; School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Division of Geriatric Medicine,False
+Duke Clinical Research Institute; Durham North Carolina,n/a,True
+Agency for Healthcare Research and Quality; Rockville Maryland,n/a,True
+Department of Psychiatry; College of Nursing and College of Medicine; Pennsylvania State University; University Park Pennsylvania,n/a,True
+"Geriatric Pharmacotherapy, Pharmacy Practice and Science; School of Pharmacy; University of Maryland Baltimore; Baltimore Maryland",n/a,True
+School of Public Health; University of North Carolina; Chapel Hill North Carolina,Gillings School of Global Public Health,False
+School of Public Health; Yale University; New Haven Connecticut,n/a,True
+Duke Clinical Research Institute; School of Medicine; Duke University; Durham North Carolina,n/a,True
+Health Outcome Research Center; National Cheng Kung University; Tainan Taiwan,n/a,True
+School of Pharmacy and Institute of Clinical Pharmacy and Pharmaceutical Sciences; National Cheng Kung University; Tainan Taiwan,n/a,True
+"Birmingham/Atlanta Geriatric Research, Education, and Clinical Center; Birmingham Department of Veterans Affairs Medical Center; Birmingham Alabama",n/a,True
+Division of Urogynecology and Reconstructive Pelvic Surgery; Department of Obstetrics and Gynecology; University of North Carolina; Chapel Hill North Carolina,Department of Obstetrics and Gynecology,False
+Departments of Radiation Oncology; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 USA,Department of Radiation Oncology,False
+Urologic Surgery; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 USA,Department of Surgery,False
+21st Century Oncology; Asheville NC,n/a,True
+21st Century Oncology; Providence RI,n/a,True
+Department of Radiation Oncology; Duke University Medical Center; Durham NC,n/a,True
+Department of Radiation Oncology; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Radiation Oncology,False
+Department of Radiation Oncology; University of California San Francisco; San Francisco California 94143 USA,n/a,True
+Department of Radiation Oncology; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27514,Department of Radiation Oncology,False
+Applied Research; Varian Medical Systems; Palo Alto CA USA,n/a,True
+Department of Radiation Oncology; Emory University; Atlanta GA,n/a,True
+Department of Radiation Oncology; Mayo Clinic; Phoenix AZ,n/a,True
+Department of Radiation Oncology; UT MD Anderson Cancer Center; Houston TX,n/a,True
+Department of Radiation Oncology; University of North Carolina; Chapel Hill NC,Department of Radiation Oncology,False
+Department of Radiation Physics; UT MD Anderson Cancer Center; Houston TX,n/a,True
+Department of Radiation Oncology; University of North Carolina Chapel Hill; Chapel Hill NC USA,Department of Radiation Oncology,False
+Medical Physics Department; Memorial Sloan Kettering Cancer Center; West Harrison NY,n/a,True
+"Thurston Arthritis Research Center, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Thurston Arthritis Research Center,False
+"University of Georgia, Athens, GA, USA",n/a,True
+"University of Maryland, Baltimore, Baltimore, MD, USA",n/a,True
+São Paulo State University,n/a,True
+"São Paulo State University,  Brazil",n/a,True
+"University of Passo Fundo,  Brazil",n/a,True
+Department of Education; University of California,n/a,True
+Department of Psychology; University of Michigan,n/a,True
+Department of Psychology; University of North Carolina,Department of Psychology and Neuroscience,False
+"Athletic Training Services, Boston University, MA",n/a,True
+"Department of Health, Physical Education, and Recreation, University of Nebraska, Omaha",n/a,True
+"Neuromuscular Research Laboratory, University of North Carolina at Chapel Hill",Department of Exercise and Sport Science,False
+"Sports Medicine Research Laboratory, University of North Carolina at Chapel Hill",Department of Exercise and Sport Science,False
+"*Proaxis Therapy, Greenville, SC",n/a,True
+"§Emory University, Atlanta, GA",n/a,True
+"¶Department of Exercise &amp; Sport Science, University of North Carolina, Chapel Hill",Department of Exercise and Sport Science,False
+"†University of Sydney, Australia",n/a,True
+"‡University of North Carolina, Chapel Hill",University of North Carolina at Chapel Hill,False
+"*Division of Occupational &amp; Environmental Medicine, Duke University, Durham, NC",n/a,True
+†Department of Epidemiology,n/a,True
+"‡Sports Medicine Research Laboratory, The University of North Carolina at Chapel Hill",University of North Carolina at Chapel Hill,False
+"Carolina Neuropsychological Service, Raleigh, NC",n/a,True
+"Clinical Research Unit, Emergency Services Institute, WakeMed Health &amp; Hospitals and Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center, Raleigh, NC",n/a,True
+"Applied Neuromechanics Research Laboratory, Department of Kinesiology, University of North Carolina at Greensboro",n/a,True
+"FPG Child Development Institute, University of North Carolina at Chapel Hill",Frank Porter Graham Child Development Institute,False
+"Health and Human Sciences, University of North Carolina at Greensboro",n/a,True
+"Campus Health Services, The University of North Carolina at Chapel Hill;",University of North Carolina at Chapel Hill,False
+"Department of Health, Physical Education, and Recreation, University of Nebraska, Omaha; §Neuromuscular Research Laboratory and",n/a,True
+"Orthopedic and Sports Injury Prevention Research Laboratory, University of North Florida, Jacksonville;",n/a,True
+"Sports Medicine Research Laboratory, The University of North Carolina at Chapel Hill",University of North Carolina at Chapel Hill,False
+"East Carolina University, Greenville, NC",n/a,True
+"Korey Stringer Institute, University of Connecticut, Storrs",n/a,True
+"Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center, University of North Carolina at Chapel Hill",Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center,False
+"Richard Stockton College, Pomona, NJ",n/a,True
+"University of Georgia, Athens",n/a,True
+"University of New Hampshire, Durham",n/a,True
+"University of Oklahoma, Norman",n/a,True
+University of Tennessee at Chattanooga,n/a,True
+"West Chester University, PA",n/a,True
+"Western Michigan University, Kalamazoo",n/a,True
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill;",Department of Exercise and Sport Science,False
+"Departments of Kinesiology and Orthopedics and Rehabilitation, University of Wisconsin–Madison School of Medicine and Public Health;",n/a,True
+"Department of Kinesiology, University of Connecticut, Storrs",n/a,True
+"Sports Medicine Research Laboratory, Department of Exercise and Sport Science, University of North Carolina at Chapel Hill;",Department of Exercise and Sport Science,False
+"Athletics Department, Duke University, Durham, NC",n/a,True
+"Campus Health Service, University of North Carolina at Chapel Hill",University of North Carolina at Chapel Hill,False
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill. Mr Lynall is now at the University of North Carolina at Chapel Hill.",Department of Exercise and Sport Science,False
+"School of Kinesiology and Recreation, Illinois State University, Normal;",n/a,True
+"Campus Health Services, The University of North Carolina at Chapel Hill",University of North Carolina at Chapel Hill,False
+"Matthew A. Gfeller Sport-Related Traumatic Brain Injury Research Center, Department of Exercise and Sport Science;",n/a,True
+"Department of Nutrition and Exercise Sciences, Oregon State University, Corvallis",n/a,True
+"Department of Orthopaedics, University of South Florida, Tampa",n/a,True
+"Department of Physical Therapy, East Carolina University, Greenville, NC",n/a,True
+"Department of Epidemiology, University of North Carolina at Chapel Hill",Department of Epidemiology,False
+"Department of Health Behavior and Health Education, University of North Carolina at Chapel Hill",Department of Health Behavior,False
+"Emergency Services Institute, WakeMed Health and Hospitals, Raleigh, NC",n/a,True
+"Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center, Department of Exercise and Sport Science, University of North Carolina at Chapel Hill",Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center,False
+"College of Public Health and Human Sciences, Oregon State University, Corvallis",n/a,True
+"Department of Allied Health Sciences, University of North Carolina at Chapel Hill",Department of Allied Health Sciences,False
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill",Department of Exercise and Sport Science,False
+"Department of Kinesiology, University of North Carolina at Greensboro",n/a,True
+"Department of Orthopaedics, University of North Carolina at Chapel Hill",Department of Orthopaedics,False
+"Departments of Allied Health Sciences, University of North Carolina at Chapel Hill",Department of Allied Health Sciences,False
+"Departments of Exercise and Sport Science, University of North Carolina at Chapel Hill",Department of Exercise and Sport Science,False
+"Departments of Orthopaedics, University of North Carolina at Chapel Hill",Department of Orthopaedics,False
+"Athletic Medicine Division, Intercollegiate Athletics, Duke University, Durham, NC;",n/a,True
+"Doctor of Physical Therapy Program, University of North Florida, Jacksonville;",n/a,True
+"School of Health, Physical Education, Recreation, University of Nebraska at Omaha;",n/a,True
+"Sports Medicine Research Laboratory, Exercise and Sport Science Department, University of North Carolina at Chapel Hill",Department of Exercise and Sport Science,False
+"|Sports Medicine, Athletic Department, University of North Carolina at Chapel Hill",University of North Carolina at Chapel Hill,False
+Departments of Kinesiology and,n/a,True
+"National Academy of Sports Medicine, Mesa, AZ;",n/a,True
+"Musculoskeletal Health and Movement Science Laboratory, University of Toledo, OH",n/a,True
+"University of North Carolina at Chapel Hill. Dr Terada and Dr Gribble are now at University of Kentucky, Lexington.",University of North Carolina at Chapel Hill,False
+"Department of Orthopaedics and Sports Medicine, Morsani College of Medicine, University of South Florida, Tampa",n/a,True
+"Department of Health Science, University of Alabama, Tuscaloosa;",n/a,True
+"Department of Health and Kinesiology, University of Texas at San Antonio;",n/a,True
+"Department of Health and Sport Sciences, Otterbein University, Westerville, OH;",n/a,True
+"Department of Epidemiology, University of North Carolina, Chapel Hill",Department of Epidemiology,False
+"Department of Exercise and Sport Science, University of North Carolina, Chapel Hill",Department of Exercise and Sport Science,False
+"Department of Kinesiology, Department of Orthopedics and Rehabilitation, University of Wisconsin–Madison",n/a,True
+"Uniformed Services University, Bethesda, MD",n/a,True
+"Athletic Training Program, A.T. Still University, Mesa, AZ",n/a,True
+"Athletico Physical Therapy, Oak Brook, IL",n/a,True
+"Department of Surgery, Emerson Hospital, Concord, MA",n/a,True
+"Division of Pediatric Neuropsychology, Children's National Medical Center, Washington, DC",n/a,True
+"Musculoskeletal Research Laboratory, Department of Rehabilitation Sciences, Division of Athletic Training, University of Kentucky, Lexington",n/a,True
+"Neuromuscular Research Laboratory, Department of Exercise and Sports Science, University of North Carolina at Chapel Hill;",Department of Exercise and Sport Science,False
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill. Dr McLeod is now with the Department of Health and Human Performance, College of Charleston, SC.",Department of Exercise and Sport Science,False
+"Department of Kinesiology, University of Toledo, OH;",n/a,True
+"Department of Rehabilitation Sciences, University of Kentucky, Lexington;",n/a,True
+"Datalys Center for Sports Injury Research and Prevention, Indianapolis, IN;",n/a,True
+"Human Movement Science Curriculum, University of North Carolina at Chapel Hill;",Curriculum in Human Movement Science,False
+"National Collegiate Athletic Association, Indianapolis, IN",n/a,True
+"Emerson Hospital, Concord, MA;",n/a,True
+"University of Michigan, Ann Arbor;",n/a,True
+"University of New Hampshire, Durham;",n/a,True
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill; Departments of",Department of Exercise and Sport Science,False
+Department of Kinesiology and,n/a,True
+"Department of Kinesiology and Health, Northern Kentucky University, Highland Heights;",n/a,True
+"Division of Orthopaedics, University of Toledo, OH",n/a,True
+Kinesiology and Health Promotion and,n/a,True
+"Rehabilitation Sciences, University of Kentucky, Lexington;",n/a,True
+"Uniformed Services University of the Health Sciences, Bethesda, MD",n/a,True
+"University of Connecticut, Storrs;",n/a,True
+"Department of Exercise and Sport Science, The University of North Carolina at Chapel Hill",Department of Exercise and Sport Science,False
+"Neuromuscular Research Laboratory, and",n/a,True
+"Sports Medicine Research Laboratory,",n/a,True
+"Sports Medicine Research Laboratory, Georgia State University, Atlanta;",n/a,True
+"The College of William and Mary, Williamsburg, VA;",n/a,True
+"National Institute of Environmental Health Sciences (NIEHS), NIH, Dept. of Health and Human Services, Research Triangle Park, NC, USA",n/a,True
+"University of New Mexico Health Sciences Center, Albuquerque, NM, USA",n/a,True
+"University of North Carolina School of Medicine, Chapel Hill, NC, USA",School of Medicine,False
+"Department of Biostatistics; UNC Gillings School of Global Public Health, University of North Carolina at Chapel Hill; Chapel Hill; NC; 27599; USA",Department of Biostatistics,False
+"Department of Environmental Sciences and Engineering; UNC Gillings School of Global Public Health, University of North Carolina at Chapel Hill; Chapel Hill; NC; 27599; USA",Department of Environmental Sciences and Engineering,False
+"Department of Nutrition; UNC Gillings School of Global Public Health, University of North Carolina at Chapel Hill; Chapel Hill; NC; 27599; USA",Department of Nutrition,False
+Department of Toxicology; CINVESTAV-IPN; Mexico City; Mexico,n/a,True
+Faculty of Medicine; Juarez University of Durango State; Durango; Mexico,n/a,True
+"National Health and Environmental Effects Research Laboratory; Office of Research and Development, U.S. Environmental Protection Agency, Research Triangle Park; NC; 27711; USA",n/a,True
+"Department of Biology, North Carolina Central University, 1801 Fayetteville Street, Durham, NC 27707, USA",n/a,True
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, 135 Dauer Drive, Chapel Hill, NC 27599-74354, USA",Department of Epidemiology,False
+"Department of Pathology and Laboratory Medicine, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599-7255, USA",Department of Pathology and Laboratory Medicine,False
+"Department of Pharmacology, University of North Carolina, Chapel Hill, NC 27599, USA",Department of Pharmacology,False
+"Department of Chemical Engineering and Materials Science, University of Minnesota, Minneapolis, MN 55455, USA",n/a,True
+"Department of Diagnostic Sciences, School of Dentistry, University of North Carolina, CB 7454, Chapel Hill, NC 27599, USA",Department of Diagnostic Sciences,False
+"NC Oral Health Institute, School of Dentistry, University of North Carolina, CB 7454, Chapel Hill, NC 27599, USA",School of Dentistry,False
+"Division of Nephrology and Hypertension, Department of Medicine and Genetics, UNC School of Medicine, UNC Kidney Center, 7024 Burnett-Womack, CB No. 7155, Chapel Hill, NC 27599-7155, USA",Division of Nephrology and Hypertension|UNC Kidney Center|Department of Genetics,False
+"Division of Nephrology, Department of Medicine, Massachusetts General Hospital, 7 Whittier Place, Suite 106, Boston, MA 02114, USA",n/a,True
+"Renal Division, Department of Medicine, Brigham and Women’s Hospital, 75 Francis Street, MRB4, Boston, MA 02115, USA",n/a,True
+"The University of North Carolina at Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"University of Florida, Gainesville, FL, USA",n/a,True
+"Walden University, Minneapolis, MN, USA, The University of North Carolina at Chapel Hill, NC, USA, ",n/a,True
+Maine Medical Center Research Institute; Scarborough ME USA,n/a,True
+Department of Anatomy and Cell Biology; Indiana University School of Medicine; Indianapolis IN USA,n/a,True
+Department of Biomedical Engineering and Radiation Oncology; University of North Carolina; Chapel Hill NC USA,Department of Radiation Oncology|UNC/NCSU Joint Department of Biomedical Engineering,False
+Department of Medicine; Indiana University School of Medicine; Indianapolis IN USA,n/a,True
+Department of Radiation Oncology; Indiana University School of Medicine; Indianapolis IN USA,n/a,True
+"Department of Breast & Thyroid Surgery, Affiliated Nanshan Hospital of Guangdong Medical College, Guangzhou, China.",n/a,True
+"Department of Emergency, Shanghai Armed Policed General Troops Hospital, Shanghai, China.",n/a,True
+"Department of Nutrition Hygiene, Shanghai Municipal Center for Disease Control and Prevention, Shanghai, China.",n/a,True
+"Department of Nutrition, University of North Carolina at Chapel Hill, Chapel Hill, USA.",Department of Nutrition,False
+Department of Dermatology; Stanford University; Stanford CA,n/a,True
+Department of Pathology and Laboratory Medicine; University of North Carolina; Chapel Hill NC,Department of Pathology and Laboratory Medicine,False
+"Division of Otolaryngology-Head and Neck Surgery, Department of Surgery; University of North Carolina; Chapel Hill NC",Department of Otolaryngology/Head and Neck Surgery,False
+"Division of Otolaryngology-Head and Neck Surgery, Department of Surgery; University of Vermont; Burlington VT",n/a,True
+Metabolon Inc.; Research Triangle Park NC,n/a,True
+" National Research Center on Rural Education Support, Pennsylvania State University, State College, PA, USA",n/a,True
+" National Research Center on Rural Education Support, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+Department of Pathology and Laboratory Medicine; University of North Carolina; Chapel Hill NC USA,Department of Pathology and Laboratory Medicine,False
+Department of Biochemistry and Biophysics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599,Department of Biochemistry and Biophysics,False
+Department of Genetics and Bioengineering; Fatih University Istanbul; Istanbul Turkey,n/a,True
+Department of Biology; The University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Biology,False
+"Department of Biomedical Engineering, Washington University, St. Louis, Missouri, U.S.A.",n/a,True
+"Department of Neurology, University of North Carolina-Chapel Hill, Chapel Hill, North Carolina, USA",Department of Neurology,False
+"Department of Neurology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+"Department of Neurology, and the Mallinckrodt Institute of Radiology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+"Department of Psychiatry and the Mallinckrodt Institute of Radiology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+"Departments of Neurology, and Anatomy and Neurobiology, the Program in Physical Therapy and the Mallinckrodt Institute of Radiology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+"Mallinckrodt Institute of Radiology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+" Department of Neurology, Washington University, St Louis, Missouri, USA",n/a,True
+" Department of Neurology, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Neurology,False
+" Mallinckrodt Institute of Radiology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+"Department of Cell and Molecular Physiology and the McAllister Heart Institute, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Cell and Molecular Physiology|UNC McAllister Heart Institute,False
+"Department of Biostatistics and the Lineberger Cancer Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Biostatistics|UNC Lineberger Comprehensive Cancer Center,False
+"Department of Neurology, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Neurology,False
+"Department of Neurology, Washington University, School of Medicine, St Louis, Missouri, USA",n/a,True
+"Departments of Neurology, Anatomy and Neurobiology, Program in Physical Therapy, Program in Occupational Therapy and the Mallinckrodt Institute of Radiology, Washington University School of Medicine, St Louis, Missouri, USA",n/a,True
+" Department of Neurology, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Neurology,False
+" Department of Neurosciences, University of California, San Diego, California, USA",n/a,True
+" Department of Pediatrics, University of California, San Diego, California, USA",n/a,True
+" Departments of Neurology and the Mallinckrodt Institute of Radiology, School of Medicine, Washington University, St Louis, Missouri, USA",n/a,True
+" Departments of Neurology, Anatomy and Neurobiology, the Program in Physical Therapy, the Program in Occupational Therapy, School of Medicine, Washington University, St Louis, Missouri, USA",n/a,True
+" Mallinckrodt Institute of Radiology, School of Medicine, Washington University, St Louis, Missouri, USA",n/a,True
+" Department of Cellular and Structural Biology, University of Texas Health Science Center at San Antonio, San Antonio, TX, USA",n/a,True
+" Department of Neurology and Biomedical Research Imaging Center, University of North Carolina, Chapel Hill, NC, USA",Biomedical Research Imaging Center|Department of Neurology,False
+" Department of Physiology, University of Texas Health Science Center at San Antonio, San Antonio, TX, USA",n/a,True
+" Department of Psychiatry, University of Texas Health Science Center at San Antonio, San Antonio, TX, USA",n/a,True
+" Research Imaging Institute, San Antonio, TX, USA",n/a,True
+" The Barshop Institute for Longevity and Aging Studies, University of Texas Health Science Center at San Antonio, San Antonio, TX, USA",n/a,True
+"Department of Biomedical Engineering, National Yang-Ming University, Taipei, Taiwan",n/a,True
+"Department of Neurology, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Neurology,False
+"Research Imaging Institute, University of Texas Health Science Center at San Antonio, San Antonio, Texas, USA",n/a,True
+"Department of Chemistry and Neuroscience Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Chemistry|UNC Neuroscience Center,False
+"Laboratory for Molecular Modeling, Division of Medicinal Chemistry and Natural Products and Carolina Exploratory Center for Cheminformatics Research, Eshelman School of Pharmacy, ‡Department of Biochemistry and Biophysics, and §Research Computing Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",University of North Carolina at Chapel Hill,False
+"Collaborations In Chemistry, 616 Hilltop Needmore Rd., Fuquay Varina,rNorth Carolina 27526, United States",n/a,True
+"Department of Chemical Biology andrTherapeutics, St. Jude Children’s Research Hospital, 262 Danny Thomas Place, Memphis, Tennessee 38105, United States",n/a,True
+"The Laboratory for MolecularrModeling, Eshelman School of Pharmacy, CB# 7568, University of North Carolina at Chapel Hill, Chapel Hill, NorthrCarolina 27599, United States",Eshelman School of Pharmacy,False
+"Department of Biochemistry andrBiophysics, School of Medicine, University of North Carolina, ChapelrHill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Laboratory for Molecular Modeling,rUNC Eshelman School of Pharmacy, University of North Carolina, ChapelrHill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"Departmentrof Pharmaceutical Sciences, College of Pharmacy, Howard University, Washington, District of Columbia 20059, United States",n/a,True
+"Center for Integrative ChemicalrBiology and Drug Discovery, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Campus Box 7363, Chapel Hill, North Carolina 27599-7363, United States",Center for Integrative Chemical Biology and Drug Discovery,False
+"CSIRO Digital Productivity Flagship, Private Bag 10, Clayton South, VIC 3169, Australia",n/a,True
+"CSIRO Manufacturing Flagship, Clayton, VIC 3168, Australia",n/a,True
+"UNCrEshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"Department of Bioengineering and Therapeutic Science, University of California San Francisco, 513 Parnassus Avenue, San Francisco, California 94143, United States",n/a,True
+"Department of Computer Science, University of North Carolina, 201 South Columbia Street, Chapel Hill, North Carolina 27599, United States",Department of Computer Science,False
+"Departmentrof Biochemistry and Biophysics, University of North Carolina, 120rMason Farm Road, Chapel Hill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Departmentrof Biochemistry, University of Washington, 1705 North East Pacific Street, Seattle, Washington 98195, United States",n/a,True
+"Fred Hutchinson Cancer ResearchrCenter, 1100 Fairview Avenue North, Seattle, Washington 98109, United States",n/a,True
+"Google Inc., 1600 AmphitheatrerParkway, Mountain View, California 94043, United States",n/a,True
+"Department of Science and Mathematics, Husson University, Maine, USA",n/a,True
+"Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina, USA",Eshelman School of Pharmacy,False
+"Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina, USA Cecil G Sheps Center for Health Services Research, North Carolina, USA",Cecil G. Sheps Center for Health Services Research|Eshelman School of Pharmacy,False
+"Gillings School of Global Public Health, University of North Carolina, Chapel Hill, North Carolina, USA",Gillings School of Global Public Health,False
+"Graduate School of Public Health, San Diego State University, California, USA",n/a,True
+"School of Medicine, Riley Children’s Hospital, Indiana, USA",n/a,True
+"Department of Psychiatry and Behavioral Sciences, Duke University Medical School, Durham, NC, USA",n/a,True
+"Department of Psychiatry and The Carolina Institute for Developmental Disabilities, University of North Carolina School of Medicine, Chapel Hill, NC, USA",Carolina Institute for Developmental Disabilities|Department of Psychiatry,False
+"Department of Radiology, Duke University Medical School, Durham, NC, USA",n/a,True
+"Istanbul Cerrahi Hastanesi, Tesvikiye mahallesi, Istanbul, Turkey",n/a,True
+Department of Health Policy and Management; University of North Carolina; Chapel Hill NC USA,Department of Health Policy and Management,False
+Division of General Internal Medicine Department of Medicine at San Francisco General Hospital; University of California; San Francisco CA USA,n/a,True
+Division of General Internal Medicine; Northwestern University; Evanston IL USA,n/a,True
+Division of General Medicine; The Cecil G. Sheps Center for Health Services Research; University of North Carolina; Chapel Hill NC USA,Division of General Medicine and Clinical Epidemiology|Cecil G. Sheps Center for Health Services Research,False
+Division of General Medicine; University of North Carolina; Chapel Hill NC USA,Division of General Medicine and Clinical Epidemiology,False
+School of Nursing; University of California; Los Angeles CA USA,n/a,True
+The Cecil G. Sheps Center for Health Services Research; University of North Carolina; Chapel Hill NC USA,Cecil G. Sheps Center for Health Services Research,False
+The School of Nursing; University of North Carolina; Chapel Hill NC USA,School of Nursing,False
+University of Colorado School of Medicine; Aurora CO USA,n/a,True
+"From the Department of Medicine, Division of Hematology/Oncology; and the Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC; Division of Biostatistics, Mayo Clinic, Rochester, MN; Community Clinical Oncology Program, IA Oncology Research Association, Des Moines, IA; Dana-Farber Cancer Institute, Boston, MA; University of Pittsburgh, Pittsburgh, PA; University of Kansas Medical Center, Kansas City, KS; National Cancer Institute of Canada, Saint Catharines, Ontario, Canada",n/a,True
+"From the Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill; Southeastern Medical Oncology Center, Oncology, Goldsboro, NC; Johns Hopkins University, School of Medicine, Baltimore, MD; University of Pittsburgh School of Medicine, Pittsburgh, PA; Washington University, School of Medicine, St Louis, MO; University of Virginia, Department of Internal Medicine, Charlottesville, VA; Pfizer Inc, Global Research and Development, La Jolla, CA; University of Turin, Department of...",n/a,True
+"From the Dana-Farber Cancer Institute; Massachusetts General Hospital; Beth Israel Deaconess Medical Center, Boston, MA; Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill, Chapel Hill, NC; and the Lombardi Comprehensive Cancer Center, Georgetown University, Washington, DC",n/a,True
+"From the Department of Radiation Oncology, University of North Carolina, Chapel Hill; Cancer and Leukemia Group B Statistical Center, Duke University, Durham, NC; Department of Surgery, Saint Joseph Cancer Institute, Towson, MD; Department of Surgery, Medical University of South Carolina, Charleston, SC; North Central Cancer Treatment Group, Rochester, MN; Department of Medicine, Northwestern University, Chicago, IL; Department of Surgery, Brigham and Women's Hospital; and Department of Medicine, Dana...",n/a,True
+"From the University of North Carolina at Chapel Hill, Chapel Hill; Duke University, Durham, NC",n/a,True
+"From the University of Chicago, Chicago, IL; Cancer and Leukemia Group B Statistical Center, Duke University Medical Center, Durham; University of North Carolina at Chapel Hill, Chapel Hill, NC; Memorial Sloan-Kettering Cancer Center, New York, NY; Vermont Cancer Center, Burlington, VT; The Ohio State University Medical Center, Columbus, OH; and the Dana-Farber Cancer Institute, Boston, MA",n/a,True
+"From the Fred Hutchinson Cancer Research Center, Division of Public Health Sciences; University of Washington, Department of Epidemiology, School of Public Health and Community Medicine, and Department of Medicine, School of Medicine, Seattle, WA; Los Angeles Biomedical Research Institute at Harbor-University of California at Los Angeles Medical Center, Torrance, CA; University of North Carolina, School of Public Health, Chapel Hill, NC; University of Oklahoma Health Sciences Center, College of Public...",n/a,True
+"From the Division of Pediatric Oncology, Columbia Presbyterian College of Physicians and Surgeons; Department of Surgery, Orthopedic Service, Memorial Sloan-Kettering Cancer Center, New York, NY; Division of Oncology and Department of Radiology, Children's Hospital of Philadelphia, Philadelphia, PA; Children's Oncology Group–Data Center, College of Medicine Center, University of Florida, Gainesville, FL; Statistics, Children's Oncology Group–Operations Center, Arcadia; Pediatric Hematology/Oncology,...",n/a,True
+"From the Mayo Clinic and Mayo Foundation, Rochester, MN; Allegheny Cancer Center, Pittsburgh, PA; The University of North Carolina at Chapel Hill, Chapel Hill, NC; and the Toledo Community Hospital Oncology Program Community Clinical Oncology Program, Toledo, OH.",n/a,True
+"From the Divisions of Biostatistics and Medical Oncology, Mayo Clinic, Rochester, MN; Department of Biostatistics, University of California, Los Angeles, Los Angeles, CA; National Surgical Adjuvant Breast and Bowel Project Operations Office and Biostatistical Center, Pittsburgh; Abramson Cancer Center at the University of Pennsylvania, Philadelphia, PA; University of North Carolina, Chapel Hill, NC; Medical Oncology, Ospedale S. Martino, Genova; Ospedali Riuniti, Bergamo; University of Siena, Siena,...",n/a,True
+"From the National Surgical Adjuvant Breast and Bowel Project; Department of Biostatistics, Graduate School of Public Health, University of Pittsburgh; Allegheny General Hospital, Pittsburgh, PA; University of Florida, Gainesville, FL; Helen F. Graham Cancer Center, Newark, DE; University of North Carolina, Chapel Hill; Southeast Cancer Control Consortium – Community Clinical Oncology Program, Goldsboro, NC; Atlanta Cancer Care, Atlanta, GA; Kaiser Permanente, Northern California, Vallejo, CA; Florida...",n/a,True
+"From the Southwest Oncology Group, San Antonio, TX; University of California Davis Cancer Center, Sacramento; and University of Southern California Norris Cancer Center, Los Angeles, CA; Cancer Research and Biostatistics, Seattle, WA; Japan Multinational Trial Organization, Kobe; National Kinki-chuo Chest Medical Center, Sakai; Kyoto University Hospital, Kyoto; National Cancer Center Hospital, Tokyo; National Cancer Center Hospital East, Kashiwa, Chiba; and Kinki University School of Medicine,...",n/a,True
+"From the Massachusetts General Hospital, Boston, MA; University of North Carolina at Chapel Hill, Chapel Hill, NC; University of Virginia, Charlottesville; School of Public Health, Class of 2007, Central Virginia Community Health Center, New Canton, VA; Jesse Brown Veterans Administration Medical Center, Chicago, IL; Washington University; Express-Scripts, St. Louis, MO; MetroHealth Medical Center, Cleveland, OH; and University of Toronto, Toronto, Canada.",n/a,True
+"From the Brigham and Women's Hospital; Dana-Farber Cancer Institute, Boston, MA; Cancer and Leukemia Group B Statistical Center, Duke University Medical Center, Durham; University of North Carolina at Chapel Hill, Chapel Hill, NC; National Cancer Institute, Bethesda, MD; Ohio State University, Columbus, OH; Memorial Sloan-Kettering Cancer Center, New York, NY; and the University of California at San Francisco, San Francisco, CA.",n/a,True
+"From the Wake Forest University School of Medicine, Winston-Salem; Department of Biostatistics and Bioinformatics, and Cancer and Leukemia Group B Statistical Center, Duke University Medical Center, Durham; University of North Carolina, Chapel Hill, NC; University of Iowa College of Pharmacy; University of Iowa Hospitals, Iowa City, IA; Memorial Sloan-Kettering Cancer Center, New York; Roswell Park Cancer Institute, Buffalo, NY; University of Chicago Medical Center, Chicago, IL; Georgetown University...",n/a,True
+"From the Mayo Clinic, Rochester, MN; University of North Carolina, Chapel Hill, NC; Memorial Sloan-Kettering Cancer Center, New York, NY; Klinikum Oldenburg, Oldenburg; Klinikum Bremen, Bremen, Germany; Cancer Research Center UK Clinical Centre, Leeds; Medical Research Council, London, United Kingdom; Hopital Saint Antoine, Paris; Hopital Ambroise Pare, Boulogne; and Center R. Gauducheau, St Herblain, France.",n/a,True
+"From the Department of Health Studies, and Section of Hematology/Oncology, Department of Medicine, University of Chicago, Chicago, IL; Institut Pasteur, Dakar, Sénégal; University of Ibadan, Ibadan; Usman Danfodio University Teaching Hospital, Sokoto; Ebonyi State University Teaching Hospital, Abakaliki, Nigeria; and University of North Carolina, Chapel Hill, NC.",n/a,True
+"From the Department of Medicine, Division of Hematology/Oncology; the Lineberger Comprehensive Cancer Center; and the University of North Carolina Institute for Pharmacogenomics and Individualized Therapy, University of North Carolina, Chapel Hill, NC; and Division of Biomedical Statistics and Informatics, Mayo Clinic, Rochester, MN.",n/a,True
+"From the Dana-Farber Cancer Institute, Boston, MA; University of California, San Francisco Comprehensive Cancer Center, San Francisco, CA; Cancer and Leukemia Group B Statistical Center, Duke University, Durham; University of North Carolina Comprehensive Cancer Center, Chapel Hill, NC; University of Chicago Medical Center, Chicago, IL; Mount Sinai Comprehensive Cancer Center, Miami, FL; and Martha Jefferson Hospital, Charlottesville, VA.",n/a,True
+"From the Division of Hematology and Oncology, Department of Medicine, The University of North Carolina at Chapel Hill, Chapel Hill, NC; and the Aab Cardiovascular Research Institute and Department of Medicine, University of Rochester, Rochester, NY.",n/a,True
+"From the Lineberger Comprehensive Cancer Center and Departments of Genetics, Pathology and Laboratory Medicine, and Department of Statistics and Operations Research, Carolina Center for Genome Sciences, University of North Carolina at Chapel Hill, Chapel Hill, NC; Department of Pathology, University of Utah Health Sciences Center; ARUP Institute for Clinical and Experimental Pathology, Salt Lake City, UT; Genetic Pathology Evaluation Centre, Department of Pathology, Vancouver Coastal Health Research...",n/a,True
+"From the National Institutes of Health, Bethesda, MD; American Society of Clinical Oncology, Alexandria, VA; University of Montana Liberal Studies, Missoula, MT; University of Connecticut Health Center, Farmington, CT; International Epidemiology Institute, Rockville, MD; Johns Hopkins University, Baltimore, MD; National Surgical Adjuvant Breast and Bowel Project, Pittsburgh, PA; University of North Carolina at Chapel Hill, Chapel Hill, NC; University of Minnesota School of Medicine, Minneapolis, MN;...",n/a,True
+"From Hopital Saint Antoine; Group Hospitalier Pitie-Salpetriere, Paris, France; International Drug Development Institute, Louvain-la-Neuve, Belgium; National Cancer Institute of Canada Clinical Trials Group, Queens University, Kingston, Ontario; British Columbia Cancer Agency, Vancouver, British Columbia, Canada; Divisions of Medical Oncology and Biomedical Statistics and Informatics, Mayo Clinic, Rochester; University of Minnesota, Minneapolis, MN; National Surgical Adjuvant Breast and Bowel Project ...",n/a,True
+"From the University of North Carolina at Chapel Hill, Chapel Hill, NC.",University of North Carolina at Chapel Hill,False
+"From the Mayo Clinic, Rochester, MN; and University of North Carolina at Chapel Hill, Chapel Hill, NC.",n/a,True
+"From the University of Chicago Cancer Research Center and Northwestern University Feinberg School of Medicine, Chicago, IL; Cancer and Leukemia Group B Statistical Center, Duke University Medical Center, Durham; University of North Carolina at Chapel Hill, Chapel Hill, NC; Dana-Farber Cancer Institute, Boston, MA; Memorial Sloan-Kettering Cancer Center, New York, NY; Delaware Christiana Care Community Clinical Oncology Program and Helen F. Graham Cancer Center, Wilmington, DE; and Washington University...",n/a,True
+"From the Hollings Cancer Center, Medical University of South Carolina, Charleston, SC; National Cancer Institute, Bethesda; The Johns Hopkins Medical Institute, Baltimore, MD; The University of Texas M. D. Anderson Cancer Center, Houston, TX; Memorial Sloan Kettering Cancer Center; Columbia University College of Physicians and Surgeons, New York, NY; The Mayo Clinic, Rochester, MN; University of California, San Francisco, San Francisco, CA; Hotel-Dieu Hospital, Paris, France; University of North Carolina...",n/a,True
+"From the Portland Veterans Affairs Medical Center; Division of Pulmonary and Critical Care Medicine, Oregon Health &amp; Sciences University, Portland, OR; Clinical Research Division and Cancer Prevention Program, Fred Hutchison Cancer Research Center; Division of Pulmonary and Critical Care and Department of Epidemiology, University of Washington; Veterans Affairs Puget Sound Health Care System, Health Services Research and Development, Seattle, WA; and Departments of Nutrition and Epidemiology,...",n/a,True
+"From the Dana-Farber Cancer Institute; Channing Laboratory, Brigham and Women's Hospital and Harvard Medical School, Boston, MA; Cancer and Leukemia Group B Statistical Center, Duke University Medical Center, Durham; University of North Carolina, Chapel Hill, NC; Memorial Sloan-Kettering Cancer Center, New York, NY; Robert H. Lurie Comprehensive Cancer Center, Northwestern University, Chicago; Edward Cancer Center, Naperville, IL; Toledo Community Hospital Oncology Program, Toledo, OH; and the Hôpital du...",n/a,True
+"From the Department of Medicine, Division of Hematology and Oncology, Lineberger Comprehensive Cancer Center; Department of Surgery, Division of Urology; Department of Radiology, The University of North Carolina at Chapel Hill, Chapel Hill; Department of Pathology, Rex Healthcare; Rex Hematology Oncology Associates; and Wake Urological Associates, Raleigh, NC.",n/a,True
+"From The University of North Carolina at Chapel Hill, Chapel Hill, NC; Mayo Clinic and Mayo Foundation, Rochester, MN; Washington University School of Medicine, St. Louis, MO; Dana-Farber Cancer Institute, Boston, MA; University of Pittsburgh Cancer Institute, Pittsburgh, PA; University of Kansas Medical Center, Kansas City, KS; National Cancer Institute of Canada, St Catharines, Ontario, Canada; and Iowa Oncology Research Association Community Clinical Oncology Program, Des Moines, IA.",n/a,True
+"From the Veterans Affairs Medical Center, Durham; Duke University Medical Center, Durham; University of North Carolina at Chapel Hill, Chapel Hill, NC; and Veterans Health Administration, Washington, DC.",n/a,True
+"From the Royal Marsden Hospital; Breakthrough Breast Cancer Research Centre, Institute of Cancer Research; and Cancer Research United Kingdom Clinical Trials and Statistics Unit, Section of Clinical Trials, Institute of Cancer Research, London, United Kingdom; Lineberger Comprehensive Cancer Center and Department of Genetics, University of North Carolina at Chapel Hill, Chapel Hill, NC; and Washington University and Siteman Cancer Center, St Louis, MO.",n/a,True
+"From the National Cancer Institute, Bethesda, MD; Lineberger Cancer Center, University of North Carolina at Chapel Hill, Chapel Hill, NC; University of California, Los Angeles, Los Angeles; and Cancer Prevention Institute of California, Fremont, CA.",n/a,True
+"Cancer and Leukemia Group B Statistical Center; Duke University Medical Center, Durham; Southeast Cancer Control Consortium, Goldsboro; University of North Carolina, Chapel Hill, NC; Brigham and Women's Hospital; Eastern Cooperative Oncology Group; Dana-Farber Cancer Institute, Boston; Massachusetts General, North Shore Cancer Center, Danvers, MA; University of California, San Francisco, San Francisco, CA; National Cancer Institute, Bethesda; National Cancer Institute Expanded Participation Project,...",n/a,True
+"From the Dana-Farber Cancer Institute and Harvard Medical School, Boston, MA; Lineberger Comprehensive Cancer Center, University of North Carolina School of Medicine, Chapel Hill, NC; Stanford University School of Medicine, Stanford; Helen Diller Family Comprehensive Cancer Center, University of California, San Francisco, San Francisco, CA; Coordinating Center for Clinical Trials, Office of the Director, National Cancer Institute, Rockville, MD; Abramson Cancer Center, University of Pennsylvania; Fox...",n/a,True
+"William J. Irvin Jr, Christine M. Walko, Karen E. Weck, Joseph G. Ibrahim, Wing K. Chiu, E. Claire Dees, Howard L. McLeod, James P. Evans, Lisa A. Carey, University of North Carolina at Chapel Hill, Chapel Hill; Susan G. Moore, Oludamilola A. Olajide, Rex Hematology/Oncology Associates; Sean T. Canale, Carolina Breast Care Specialists, Raleigh; Mark L. Graham, Waverly Hematology/Oncology, Cary; Rachel E. Raab, East Carolina University, Greenville; Jeffrey M. Peppercorn, Duke University, Durham; Steven M....",n/a,True
+"Charles D. Blanke, University of British Columbia and British Columbia Cancer Agency, Vancouver, British Columbia, Canada; Brian M. Bot and Daniel J. Sargent, Mayo Clinic, Rochester, MN; David M. Thomas, Peter MacCallum Cancer Centre, Melbourne, Australia; Archie Bleyer, St Charles Medical Center, Bend, OR; Claus-Henning Kohne, Clinic for Oncology and Hematologie, Oldenburg, Germany; Matthew T. Seymour, University of Leeds, Leeds, United Kingdom; Aimery de Gramont, Hospital St Antoine, Paris, France; and...",n/a,True
+"Monica M. Bertagnolli and Mark Redston, Brigham and Women's Hospital; Monica M. Bertagnolli and Robert J. Mayer, Dana-Farber Cancer Institute, Boston, MA; Donna Niedzwiecki, Cancer and Leukemia Group B Statistical Center, Duke University Medical Center, Durham; Richard M. Goldberg, University of North Carolina at Chapel Hill, Chapel Hill, NC; Carolyn C. Compton, National Cancer Institute, Bethesda, MD; Thomas A. Colacchio, Dartmouth Hitchcock Medical Center, Hanover, NH; Leonard B. Saltz, Memorial Sloan...",n/a,True
+"From the University of North Carolina at Chapel Hill, NC; Vanderbilt University, Nashville, TN; Emory University, Atlanta, GA; H. Lee Moffitt Cancer Center, Tampa, FL; The Ohio State University, Columbus, OH; Virginia Commonwealth University, Richmond, VA; and AstraZeneca, Alderley Park, Macclesfield, Cheshire, United Kingdom.",n/a,True
+"From the National Surgical Adjuvant Breast and Bowel Project; Graduate School of Public Health, University of Pittsburgh; and Allegheny General Hospital, Pittsburgh, PA; University of Florida, Gainesville; and Florida Cancer Specialists–Sarasota, FL; Helen F. Graham Cancer Center at Christiana Care, Newark, DE; Southeast Cancer Control Consortium–Community Clinical Oncology Program (CCOP), Goldsboro, NC; Atlanta Cancer Care Regional CCOP, Atlanta, GA; Kaiser Permanente Northern California, Vallejo, CA;...",n/a,True
+"Sophia K. Smith and Amy P. Abernethy, Duke University, Durham; Sheryl Zimmerman, Habtamu Benecha, Deborah K. Mayer, and Lloyd J. Edwards, University of North Carolina at Chapel Hill, Chapel Hill, NC; Patricia A. Ganz, University of California at Los Angeles, Los Angeles, CA; Christianna S. Williams, no affiliation.",n/a,True
+"From the Siteman Cancer Center; Washington University, St Louis, MO; American College of Surgeons Oncology Group Statistical Center, Mayo Clinic, Rochester, MN; Linberger Cancer Center, University of North Carolina, Chapel Hill; Duke University Cancer Center, Durham, NC; Helen Diller Cancer Center, University of California San Francisco, San Francisco, CA; Doctors Hospital of Laredo, Laredo; University of Texas MD Anderson Cancer Center, Houston; Simmons Cancer Center, University of Texas Southwestern,...",n/a,True
+"Ramaswamy Govindan, Washington University School of Medicine, St Louis, MO; Jeffrey Bogart, State University of New York Upstate Medical University, Syracuse, NY; Thomas Stinchcombe, University of North Carolina at Chapel Hill, Chapel Hill; Xiaofei Wang and Lydia Hodgson, Cancer and Leukemia Group B Statistical Center, Duke University Medical Center; Jennifer Garst, Duke University Medical Center, Durham; Timothy Brotherton, Southeast Cancer Control Consortium, Community Clinical Oncology Program,...",n/a,True
+"James A. Talcott and Beow Y. Yeap, Massachusetts General Hospital; James A. Talcott, Harvard Medical School; Jack A. Clark, Boston University School of Public Health, Boston; Jack A. Clark, Center for Health Quality, Outcomes, and Economic Research, VA Medical Center, Bedford, MA; Robert D. Siegel, Helen and Harry Gray Cancer Center, Hartford, CT; Elizabeth Trice Loggers, Fred Hutchinson Cancer Research Center and Group Health Research Institute, Seattle, WA; Charles Lu, MD Anderson Cancer Center,...",n/a,True
+"From the Washington University School of Medicine, St Louis, MO; University of North Carolina, Chapel Hill, NC; and Université de Toulouse, Toulouse, France.",n/a,True
+"From the Dana-Farber Cancer Institute; Brigham and Women's Hospital and Harvard Medical School, Boston, MA; North Central Cancer Treatment Group; Mayo Clinic, Rochester, MN; University of North Carolina, Chapel Hill, NC; Medical University of South Carolina, Charleston, SC; and the Jewish General Hospital, McGill University, Montreal, Quebec, Canada.",n/a,True
+"Lee W. Jones, Whitney E. Hornsby, April D. Coan, James E. Herndon II, and Pamela S. Douglas, Duke University Medical Center, Durham; Hyman B. Muss, University of North Carolina at Chapel Hill, Chapel Hill, NC; Kerry S. Courneya, John R. Mackey, Edith N. Pituskin, and Mark Haykowsky, University of Alberta, Edmonton, Alberta, Canada; and Jessica M. Scott, NASA Johnson Space Center, Houston, TX.",n/a,True
+Author affiliations appear at the end of this article.,n/a,True
+"Toni K. Choueiri, Robert W. Ross, Susanna Jacobus, Stephanie C. Morrissey, Geoffrey C. Buckle, Mary-Ellen Taplin, Jonathan E. Rosenberg, and Philip W. Kantoff, Dana-Farber Cancer Institute; Glenn J. Bubley, Beth Israel Deaconess Medical Center, Boston, MA; Ulka Vaishampayan, Karmanos Cancer Institute, Detroit, MI; Evan Y. Yu, Seattle Cancer Care Alliance/University of Washington, Seattle, WA; David I. Quinn, University of Southern California/Norris Comprehensive Cancer Center, Los Angeles, CA; Noah M....",n/a,True
+"Jeffrey A. Meyerhardt, Ling Li, and Deborah Schrag, Dana-Farber Cancer Institute, Boston, MA; Hanna K. Sanoff, University of Virginia, Charlottesville, VA; and William Carpenter IV, University of North Carolina at Chapel Hill, Chapel Hill, NC.",n/a,True
+"Charles F. Levenback and Robert L. Coleman, The University of Texas MD Anderson Cancer Center, Houston, TX; Shamshad Ali, Gynecologic Oncology Group Statistical &amp; Data Center, Roswell Park Cancer Institute, Buffalo; Mario M. Leitao Jr, Memorial Sloan-Kettering Cancer Center, New York, NY; Michael A. Gold, University of Oklahoma, Oklahoma City, OK; Jeffrey M. Fowler, The Ohio State University Columbus Cancer Council, Hilliard, OH; Patricia L. Judson, University of Minnesota School of Medicine,...",n/a,True
+"Joseph G. Ibrahim, University of North Carolina at Chapel Hill, Chapel Hill, NC; Haitao Chu, University of Minnesota, Minneapolis, MN; and Ming-Hui Chen, University of Connecticut, Storrs, CT.",n/a,True
+"Laura J. Esserman, Sarah E. Davis, Meredith B. Buxton, Christina Yau, Hope S. Rugo, Joseph Rabban, Yunn-Yi Chen, Laura van 't Veer, and Nola Hylton, University of California at San Francisco, San Francisco; Debasish Tripathy, University of Southern California at Los Angeles, Los Angeles, CA; Donald A. Berry, MD Anderson Cancer Center, Houston, TX; Angela DeMichele and Carolyn Mies, University of Pennsylvania, Philadelphia, PA; Lisa Carey, Charles Perou, Chad Livasy, and Lynn Dressler, University of North...",n/a,True
+"Richard B. Womer, Bruce R. Pawel, and John P. Dormans, Children's Hospital of Philadelphia and University of Pennsylvania, Philadelphia, PA; Daniel C. West, University of California, San Francisco, San Francisco; Mark D. Krailo, Children's Oncology Group, Arcadia, CA; Paul S. Dickman, Phoenix Children's Hospital, Phoenix, AZ; Holcombe E. Grier, Karen Marcus, Dana-Farber Cancer Institute, Boston, MA; Scott Sailer, University of North Carolina, Chapel Hill, NC; John H. Healey, Memorial Sloan-Kettering...",n/a,True
+"Pasi A. Jänne and Marzia Capelletti, Dana-Farber Cancer Institute and Brigham and Women's Hospital, Boston, MA; Xiaofei Wang, Jeffrey Crawford, and Lin Gu, Duke University Medical Center, Durham; Mark A. Socinski and Thomas E. Stinchcombe, University of North Carolina, Chapel Hill, NC; Martin J. Edelman, University of Maryland, Baltimore, MD; Miguel A. Villalona-Calero, The Ohio State University, Columbus, OH; Robert Kratzke, University of Minnesota, Minneapolis, MN; Everett E. Vokes, University of...",n/a,True
+"Lawrence N. Shulman, Erica Mayer, Eric P. Winer, Dana-Farber Cancer Institute, Boston, MA; Constance T. Cirrincione, Gretchen Kimmick, Duke University Medical Center, Durham, NC; Donald A. Berry, MD Anderson Cancer Center, Houston, TX; Heather P. Becker, Cancer and Leukemia Group B Central Office, Chicago, IL; Edith A. Perez, Mayo Clinic Florida, Jacksonville, FL; Ruth O'Regan, Emory University, Atlanta, GA; Silvana Martino, The Angeles Clinic and Research Institute, Los Angeles, CA; James N. Atkins,...",n/a,True
+"Lisa A. Carey, Anastasia Ivanova, Wing-Keung Chiu, Madlyn Ferraro, Emily Burrows, Katherine A. Hoadley, and Charles M. Perou, University of North Carolina at Chapel Hill, Chapel Hill; P. Kelly Marcom, Duke University, Durham, NC; Hope S. Rugo, University of California at San Francisco, San Francisco, CA; Erica L. Mayer, Dana-Farber Cancer Institute, Boston, MA; Francisco J. Esteva, The University of Texas MD Anderson Cancer Center; Mothaffar F. Rimawi, Baylor University College of Medicine, Houston, TX;...",n/a,True
+"Jan Franko and Charles D. Goldman, Mercy Medical Center, Des Moines, IA; Qian Shi, Garth D. Nelson, Henry C. Pitot, Axel Grothey, Steven R. Alberts, and Daniel J. Sargent, Mayo Clinic, Rochester, MN; Barbara A. Pockaj, Mayo Clinic, Scottsdale, AZ; and Richard M. Goldberg, University of North Carolina, Chapel Hill, NC.",n/a,True
+"Polly A. Newcomb and Michael N. Passarelli, Fred Hutchinson Cancer Research Center, Seattle, WA; Polly A. Newcomb, Amy Trentham-Dietz, and John M. Hampton, University of Wisconsin Paul P. Carbone Comprehensive Cancer Center, Madison, WI; Ellen Kampman, Wageningen University, Wageningen, the Netherlands; Kathleen M. Egan, H. Lee Moffitt Cancer Center and Research Institute, Tampa, FL; Linda J. Titus, Norris Cotton Cancer Center, Lebanon, NH; John A. Baron, University of North Carolina Lineberger...",n/a,True
+"Eyal C. Attar and Philip C. Amrein, Massachusetts General Hospital; Martha Wadleigh, Daniel J. DeAngelo, and Richard M. Stone, Dana-Farber Cancer Institute, Boston, MA; Jeffrey L. Johnson and Barry K. Moser, Duke University Medical Center, Durham; Bayard L. Powell, Wake Forest University School of Medicine, Winston-Salem; Peter M. Voorhees, University of North Carolina at Chapel Hill, Chapel Hill, NC; Gerard Lozanski, William Blum, Guido Marcucci, and Clara D. Bloomfield, The Ohio State University...",n/a,True
+"Leah L. Zullig, Dawn Provenzale, Morris Weinberger, and George L. Jackson, Center of Excellence for Health Services Research in Primary Care, Durham Veterans Affairs Medical Center; Dawn Provenzale and George L. Jackson, Duke University, Durham; and Leah L. Zullig, William R. Carpenter, Morris Weinberger, and Bryce B. Reeve, University of North Carolina at Chapel Hill, Chapel Hill, NC.",n/a,True
+"Timothy J. Judson and Ethan Basch, Weill Cornell Medical College; Antonia V. Bennett, Lauren J. Rogak, Laura Sit, Allison Barz, Mark G. Kris, Clifford A. Hudis, Howard I. Scher, Paul Sabattini, and Ethan Basch, Memorial Sloan-Kettering Cancer Center, New York, NY; Deborah Schrag, Dana-Farber Cancer Institute, Boston, MA; and Ethan Basch, University of North Carolina, Chapel Hill, NC.",n/a,True
+"F. Stephen Hodi, Anita Giobbie-Hurder, Philip Friedlander, Jason J. Luke, Katherine A. Zukotynski, Jeffrey T. Yap, Annick D. Van den Abbeele, and George D. Demetri, Dana-Farber Cancer Institute; Jonathan A. Fletcher, Meijun Zhu, and Adrian Marino-Enriquez, Brigham and Women's Hospital; Donald Lawrence, Keith T. Flaherty, and David E. Fisher, Massachusetts General Hospital, Boston, MA; Christopher L. Corless, Michael C. Heinrich, and Carol Beadling, Portland Veterans Administration Medical Center and...",n/a,True
+"Christina D. Williams, Karen M. Stechuchak, Leah L. Zullig, Dawn Provenzale, and Michael J. Kelley, Durham Veterans Affairs Medical Center; Dawn Provenzale and Michael J. Kelley, Duke University Medical Center, Durham; and Leah L. Zullig, University of North Carolina at Chapel Hill, Chapel Hill, NC.",n/a,True
+"University of North Carolina, Chapel Hill, NC",University of North Carolina at Chapel Hill,False
+"A. Craig Lockhart, Washington University Siteman Cancer Center, St Louis, MO; Marcia S. Brose and Lynn M. Schuchter, University of Pennsylvania Abramson Cancer Center, Philadelphia, PA; Edward S. Kim, Levine Cancer Institute, Carolinas HealthCare System, Charlotte; Jeffrey M. Peppercorn, Duke University Medical Center, Durham; W. Kimryn Rathmell, University of North Carolina Lineberger Comprehensive Cancer Center, Chapel Hill, NC; David H. Johnson, University of Texas Southwestern Medical School, Dallas,...",n/a,True
+"All authors: University of North Carolina at Chapel Hill; and Karyn B. Stitzenberg, Hanna K. Sanoff, Michael O. Meyers, and Joel E. Tepper, Lineberger Comprehensive Cancer Center, Chapel Hill, NC.",University of North Carolina at Chapel Hill,False
+"Gopa Iyer, Hikmat Al-Ahmadie, Nikolaus Schultz, Aphrothiti J. Hanrahan, Irina Ostrovnaya, Arjun V. Balar, Philip H. Kim, Oscar Lin, Nils Weinhold, Chris Sander, Emily C. Zabor, Manickam Janakiraman, Ilana R. Garcia-Grossman, Adriana Heguy, Agnes Viale, Bernard H. Bochner, Victor E. Reuter, Dean F. Bajorin, and David B. Solit, Memorial Sloan-Kettering Cancer Center; Victor E. Reuter, Dean F. Bajorin, and David B. Solit, Weill Medical College, Cornell University, New York, NY; Matthew I. Milowsky,...",n/a,True
+"Sophia K. Smith and Amy P. Abernethy, Duke University, Durham; Deborah K. Mayer, Sheryl Zimmerman, Habtamu Benecha, and Lloyd J. Edwards, University of North Carolina at Chapel Hill; Christianna S. Williams, Private Statistical Consultant, Chapel Hill, NC; Patricia A. Ganz, University of California at Los Angeles, Los Angeles, CA.",n/a,True
+"Nancy E. Thomas, Pamela A. Groben, Honglin Hao, and David W. Ollila, University of North Carolina, Chapel Hill, NC; Klaus J. Busam, Irene Orlow, Anne S. Reiner, and Colin B. Begg, Memorial Sloan-Kettering Cancer Center, New York, NY; Lynn From, Women's College Hospital, Toronto, Ontario; Richard P. Gallagher, British Columbia Cancer Research Centre, Vancouver, British Columbia, Canada; Anne Kricker and Bruce K. Armstrong, The University of Sydney, Sydney, New South Wales; Alison Venn, Menzies Research...",n/a,True
+"Matthew R. Smith, Massachusettes General Hospital; Christopher J. Sweeney, Aymen Elfiky, Dana-Farber Cancer Institute, Boston, MA; Paul G. Corn, Christopher J. Logothetis, MD Anderson Cancer Center, Houston, TX; Dana E. Rathkopf, Howard I. Scher, Sidney Kimmel Center for Prostate and Urologic Cancers, Memorial Sloan-Kettering Cancer Center and Weill Cornell Medical College, New York, NY; David C. Smith, Maha Hussain, University of Michigan, Ann Arbor, MI; Daniel J. George, Duke University Medical Center,...",n/a,True
+"Lawrence N. Shulman, Harold J. Burstein, Eric P. Winer, Dana-Farber Cancer Institute, Boston, MA; Donald A. Berry, MD Anderson Cancer Center, Houston, TX; Constance T. Cirrincione, Gretchen Kimmick, Duke University Medical Center, Durham; Hyman Muss, University of North Carolina at Chapel Hill, Chapel Hill, NC; Heather P. Becker, University of Chicago, Chicago, IL; Edith A. Perez, Mayo Clinic, Jacksonville, FL; Ruth O'Regan, Emory University, Atlanta, GA; Silvana Martino, The Angeles Clinic and Research...",n/a,True
+"Arti Hurria and Betty Ferrell, City of Hope, Duarte, CA; William Dale and Richard L. Schilsky, University of Chicago, Chicago, IL; Margaret Mooney and Julia H. Rowland, National Cancer Institute, Bethesda, MD; Karla V. Ballman, Mayo Clinic, Rochester, MN; Supriya G. Mohile, University of Rochester, Rochester, NY; Harvey J. Cohen and Kenneth E. Schmader, Duke University; Kenneth E. Schmader, Geriatric Research Education and Clinic Center, Durham Veterans Affairs Medical Center, Durham; Hyman B. Muss,...",n/a,True
+"Vanessa B. Sheppard, Leigh Anne Faul, George Luta, Jonathan D. Clapp, Judy Huei-yu Wang, Claudine Isaacs, Michelle Tallarico, and Jeanne S. Mandelblatt, Georgetown University Medical Center and Georgetown-Lombardi Comprehensive Cancer Center, Washington, DC; Rachel L. Yung and Eric P. Winer, Dana-Farber Cancer Institute, Boston, MA; Gretchen Kimmick, William T. Barry, Brandelyn N. Pitcher, and Harvey J. Cohen, Duke University Medical Center; William T. Barry and Brandelyn N. Pitcher, Cancer and Leukemia...",n/a,True
+"Dan Rosmarin, Claire Palles, David Church, Enric Domingo, Angela Jones, Ian Tomlinson, Wellcome Trust Centre for Human Genetics, NIHR Comprehensive Biomedical Research Centre, University of Oxford; Dan Rosmarin, David Church, Elaine Johnstone, Haitao Wang, Sharon Love, Patrick Julier, Claire Scudder, George Nicholson, Rachel Midgley, David Kerr, and George Nicholson, University of Oxford, Oxford; Michael Braun, The Christie NHS Foundation Trust, Manchester; Matthew Seymour, St James's University Hospital...",n/a,True
+"Joleen M. Hubbard, Mayo Clinic, Rochester, MN; Harvey J. Cohen, Duke University Medical Center, Durham; and Hyman B. Muss, University of North Carolina, Chapel Hill, NC.",n/a,True
+"All authors: Lineberger Comprehensive Cancer Center, Carolina Center for Cancer Nanotechnology Excellence, University of North Carolina at Chapel Hill, Chapel Hill, NC.",UNC Lineberger Comprehensive Cancer Center,False
+"Tait D. Shanafelt, Tim Moynihan, Daniel Satele, and Jeff Sloan, Mayo Clinic, Rochester, MN; Marilyn Raymond, American Society of Clinical Oncology, Alexandria, VA; Leora Horn, Vanderbilt University Medical Center, Nashville, TN; Frances Collichio, University of North Carolina, Chapel Hill, NC; Helen Chew, University of California, Davis, Davis; Michael P. Kosty, Scripps Clinic, San Diego, CA; and William J. Gradishar, Northwestern University, Chicago, IL.",n/a,True
+"Mark E. Sherman, Phuong L. Mai, Lori Minasian, and Mark H. Greene, National Cancer Institute, Rockville; Olga B. Ioffe, University of Maryland Medical Center; Brigitte M. Ronnett, Johns Hopkins Medical Institutions, Baltimore; Chad A. Hamilton, Walter Reed National Military Medical Center, Bethesda, MD; Marion Piedmonte, Roswell Park Cancer Institute, Buffalo; Stephanie V. Blank, New York University School of Medicine; Noah D. Kauff, Memorial Sloan Kettering Cancer Center; New York, NY; Linda Van Le,...",n/a,True
+"Michelle van Ryn and Sean M. Phelan, Mayo Clinic, Rochester; Joan M. Griffin, Veterans Affairs Medical Center; Mark W. Yeazel, University of Minnesota, Minneapolis, MN; Neeraj K. Arora and Steven B. Clauser, National Cancer Institute, Bethesda, MD; David A. Haggstrom, Roudebush Veterans Affairs Medical Center and Indiana University School of Medicine, Indianapolis, IN; George L. Jackson, Leah L. Zullig, and Dawn Provenzale, Durham Veterans Affairs Medical Center; George L. Jackson, S. Yousuf Zafar, and...",n/a,True
+"Ethan Basch, Ronald C. Chen, and Stacie B. Dusetzina, University of North Carolina, Chapel Hill; Derek Raghavan, Carolinas Health Care/Levine Cancer Institute, Charlotte, NC; D. Andrew Loblaw, Odette Cancer Centre, Sunnybrook Health Sciences Centre; Ted Wootton, Patient Representatives, Toronto; Sebastian Hotte and Cindy Walker-Dilks, McMaster University; Cindy Walker-Dilks, Cancer Care Ontario, Hamilton; Eric Winquist, London Health Sciences Centre, London, Ontario; Fred Saad, University of Montreal,...",n/a,True
+"Erin E. Kent, Sandra A. Mitchell, Kathleen M. Castro, Worta J. McCaskill-Stevens, Barnett S. Kramer, and Steven B. Clauser, National Cancer Institute, National Institutes of Health (NIH); Rachel M. Ballard, NIH Office of Disease Prevention, Bethesda, MD; Darren A. DeWalt and Arnold D. Kaluzny, University of North Carolina at Chapel Hill, Chapel Hill, NC; and Judith A. Hautala and Oren Grad, Institute for Defense Analyses Science and Technology Policy Institute, Alexandria, VA.",n/a,True
+"All authors: University of North Carolina, Chapel Hill, NC.",University of North Carolina at Chapel Hill,False
+"D. Neil Hayes, The University of North Carolina, Chapel Hill, NC; Carter Van Waes, National Institute on Deafness and Other Communication Disorders, Bethesda, MD; and Tanguy Y. Seiwert, The University of Chicago, Chicago, IL.",n/a,True
+"William M. Sikov, Miriam Hospital and Alpert Medical School of Brown University, Providence, RI; Donald A. Berry, University of Texas MD Anderson Cancer Center, Houston, TX; Charles M. Perou and Lisa A. Carey, University of North Carolina Lineberger Comprehensive Cancer Center, Chapel Hill; Constance T. Cirrincione, Alliance Statistical Center, Durham; Charles S. Kuzma, Southeast Cancer Control Consortium, Winston-Salem, NC; Baljit Singh, New York University Medical Center; Elisa R. Port, Mount Sinai...",n/a,True
+"Anita D'Souza, Mei-Jie Zhang, Jiaxing Huang, and Parameswaran Hari, Center for International Blood and Marrow Transplant Research, Medical College of Wisconsin; Mei-Jie Zhang, Institute for Health and Society, Medical College of Wisconsin, Milwaukee; Natalie S. Callander, University of Wisconsin Carbone Cancer Center, Madison, WI; Angela Dispenzieri, Morie A. Gertz, Robert A. Kyle, and Shaji Kumar, Mayo Clinic, Rochester, MN; Baldeep Wirk, Seattle Cancer Care Alliance, Seattle, WA; Raymond L. Comenzo,...",n/a,True
+"Steven M. Devine and William Blum, Ohio State University, Columbus, OH; Kouros Owzar, Flora Mulkey, Vera Hars, and Alexander B. Sibley, Alliance Statistics and Data Center, Duke University, Durham; Thomas C. Shea, University of North Carolina, Chapel Hill, NC; Richard M. Stone, Robert J. Soiffer, and Edwin P. Alyea, Dana-Farber Cancer Institute; Yi-Bin Chen, Massachusetts General Hospital, Boston, MA; Jack W. Hsu, University of Florida, Gainesville, FL; Richard E. Champlin, MD Anderson Cancer Research...",n/a,True
+"Nancy U. Lin, Hao Guo, Nicole Ryabin, Julie S. Najita, William T. Barry, Ian E. Krop, Eric P. Winer, and Annick D. Van den Abbeele, Dana-Farber Cancer Institute; Andrea L. Richardson and Annick D. Van den Abbeele, Brigham and Women's Hospital, Boston, MA; Jeffrey T. Yap, Huntsman Cancer Institute, University of Utah, Salt Lake City, UT; Ingrid A. Mayer and Carlos L. Arteaga, Vanderbilt-Ingram Cancer Center, Nashville, TN; Carla I. Falkson, University of Alabama, Birmingham, AL; Timothy J. Hobday, Mayo...",n/a,True
+"Caitlin C. Murphy, University of North Carolina at Chapel Hill, Chapel Hill, NC; and Linda C. Harlan, Joan L. Warren, Ann M. Geiger, Division of Cancer Control and Population Sciences, National Cancer Institute, Rockville, MD.",n/a,True
+"Hope S. Rugo, University of California San Francisco Helen Diller Family Comprehensive Cancer Center, San Francisco, CA; William T. Barry, Alliance Statistics and Data Center, Dana-Farber Cancer Institute; Erica L. Mayer and Eric P. Winer, Dana-Farber Cancer Institute, Boston, MA; Alvaro Moreno-Aspitia and Edith A. Perez, Mayo Clinic, Jacksonville, FL; Alan P. Lyss, Heartland Cancer Research Community Clinical Oncology Program; Michael Naughton, Washington University School of Medicine, St Louis, MO;...",n/a,True
+"Joan L. Warren, Anne-Michelle Noone, and Linda C. Harlan, National Cancer Institute, Bethesda; Jennifer Stevens, Information Management Services, Beltsville, MD; Eboneé N. Butler, University of North Carolina, Chapel Hill, NC; Christopher S. Lathan, Dana-Farber Cancer Institute, Boston, MA; and Kevin Ward, Emory University, Atlanta, GA.",n/a,True
+"Steven J. Isakoff, Lei He, Darrel R. Borger, Dianne M. Finkelstein, Paula D. Ryan, Paul E. Goss, and Leif W. Ellisen, Massachusetts General Hospital Cancer Center; Steven J. Isakoff, Erica L. Mayer, Lei He, Karen Krag, Steven E. Come, Darrel R. Borger, Dianne M. Finkelstein, Judy E. Garber, Paula D. Ryan, Eric P. Winer, Paul E. Goss, and Leif W. Ellisen, Harvard Medical School; Erica L. Mayer, Judy E. Garber, and Eric P. Winer, Dana-Farber Cancer Institute; Steven E. Come, Beth Israel Deaconess Medical...",n/a,True
+"Gary H. Lyman, Fred Hutchinson Cancer Research Center; Gary H. Lyman and Nicole M. Kuderer, University of Washington, Seattle, WA; Kari Bohlke and Mark R. Somerfield, American Society of Clinical Oncology, Alexandria, VA; Alok A. Khorana, Cleveland Clinic, Cleveland, OH; Agnes Y. Lee, University of British Columbia, Vancouver, British Columbia; Mark N. Levine, McMaster University, Hamilton, Ontario, Canada; Juan Ignacio Arcelus, Hospital Universitario Virgen de las Nieves, University of Granada, Granada,...",n/a,True
+Department of Dental Ecology; School of Dentistry; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Dental Ecology,False
+Department of Periodontology; School of Dentistry; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Periodontology,False
+Department of Epidemiology; Gillings School of Global Public Health; University of North Carolina-Chapel Hill (UNC); Chapel Hill NC USA,Department of Epidemiology,False
+Department of Pathology; University of Washington; Seattle WA USA,n/a,True
+Department of Pediatric Dentistry; School of Dentistry; University of North Carolina-Chapel Hill; Chapel Hill NC USA,Department of Pediatric Dentistry,False
+Division of Operative Dentistry; Department of Conservative Dentistry; School of Dentistry; Prince of Songkla University; Hat Yai Thailand,n/a,True
+Charleston Southern University,n/a,True
+University of Alabama,n/a,True
+"Department of Communication Studies, The University of North Carolina at Chapel Hill, NC, USA",Department of Communication,False
+"Department of Social Medicine and Center for Bioethics, The University of North Carolina at Chapel Hill, NC, USA",UNC Center for Bioethics|Department of Social Medicine,False
+Department of Dermatology; UNC School of Medicine; Chapel Hill NC USA,Department of Dermatology,False
+Department of Pathology and Laboratory Medicine; UNC School of Medicine; Chapel Hill NC USA,Department of Pathology and Laboratory Medicine,False
+Department of Surgical Oncology; UNC School of Medicine; Chapel Hill NC USA,Division of Surgical Oncology,False
+"VA Dental Longitudinal Study, VA Boston Healthcare System;",n/a,True
+"Departments of Dental Ecology,",n/a,True
+"Department of Prosthodontics,",n/a,True
+Department of Operative Dentistry and,n/a,True
+"Center for Oral and Systemic Diseases, Department of Periodontology, School of Dentistry, University of North Carolina at Chapel Hill, Room 222, CB 7455, Chapel Hill, NC, USA 27599",Department of Periodontology,False
+"Department of Orthodontics, School of Dentistry, University of Northr               Carolina at Chapel Hill, Chapel Hill, NC 27599-7450, USA;",Department of Orthodontics,False
+"Department of Biological Sciences, Bauru Dental School, University ofr               São Paulo, Al. Octávio Pinheiro Brisolla, 9-75, Bauru—SP 17012-901, São Paulo,r               Brazil;",n/a,True
+"Dept. of Pediatric Dentistry, School of Dentistry, CB #7450 Brauer Hall, UNC Chapel Hill, NC 27599, USA;",Department of Pediatric Dentistry,False
+"Center for Oral and Systemic Diseases, School of Dentistry, University of North Carolina at Chapel Hill, 4301 Research Commons, 79 TW Alexander Drive, Durham, NC 27709, USA;",School of Dentistry,False
+"University of Alabama at Birmingham, School of Dentistry, Institute of Oral Health Research, Department of Oral and Maxillofacial Surgery, 1919 7th Avenue South, Rm 702, Birmingham, AL 35294, USA",n/a,True
+"University of North Carolina, School of Dentistry, Department of Dental Research CB#7454, Chapel Hill, NC 27599-7450, USA",School of Dentistry,False
+"University of Texas Health Science Center at San Antonio Dental School, Department of Dental Diagnostic Science, 7703 Floyd Curl Drive, MCS 7888, San Antonio, TX 78229-3900, USA",n/a,True
+"Department of Mathematical Sciences, the University of Bath, UK",n/a,True
+"Department of Orthodontics, University of Maryland Dental School, 650 W. Baltimore Street, Room 6408, Baltimore, MD 21201, USA",n/a,True
+"Department of Orthodontics, the University of North Carolina at Chapel Hill, NC, USA",Department of Orthodontics,False
+"Department of Plastic and Reconstructive Surgery at the University of North Carolina School of Medicine, Chapel Hill, NC, USA",School of Medicine,False
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Department of Pediatric Dentistry,False
+"Department of Anatomy and Cell Biology, University of Pennsylvania School of Dental Medicine, 240 S. 40th Street, Philadelphia, PA 19104-6030, USA;",n/a,True
+"Australian Research Centre for Population Oral Health, School of Dentistry, The University of Adelaide, 122 Frome Street, Australia 5000",n/a,True
+"Department of Cytokine Biology, The Forsyth Institute, and Department of Developmental Biology, Harvard School of Dental Medicine, Boston, MA 02115, USA ",n/a,True
+"Department of Cytokine Biology, The Forsyth Institute, and Department of Developmental Biology, Harvard School of Dental Medicine, Boston, MA 02115, USA    jbartlett@forsyth.org",n/a,True
+"Department of Oral Biology and Maxillofacial Pathology, Medical College of Georgia, Augusta, GA, USA ",n/a,True
+"Department of Pediatric Dentistry and The Carolina Center for Genome Sciences, University of North Carolina, Chapel Hill, NC, USA ",Carolina Center for Genome Sciences|Department of Pediatric Dentistry,False
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina at Chapel Hill, 228 Brauer Hall, CB# 7450, Chapel Hill, NC 27599, USA",Department of Pediatric Dentistry,False
+"Department of Oral Pathology, University of North Carolina at Chapel Hill, NC 27599, USA",School of Dentistry,False
+"Department of Pathology, University of Alabama at Birmingham",n/a,True
+"Department of Pediatric Dentistry, CB #7450",Department of Pediatric Dentistry,False
+"Department of Microbiology and Immunology, School of Medicine; University of North Carolina, Chapel Hill, NC, USA",Department of Microbiology and Immunology,False
+"North Carolina Oral Health Institute, School of Dentistry; University of North Carolina, Chapel Hill, NC, USA",School of Dentistry,False
+"Delta Site, Oral Health Center, Westborough, MA 01581, USA",n/a,True
+"Indiana University School of Dentistry and the Regenstrief Institute, Indianapolis, IN 46202, USA",n/a,True
+"Kaiser Permanente Center for Health Research, 3800 North Interstate Avenue, Portland, OR 97227, USA",n/a,True
+"Kaiser Permanente Dental Associates, Portland, OR 97227, USA",n/a,True
+"Tufts University School of Dental Medicine, Boston, MA 02111, USA",n/a,True
+"University of North Carolina School of Dentistry, Chapel Hill, NC 27599-7450, USA",School of Dentistry,False
+"Center for Neurosensory Disorders, University of North Carolina, Chapel Hill, NC 27599, USA",Center for Pain Research and Innovation,False
+"Department of Anesthesiology and Neurobiology, University of Utah, Salt Lake City, UT, USA",n/a,True
+"Department of Cell and Molecular Physiology, University of North Carolina, Chapel Hill, NC, USA",Department of Cell and Molecular Physiology,False
+"Department of Oral Physiology, School of Dentistry, Kyungpook National University, 188-1 Sam Deok 2ga, Chung-gu, Daegu, Korea",n/a,True
+"Institute of Biomedicine, Physiology, University of Eastern Finland, Kuopio, Finland; Daegu (700-412)",n/a,True
+"Department of Dental Ecology, School of Dentistry, University of North Carolina-Chapel Hill, NC, USA",Department of Dental Ecology,False
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina-Chapel Hill, NC, USA",Department of Epidemiology,False
+"Department of Genetics, School of Medicine, University of North Carolina-Chapel Hill, NC, USA",Department of Genetics,False
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina-Chapel Hill, 228 Brauer Hall, CB#7450, NC 27599, USA",Department of Pediatric Dentistry,False
+"Department of Periodontology, School of Dentistry, University of North Carolina-Chapel Hill, NC, USA",Department of Periodontology,False
+"Center for Oral and Systemic Diseases, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",School of Dentistry,False
+"Department of Periodontology and School of Dentistry, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Periodontology,False
+"Center for Neurosensory Disorders, University of North Carolina, Chapel Hill, NC",Center for Pain Research and Innovation,False
+"Chronic Pain and Fatigue Research Center, University of Michigan, Ann Arbor, MI",n/a,True
+"Department of Biologic and Materials Sciences, School of Dentistry, 1011 N. University Ave., University of Michigan, Ann Arbor, MI",n/a,True
+"Department of Biologic and Materials Sciences, School of Dentistry, 1011 N. University Ave., University of Michigan, Ann Arbor, MI 48109-1078, USA",n/a,True
+"Department of Diagnostic Radiology, Clinical Sciences/Lund, University of Lund, Lund, Sweden",n/a,True
+"Department of Restorative Dentistry, School of Dentistry, University of Detroit Mercy, Detroit, MI",n/a,True
+"Center for Health Promotion and Disease Prevention, University of North Carolina-Chapel Hill",UNC Center for Health Promotion and Disease Prevention,False
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina-Chapel Hill",Department of Pediatric Dentistry,False
+"Department of Dental Ecology, School of Dentistry, University of North Carolina at Chapel Hill, USA",Department of Dental Ecology,False
+"Department of Epidemiology, Gillings School of Global Public Health, University of North, Carolina at Chapel Hill, USA",Department of Epidemiology,False
+"Department of Neurology, Johns Hopkins Hospital, Baltimore, MD, USA",n/a,True
+"Division of Epidemiology and Community Health, School of Public Health, University of Minnesota, Minneapolis, USA",n/a,True
+"Division of Geriatrics, University of Mississippi Medical Center, Jackson, USA",n/a,True
+"Department of Anatomy and Cell Biology, University of Pennsylvania School of Dental Medicine, 240 S. 40th Street, Philadelphia, PA 19104-6030, USA",n/a,True
+"Department of Mineralized Tissue Biology, Forsyth Institute, and Department of Developmental Biology, Harvard School of Dental Medicine, 245 First Street, Cambridge, MA 02142, USA",n/a,True
+"Functional Genomics Section, Laboratory of Cell and Developmental Biology, National Institute of Dental and Craniofacial Research, NIH, Bethesda, MD 20892, USA",n/a,True
+"Pediatric Dentistry, University of North Carolina, School of Dentistry, CB#7450, Chapel Hill, NC 27599-7450, USA",Department of Pediatric Dentistry,False
+"Battelle Memorial Institute, Durham, NC, USA",n/a,True
+"Department of Oral Diagnostic Sciences, University of Buffalo, USA",n/a,True
+"School of Global Public Health, University of North Carolina at Chapel Hill, Gillings, Chapel Hill, NC, USA",Gillings School of Global Public Health,False
+University of Florida College of Dentistry,n/a,True
+"University of Maryland, Baltimore, MD, USA",n/a,True
+"University of North Carolina at Chapel Hill, Koury Oral Health Sciences Building, 385 South Columbia Street, Chapel Hill, NC 27599-7450, USA",School of Dentistry,False
+Kaiser Permanente Center for Health Research,n/a,True
+"University of North Carolina, School of Dentistry, 441 Brauer Hall, Chapel Hill, NC 27599-7450, USA",School of Dentistry,False
+University of Texas Health Science Center at San Antonio,n/a,True
+"Department of Periodontology at the UNC School of Dentistry, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Department of Periodontology,False
+"Department of Dental Ecology, School of Dentistry, University of North Carolina, Chapel Hill, NC, USA",Department of Dental Ecology,False
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC, USA",Department of Epidemiology,False
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina, Chapel Hill, NC, USA",Department of Pediatric Dentistry,False
+"Department of Periodontology, School of Dentistry, University of North Carolina, Chapel Hill, NC, USA",Department of Periodontology,False
+"Department of Health Policy and Management, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Health Policy and Management,False
+"Oral Health Section, Division of Public Health, North Carolina Department of Health and Human Services, Raleigh, NC, USA",n/a,True
+"Center for Craniofacial and Dental Genetics, Department of Oral Biology, School of Dental Medicine, University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"Department of Oral Health Sciences, University of Washington, Seattle, WA, USA",n/a,True
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina–Chapel Hill, Chapel Hill, NC, USA",Department of Pediatric Dentistry,False
+"Division of Pediatric Dentistry and Community Oral Health, The Ohio State University College of Dentistry, Columbus, OH, USA",n/a,True
+"Center to Address Disparities in Children’s Oral Health, School of Dentistry, University of California, San Francisco, USA",n/a,True
+"Department of Orthodontics, School of Dentistry, University of North Carolina at Chapel Hill",Department of Orthodontics,False
+"Department of Pediatric Dentistry, School of Dentistry, University of North Carolina at Chapel Hill",Department of Pediatric Dentistry,False
+"Department of Pharmacology, School of Medicine, University of North Carolina at Chapel Hill",Department of Pharmacology,False
+"Department of Dental Ecology, University of North Carolina at Chapel Hill, USA",Department of Dental Ecology,False
+"Department of Oral Medicine, School of Dental Medicine, University of Pennsylvania, Philadelphia, PA, USA",n/a,True
+"Department of Pediatric Dentistry, School of Dentistry, The University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Department of Pediatric Dentistry,False
+"National Institute for Arthritis and Musculoskeletal and Skin Diseases, National Institutes of Health, Bethesda, MD 20892, USA",n/a,True
+"National Institute of Child Health and Human Development, National Institutes of Health, Bethesda, MD 20892, USA",n/a,True
+"Office of Clinical Director, National Institute of Dental and Craniofacial Research, National Institutes of Health, Bethesda, MD, USA",n/a,True
+"Skeletal Clinical Studies Unit, Craniofacial and Skeletal Diseases Branch, National Institute of Dental and Craniofacial Research, National Institutes of Health, Bethesda, MD, USA",n/a,True
+"Department of Orthodontics, The University of North Carolina at Chapel Hill",Department of Orthodontics,False
+"North Carolina Oral Health Institute, The University of North Carolina at Chapel Hill, USA",School of Dentistry,False
+"The University of North Carolina at Chapel Hill - Department of Pediatric Dentistry, 228 Brauer Hall, Chapel Hill, North Carolina 27599, USA",Department of Pediatric Dentistry,False
+"Allan Edwards Centre for Research on Pain, McGill University, Montreal, Quebec, Canada",n/a,True
+"Center for Pain Research and Innovation, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Center for Pain Research and Innovation,False
+"Department of Community Dentistry &amp; Behavioral Science, University of Florida, Gainesville, FL, USA",n/a,True
+"Department of Neural and Pain Sciences, University of Maryland School of Dentistry, Baltimore, MD, USA",n/a,True
+"Department of Oral Diagnostic Sciences, University at Buffalo, Buffalo, NY, USA",n/a,True
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Chemistry,False
+"Center for Oral and Systemic Diseases and Department of Dental Ecology, University of North Carolina at Chapel Hill, School of Dentistry, Chapel Hill, NC, USA",Department of Dental Ecology,False
+"Center for Oral and Systemic Diseases and Department of Periodontology, University of North Carolina at Chapel Hill, School of Dentistry, Chapel Hill, NC, USA",Department of Periodontology,False
+"Bon Secours Pediatric Dental Associates, Richmond, VA, USA",n/a,True
+"Department of Pediatric Dentistry, School of Dentistry, The University of North Carolina, Chapel Hill, NC, USA",Department of Pediatric Dentistry,False
+"Meharry School of Dentistry, Nashville, TN, USA",n/a,True
+"Center of Research in Childhood Health, Department of Sport Sciences and Clinical Biomechanics, University of Southern Denmark, Campusvej 55, 5230 Odense M, Denmark",n/a,True
+"Department of Exercise and Sport Science, University of North Carolina, 025 Fetzer Gym, CB No. 8700, Chapel Hill, NC 27599-8700, USA",Department of Exercise and Sport Science,False
+"Department of Sports Medicine, Norwegian School of Sport Sciences, Sognsveien 220, 0806 Oslo, Norway",n/a,True
+"Epidemiology, Biostatistics and Prevention Institute, University of Zürich, Hirschengraben 84, 8001 Zürich, Switzerland",n/a,True
+"Exercise and Health Laboratory, CIPER, Fac Motricidade Humana, Universidade de Lisboa, Estrada Dacosth, Cruz-Quebrada, 1499 Lisbon, Portugal",n/a,True
+"School of Physical Education, University of Pernambuco, Campus Universitario HUOC-ESEF, Arnobio Marques 310, Santo Amaro, 50.100-130 Recife, PE, Brazil",n/a,True
+"College of Arts and Sciences, University of North Carolina at Chapel Hill, Chapel Hill, NC 27514, USA",College of Arts and Sciences,False
+"Department of Nephrology, Advanced Institute for Medical Sciences, Second Hospital, Dalian Medical University, Dalian 116023, China",n/a,True
+"Department of Preventive Medicine, Institute for Prevention Research University of Southern California",n/a,True
+"Pacific Institute for Research and Evaluation, Chapel Hill, North Carolina",n/a,True
+"National Cancer Institute, Rockville, MD, USA",n/a,True
+"Independent Consultant, Lilongwe, Malawi",n/a,True
+Family Health International (USA),n/a,True
+Kamuzu Central Hospital in Lilongwe (Malawi),n/a,True
+University of North Carolina at Chapel Hill (USA),University of North Carolina at Chapel Hill,False
+Cleveland Clinic Foundation,n/a,True
+Vanderbilt University Medical Center,n/a,True
+Wake Forest University School of Medicine,n/a,True
+Case Western Reserve University,n/a,True
+Fordham University,n/a,True
+Loyola University Chicago,n/a,True
+Saint Louis University,n/a,True
+The Rockefeller University,n/a,True
+University of Chicago,n/a,True
+Vanderbilt University,n/a,True
+Virginia Commonwealth University,n/a,True
+"RTI International, Research Triangle Park, Durham, NC, USA",n/a,True
+"FPG Child Development Institute, The University of North Carolina, Chapel Hill, ",Frank Porter Graham Child Development Institute,False
+"The Pennsylvania State University, University Park",n/a,True
+University of Nebraska-Lincoln,n/a,True
+"University of North Carolina at Chapel Hill, NC, USA, ",University of North Carolina at Chapel Hill,False
+"Lehman College, City University of New York, Bronx, NY, USA",n/a,True
+"WESTAT, Rockville, MD, USA",n/a,True
+"University of California–Los Angeles, CA, USA",n/a,True
+"University of North Carolina–Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"University of Texas–Austin, TX, USA",n/a,True
+University of Illinois at Chicago College of Nursing,n/a,True
+"University of North Carolina Chapel Hill School of Nursing,r",School of Nursing,False
+University of Pennsylvania School of Nursing,n/a,True
+Oregon Health &amp; Science University,n/a,True
+University of Illinois at Chicago,n/a,True
+"University of North Carolina at Chapel Hill, ",University of North Carolina at Chapel Hill,False
+University of Pennsylvania,n/a,True
+Yale University,n/a,True
+"University of Tennessee, Knoxville",n/a,True
+School of Nursing University of North Carolina at Chapel Hill,School of Nursing,False
+Department of Medicine; Division of Gastroenterology and Hepatology; University of North Carolina; Chapel Hill; North Carolina; USA,Division of Gastroenterology and Hepatology,False
+Department of Nutrition; University of North Carolina; Chapel Hill; North Carolina; USA,Department of Nutrition,False
+Department of Microbiology and Immunology; Lineberger Comprehensive Cancer Center; School of Medicine; The University of North Carolina; Chapel Hill; North Carolina; USA,UNC Lineberger Comprehensive Cancer Center|Department of Microbiology and Immunology,False
+"Division of Gynecologic Oncology, Department of Obstetrics and Gynecology, University of North Carolina, Chapel Hill, NC, USA.",Department of Obstetrics and Gynecology,False
+"Division of Reproductive Endocrinology and Infertility, Department of Obstetrics and Gynecology, University of North Carolina, Chapel Hill, NC, USA.",Department of Obstetrics and Gynecology,False
+"David Warner is a postdoctoral scholar in the Carolina Population Center at the University of North Carolina at Chapel Hill. His research interests broadly center on the role of marriage and family in shaping work and health across the life course, with an emphasis on gender and race-ethnicity differentials. He is currently involved in projects examining marriage differences in work and retirement behavior and family-of-origin influences on the development of health-risk behaviors among young adults.",Carolina Population Center,False
+"Mark D. Hayward is Professor of Sociology and Director of the Population Research Center at the University of Texas, Austin. His research agenda focuses on racial/ethnic and socioeconomic stratification in adult health and mortality. Currently, his work concentrates on the influence of socioeconomic and family conditions across the life course on adult health.",n/a,True
+"Carolina Population Center and Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Carolina Population Center|UNC Lineberger Comprehensive Cancer Center,False
+"Department of Sociology and Center on Aging at National Opinion Research Center, University of Chicago, Chicago, IL, USA",n/a,True
+"Department of Sociology, Lineberger Comprehensive Cancer Center, and Carolina Population Center, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",UNC Lineberger Comprehensive Cancer Center|Department of Sociology|Carolina Population Center,False
+"Institute for Mind and Biology and Departments of Comparative Human Development and Psychology, University of Chicago, Chicago, IL, USA",n/a,True
+"University of North Carolina, ",University of North Carolina at Chapel Hill,False
+"Hackensack University Medical Center, USA",n/a,True
+"Indiana University-Purdue University Indianapolis, USA",n/a,True
+"Mount Sinai School of Medicine, USA",n/a,True
+"Temple University, USA",n/a,True
+"William Paterson University, USA",n/a,True
+"University of North Carolina, USA",University of North Carolina at Chapel Hill,False
+"Duke University Medical Center, Durham;",n/a,True
+"Health Services Research &amp; Development Service, Durham Veterans Affairs Medical Center, Durham",n/a,True
+"University of North Carolina at Chapel Hill School of Nursing, Chapel Hill, North Carolina, USA",School of Nursing,False
+"Translational Pathology Laboratory (NNF, SMC, BM, MO, CRM), University of North Carolina School of Medicine, NC, USA",Translational Pathology Laboratory,False
+Division of General Internal Medicine; Medical College of Wisconsin; Milwaukee Wisconsin,n/a,True
+Division of General Internal Medicine; University of Minnesota; Minneapolis Minnesota,n/a,True
+Division of General Medicine and Epidemiology; University of North Carolina; Chapel Hill North Carolina,Division of General Medicine and Clinical Epidemiology,False
+Division of Pulmonary; Critical Care; and Sleep Medicine; North Shore/LIJ Medical Center; New Hyde Park New York,n/a,True
+Section of Hospital Medicine; South Texas Veterans Health Care System and University of Texas Health Science Center; San Antonio Texas,n/a,True
+Section of Pulmonary and Critical Care Medicine; South Texas Veterans Health Care System and University of Texas Health Science Center; San Antonio Texas,n/a,True
+"Carolina Population Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Carolina Population Center,False
+"Department of Epidemiology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Epidemiology,False
+"National Children’s Study, Eunice Kennedy Shriver National Institute of Child Health and Human Development, Bethesda, Maryland",n/a,True
+"Durham University, Durham, UK",n/a,True
+"School of Dentistry, University of Alberta, 7020 Katz Group Centre, Edmonton, AB, Canada T6G 2R3",n/a,True
+"Theralogics, Inc., 1829 E. Franklin Street, Chapel Hill, NC 27514-5861, USA",n/a,True
+"Duke University Health Systems, Durham, NC, USA",n/a,True
+"University of North Carolina at Greensboro, Greensboro, NC, USA",n/a,True
+"Wake Forest University Baptist Medical Center, Winston-Salem, NC, USA",n/a,True
+Department of Pediatrics; Division of Medical Genetics; Duke University Medical Center; Durham NC USA,n/a,True
+Department of Psychiatry and The Carolina Institute for Developmental Disabilities; University of North Carolina School of Medicine; Chapel Hill NC USA,Carolina Institute for Developmental Disabilities|Department of Psychiatry,False
+Department of Psychology & Neuroscience; Duke University; Durham NC USA,n/a,True
+Frank Porter Graham Child Development Institute; The University of North Carolina; Chapel Hill North Carolina USA,Frank Porter Graham Child Development Institute,False
+Roxelyn and Richard Pepper Department of Communication Sciences and Disorders; Northwestern University; Evanston Illinois USA,n/a,True
+Abarbanel Mental Health Center; Bat Yam Israel,n/a,True
+Duke University Medical Center; Division of Medical Genetics; Durham NC USA,n/a,True
+Sheba Medical Center; Behavioral Neurogenetics Center; Child Psychiatry Unit; Edmond and Lily Safra Children's Hospital; Ramat Gan Israel,n/a,True
+University of Newcastle; School of Psychology; Ourimbah NSW Australia,n/a,True
+University of North Carolina School of Medicine; Department of Allied Health Sciences; Chapel Hill NC USA,Department of Allied Health Sciences,False
+Department of Allied Health Sciences; University of North Carolina at Chapel Hill; Chapel Hill North Carolina USA,Department of Allied Health Sciences,False
+Department of Pediatrics; Duke University Medical Center; Durham North Carolina USA,n/a,True
+Department of Psychiatry; Harvard Medical School; Boston Massachusetts USA,n/a,True
+School of Social Work and Psychiatry; University of Pittsburgh; Pittsburgh Pennsylvania USA,n/a,True
+"School of Social Work and Harborview Injury Prevention and Research Center affiliate, University of Washington, ",n/a,True
+"School of Social Work, University of North Carolina at Chapel Hill",School of Social Work,False
+University of North Carolina at Chapel Hill Gillings School of Global Public Health,Gillings School of Global Public Health,False
+"University of North Carolina at Chapel Hill Gillings School of Global Public Health, ",Gillings School of Global Public Health,False
+"Florida State University, Tallahassee",n/a,True
+"Iowa State University, Ames",n/a,True
+"Saint Louis University, St. Louis, MO",n/a,True
+"University of Washington, Seattle",n/a,True
+"University of Washington, Seattle, ",n/a,True
+"ICDDR, B: Center for Health and Population Research, Dhaka, Bangladesh",n/a,True
+"Department of Maternal and Child Health, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Maternal and Child Health,False
+"Nelson R Mandela School of Medicine, Durban, KwaZuluNatal, South Africa",n/a,True
+"Stellenbosch University, Stellenbosch, Western Cape, South Africa",n/a,True
+"Department of Human Development and Family Studies and Department of Statistics, Purdue University",n/a,True
+"Gillings School of Global Public Health, University of North Carolina at Chapel Hill",Gillings School of Global Public Health,False
+"Pacific Institute for Research and Evaluation, Chapel Hill, NC, USA",n/a,True
+"Department of Internal Medicine, College of Medicine, The Catholic University of Korea, Seoul, Korea.",n/a,True
+"Department of Anesthesiology and Pain Medicine, College of Medicine, Yeungnam University, Daegu, Korea.",n/a,True
+"Department of Anesthesiology, Pureun Hospital, Daegu, Korea.",n/a,True
+"Department of Anesthesiology, University of North Carolina, Chapel Hill, North Carolina, USA.",Department of Anesthesiology,False
+"Department of Physiology1, School of Medicine, Keimyung University, Daegu, Korea.",n/a,True
+"Institute of Cardiovascular Research, Pusan National University Yangsan Hospital, Yangsan, Korea.",n/a,True
+"Department of Pediatrics, College of Medicine, Korea University, Seoul, Korea.",n/a,True
+"Department of Pediatrics, Inje College of Medicine, Seoul, Korea.",n/a,True
+"International Vaccine Institute, Seoul, Korea.",n/a,True
+Johns Hopkins University,n/a,True
+Centers for Disease Control and Prevention,n/a,True
+University of North Carolina at Greensboro,n/a,True
+North Carolina Oral Health Institute,n/a,True
+Australian Institute for Bioengineering and Nanotechnology,n/a,True
+College of Pharmacy,n/a,True
+Department of Materials Science and Engineering,n/a,True
+SEAC-ME Key Laboratory of Biotechnology and Bio-resources Utilization,n/a,True
+State Key Laboratory of Fine Chemicals,n/a,True
+"Department of Health Behavior, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Health Behavior,False
+"Department of Health Behavior, Gillings School of Global Public Health, University of North Carolina; Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Health Behavior|UNC Lineberger Comprehensive Cancer Center,False
+"Gillings School of Global Public Health, University of North Carolina; Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, North Carolina, USA",UNC Lineberger Comprehensive Cancer Center|Gillings School of Global Public Health,False
+"National Cancer Institute, Division of Cancer Control and Population Sciences, Rockville, Maryland, USA",n/a,True
+Department of Psychiatry; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599-7305,Department of Psychiatry,False
+"Laboratory of Immunopathogenesis and Bioinformatics; SAIC-Frederick, Inc., National Cancer Institute at Frederick; Frederick Maryland 21702",n/a,True
+"Laboratory of Immunoregulation, National Institute of Allergy, Infectious Diseases; National Institutes of Health; Bethesda Maryland 20892",n/a,True
+Adult Infectious Diseases Centre; University Teaching Hospital; Lusaka Zambia,n/a,True
+Centre for Infectious Disease Research Zambia; Lusaka; Zambia,n/a,True
+School of Medicine; University of Alabama at Birmingham; Alabama,n/a,True
+"Department of Surgery, Duke University Medical Center, Durham, North Carolinar27710, United States",n/a,True
+"Natural Products ResearchrLaboratories,rUNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599, UnitedrStates",Eshelman School of Pharmacy,False
+"Chinese Medicine Research and DevelopmentrCenter, China Medical University and Hospital, Taichung 404, Taiwan",n/a,True
+"Institute of Biomedical Sciences,rAcademia Sinica, Taipei, Taiwan",n/a,True
+"Cell and DevelopmentalrBiology,rSchool of Medicine, University of North Carolina, Chapel Hill, North Carolina 27599-7090, United States",Department of Cell Biology and Physiology,False
+"Division of Chemical Biology &amp;rMedicinal Chemistry, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolinar27599-7568, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"Natural Products ResearchrLaboratories,rUNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599-7568, UnitedrStates",Eshelman School of Pharmacy,False
+"Division of Medicinal Chemistryrand Natural Products, School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, NorthrCarolina 27599, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"National Institute of MentalrHealth Psychoactive Drug Screening Program, Department of Pharmacology,rSchool of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",NIMH Psychoactive Drug Screening Program,False
+"Beijing Institute of Pharmacology and Toxicology, 27 Tai-Ping Road, Beijing,r100850, China",n/a,True
+"Natural Products Research Laboratories,rUNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599-7568, UnitedrStates",Eshelman School of Pharmacy,False
+"SurgicalrOncology Research Facility, Duke University Medical Center, Box 2926, Durham, NorthrCarolina 27710, United States",n/a,True
+"BeiGene (Beijing) Co., Ltd.,rNo. 30 Science Park Road, Zhongguancun Life Science Park, Beijingr102206, China",n/a,True
+"Department of Pharmacology andrDivision of Medicinal Chemistry and Natural Products, The Universityrof North Carolina, Chapel Hill, North Carolina 27759, United States",Division of Chemical Biology and Medicinal Chemistry|Department of Pharmacology,False
+"Departmentrof PharmaceuticalrSciences, Howard University, Washington, D.C. 20059, United States",n/a,True
+"National Instituterof BiologicalrSciences, Beijing, No. 7 Science Park Road, Zhongguancun Life SciencerPark, Beijing 102206, China",n/a,True
+"Center for Integrative ChemicalrBiology and Drug Discovery, Division of Chemical Biology and MedicinalrChemistry, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599, United States",Center for Integrative Chemical Biology and Drug Discovery|Division of Chemical Biology and Medicinal Chemistry,False
+"Departmentrof Cell and MolecularrPhysiology, UNC Neuroscience Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599, United States",Department of Cell and Molecular Physiology|UNC Neuroscience Center,False
+"Departmentrof Pharmacology, University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",Department of Pharmacology,False
+"Departmentrof Biochemistry andrBiophysics and Lineberger Comprehensive Cancer Center, The University of North Carolina, Chapel Hill, NorthrCarolina 27599-7260, United States",Department of Biochemistry and Biophysics|UNC Lineberger Comprehensive Cancer Center,False
+"School of Chemistry and ChemicalrEngineering, Sun Yat-Sen University, Guangzhour510275, People's Republic of China",n/a,True
+"School of Pharmaceutical Sciences, Sun Yat-sen University, Guangzhou 510006, People'srRepublic of China",n/a,True
+"Center for Combinatorial Chemistryrand Drug Discovery, Jilin University, Changchun, Jilin 130012, China",n/a,True
+"Center for Integrative ChemicalrBiology and Drug Discovery, Division of Chemical Biology and MedicinalrChemistry, UNC Eshelman School of Pharmacy, University of North Carolinarat Chapel Hill, Chapel Hill, North Carolina 27599, United States",Center for Integrative Chemical Biology and Drug Discovery|Division of Chemical Biology and Medicinal Chemistry,False
+"Department of Pharmacology andrNational Institute of Mental Health Psychoactive Drug Screening Program,rSchool of Medicine, University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",NIMH Psychoactive Drug Screening Program,False
+"Departments of Psychiatry andrBehavioral Sciences, Cell Biology, and Neurobiology, Duke UniversityrMedical Center, Durham, North Carolina 27710, United States",n/a,True
+"Divisionrof Chemical Biology and Medicinal Chemistry, UNC Eshelman School ofrPharmacy and ⊥Department of Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599, UnitedrStates",Division of Chemical Biology and Medicinal Chemistry,False
+"Centerrfor Organic and Medicinal Chemistry, Research Triangle Institute, P.O. Box 12194, Research Triangle Park, North Carolina 27709, United States",n/a,True
+"NationalrInstitute of Mental Health Psychoactive Drug Screening Program, Departmentrof Pharmacology and Division of Chemical Biology and Medicinal Chemistry, University of North Carolina Chapel Hill Medical School, 4072 Genetic Medicine Building, Chapel Hill, North Carolina 27599, United States",NIMH Psychoactive Drug Screening Program|Division of Chemical Biology and Medicinal Chemistry,False
+"Department of PharmaceuticalrChemistry, University of California San Francisco, San Francisco, California, United States, 94158-2550",n/a,True
+"Department of Pharmacology andrthe NIMH Psychoactive Drug Screening Program, University of North Carolina Chapel Hill School of Medicine, ChapelrHill, North Carolina, United States, 27759",NIMH Psychoactive Drug Screening Program,False
+"Department of Pediatrics, School of Medicine, University of Colorado Denver , Anschutz Medical Campus, Aurora, Colorado 80045, United States",n/a,True
+"Department of Biochemistry andrBiophysics, University of North Carolina, Chapel Hill, North Carolina, United States",Department of Biochemistry and Biophysics,False
+"Department of Biochemistry, Nycomed GmbH, Konstanz, Germany",n/a,True
+"Division of Medicinal Chemistry,rFaculty of Sciences, Amsterdam Institute of Molecules, Medicines andrSystems (AIMMS), VU University Amsterdam, Amsterdam, The Netherlands",n/a,True
+"IOTA Pharmaceuticals, St. John’s Innovation Centre, Cowley Road, CambridgerCB4 0WS, United Kingdom",n/a,True
+"Institute of Cell Biology, University of Bern, Baltzerstrasse 4, 3012 Bern, Switzerland",n/a,True
+"Natural Products Research Laboratories,rUNC Eshelman School of Pharmacy, University of North Carolina, ChapelrHill, North Carolina 27599-7568, United States",Eshelman School of Pharmacy,False
+"State Key Laboratory of Bioorganicrand Natural Products Chemistry, EISU Chemical Biology Division, ShanghairInstitute of Organic Chemistry, Chinese Academy of Sciences, Shanghair200032, China",n/a,True
+"State Key Laboratory of Phytochemistryrand Plant Resources in West China, Kunming Institute of Botany, ChineserAcademy of Sciences, Kunming 650204, China",n/a,True
+"Center forrIntegrative ChemicalrBiology and Drug Discovery, Division of Chemical Biology and MedicinalrChemistry, UNC Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, NorthrCarolina 27599, United States",n/a,True
+"Structural Genomics Consortium, University of Toronto, Toronto, Ontario M5G 1L7, Canada",n/a,True
+"NaturalrProducts Research Laboratories,rEshelman School of Pharmacy, University of North Carolina, ChapelrHill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"Surgical Science, Departmentrof Surgery, Duke University Medical Center, Durham, North Carolinar27710, United States",n/a,True
+"Department of Pediatrics, School of Medicine, University of Colorado Denver, AnschutzrMedical Campus, Aurora, Colorado 80045, United States",n/a,True
+"Departmentrof Pharmacology, University of North Carolina, School of Medicine, Chapel Hill, North Carolina 27599 United States",Department of Pharmacology,False
+"MolecularrRecognition Section, Laboratory of Bioorganic Chemistry, National Institute of Diabetes and Digestive and Kidney Diseases, National Institutes of Health, Bethesda, Maryland 20892 United States",n/a,True
+"ChineserMedicine Research and Development Center, China Medical University and Hospital, Taichung, Taiwan",n/a,True
+"Departmentrof Chemistry, National Cheng-Kung University, Tainan 701, Taiwan",n/a,True
+"Departmentrof Pharmacology, China Medical University, Taichung 404, Taiwan",n/a,True
+"Departmentrof Pharmacy and Graduate Institute of Pharmaceutical Technology, Tajen University, Pingtung 907, Taiwan",n/a,True
+"Environmentalrand Municipal Engineering School, Lanzhou Jiaotong University, Lanzhou 730000, PR China",n/a,True
+"GraduaterInstitute of Pharmaceutical Chemistry, China Medical University, Taichung 40402, Taiwan",n/a,True
+"NaturalrProducts Research Laboratories, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"Ph.D.rProgram for Cancer Biology and Drug Discovery, College of MedicalrScience and Technology, Taipei Medical University, Taipei 11031, Taiwan",n/a,True
+"PharmacologicalrInstitute, College of Medicine, National Taiwan University, Taipei 10051, Taiwan",n/a,True
+"Schoolrof Pharmacy, Lanzhou University, Lanzhou 730000, PR China",n/a,True
+"Departmentsrof Psychiatry, Neurology, and Veterans Affairs, University of Iowa Carver College of Medicine, 200 Hawkins Avenue, IowarCity, Iowa 52242, United States",n/a,True
+"NationalrInstitute of Mental Health Psychoactive Drug Screening Program, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",NIMH Psychoactive Drug Screening Program,False
+"Department of Biochemistry and Biophysics and LinebergerrComprehensive Cancer Center, The University of North Carolina, Chapel Hill, North Carolina 27599-7260, United States",Department of Biochemistry and Biophysics|UNC Lineberger Comprehensive Cancer Center,False
+"School of Chemistry and Chemical Engineering, Sun Yat-Sen University, Guangzhou 510275, P. R. China",n/a,True
+"School of PharmaceuticalrSciences, Sun Yat-Sen University, Guangzhou 510006, P. R. China",n/a,True
+"StructuralrGenomics Consortium, University of Toronto, Toronto, Ontario M5G 1L7, Canada",n/a,True
+"Beijing Institute of Pharmacology and Toxicology, 27 Tai-Ping Road, Beijing 100850, China",n/a,True
+"Beijing Institute of Radiation Medicine, 27 Tai-Ping Road, Beijing 100850, China",n/a,True
+"NaturalrProducts Research Laboratories, UNC Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"ScreeningrTechnologies Branch, Developmental Therapeutics Program, Divisionrof Cancer Treatment and Diagnosis, National Cancer Institute, Frederick National Laboratory for Cancer Research, National Institutes of Health, Frederick, Maryland 21702, United States",n/a,True
+"Altamira LLC, Columbus, Ohio 43235, United States",n/a,True
+"Department of Chemistry, L. Pasteur University of Strasbourg, Strasbourg, 67000, France",n/a,True
+"Department of Molecular Structure and Cheminformatics, A. V. Bogatsky Physical-Chemical Institute, National Academy of Sciences of Ukraine, Odessa, 65080, Ukraine",n/a,True
+"Department of Structural and Functional Biology, University of Insubria, Varese, 21100, Italy",n/a,True
+"Departmentrof Physics, Lomonosov Moscow State University, Moscow, 119991, Russia",n/a,True
+"Environment and Health Department, Istituto Superiore di Sanità, Rome, 00161, Italy",n/a,True
+"Laboratoryrfor Molecular Modeling, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"Martin Consulting, Waukegan, Illinois 60079, United States",n/a,True
+"Milano Chemometrics and QSAR Research Group, University of Milano-Bicocca, Milan, 20126, Italy",n/a,True
+"Molecular Networks GmbH, 91052 Erlangen, Germany",n/a,True
+"National Center for Computational Toxicology, U.S. Environmental Protection Agency, Research Triangle Park, North Carolina 27519, United States",n/a,True
+"School of Pharmacy and Biomolecular Sciences, Liverpool John Moores University, Liverpool L33AF, U.K.",n/a,True
+"Tripos, Inc., St.rLouis, Missouri 63144, United States",n/a,True
+"Vancouver ProstaterCentre, University of British Columbia, Vancouver, British Columbia, V6H3Z6, Canada",n/a,True
+"Departmentrof Pharmacology, College of Medicine, University of Arizona, Tucson, Arizona 85742, United States",n/a,True
+"NeuroGate Therapeutics, Inc., 150rFayetteville Street, Suite 2300, Raleigh, North Carolina 27601, United States",n/a,True
+"Departmentrof Microbiology, University of Washington, Seattle, Washington 98195, United States",n/a,True
+"Departmentrof Molecular and Cellular Biology, School of Medicine, Chang Gung University, Kwei-San, Tao-Yuan, Taiwan",n/a,True
+"Departmentrof Respiratory Therapy, Fu-Jen Catholic University, New Taipei, Taiwan",n/a,True
+"Graduate Institute of Biochemistry and Molecular Biology, Collegerof Medicine, National Taiwan University, Taipei, Taiwan",n/a,True
+"Institute of Biomedical Sciences, Academia Sinica, Taipei, Taiwan",n/a,True
+"Instituterof Clinical Medicine, National Cheng Kung University, Tainan, Taiwan",n/a,True
+"Natural ProductsrResearch Laboratories, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Eshelman School of Pharmacy,False
+"BiologicalrTesting Branch, Developmental Therapeutics Program, Leidos Biomedical Research, Inc, Frederick National Laboratory for Cancer Research, Frederick, Maryland 21702, United States",n/a,True
+"Departmentrof Pediatrics, School of Medicine, University of Colorado Denver, Aurora, Colorado 80045, United States",n/a,True
+"NaturalrProduct Research Laboratories, Chemical Biology and Medicinal Chemistry,rUNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599-7568, United States",Eshelman School of Pharmacy,False
+"Schoolrof Pharmaceutical Sciences, College of Medical, Pharmaceutical andrHealth Sciences, Kanazawa University, Kanazawa, 920-1192, Japan",n/a,True
+"ScreeningrTechnologies Branch, Developmental Therapeutics Program, Divisionrof Cancer Treatment and Diagnosis, Frederick National Laboratory forrCancer Research, National Cancer Institute, Frederick, Maryland 21702, United States",n/a,True
+"Departmentrof Psychiatry and Behavioral Sciences, Mouse Behavioral and NeuroendocrinerAnalysis Core Facility, Duke University Medical Center, Durham, North Carolina 27710, United States",n/a,True
+"Departmentsrof Psychiatry and Behavioral Sciences, Cell Biology, and Neurobiology,rMouse Behavioral and Neuroendocrine Analysis Core Facility, Duke University Medical Center, Durham, North Carolina 27710, United States",n/a,True
+"Dipartimentordi Scienze Farmaceutiche, Università degli Studi di Milano, Via Mangiagalli 25, 20133 Milano, Italy",n/a,True
+"DrugrDiscovery Program, Department of Medicinal Chemistry and Pharmacognosy,rCollege of Pharmacy, University of Illinois at Chicago, 833 SouthrWood Street, Chicago, Illinois 60612, United States",n/a,True
+"NationalrInstitute of Mental Health Psychoactive Drug Screening Program, Departmentrof Pharmacology and Division of Chemical Biology and Medicinal Chemistry, University of North Carolina Chapel Hill Medical School, Chapel Hill, North Carolina 27599, United States",NIMH Psychoactive Drug Screening Program|Division of Chemical Biology and Medicinal Chemistry,False
+Department of Clinical Sciences; College of Veterinary Medicine; North Carolina State University; Raleigh NC USA,n/a,True
+Department of Molecular Biomedical Sciences; College of Veterinary Medicine; North Carolina State University; Raleigh NC USA,n/a,True
+Department of Stem Cell Biology; Atomic Bomb Disease Institute; Nagasaki University; Nagasaki Japan,n/a,True
+Division of Cardiothoracic Surgery; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Division of Cardiothoracic Surgery,False
+The Cyrus Tang Hematology Center; Soochow University; Suzhou China,n/a,True
+Department of Hematology-Oncology; Pontificia Universidad Católica de Chile; Santiago Chile,n/a,True
+Department of Medicine; Roswell Park Cancer Institute; Buffalo NY USA,n/a,True
+Department of Pathology and Laboratory Medicine; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Pathology and Laboratory Medicine,False
+Department of Urology; Pontificia Universidad Católica de Chile; Santiago Chile,n/a,True
+Department of Urology; Roswell Park Cancer Institute; Buffalo NY USA,n/a,True
+"Duke University Medical Center and Department of VeteransrAffairs Medical Center, Durham, North Carolina",n/a,True
+"The University of North Carolina at Chapel Hill, Schoolrof Nursing",School of Nursing,False
+"The University of North Carolina at Chapel Hill, Schoolrof Nursing, ",School of Nursing,False
+"Durham Veterans Affairs Medical Center &amp; Duke University Medical Center, Durham, NC, USA",n/a,True
+"Department of Biological Chemistry,rCollege of Medicine, University of California, Irvine, California 92697, United States",n/a,True
+"Division of Medicinal Chemistry and Natural Products, UNC EshelmanrSchool of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599-7568, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"Natural Products Research Laboratories, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolinar27599-7568, United States",Eshelman School of Pharmacy,False
+"Department of Chemistry, Louisiana State University, Baton Rouge, Louisianar70803-1804, United States",n/a,True
+"Department of Pharmacology,rSchool of Medicine and NIMH Psychoactive Drug Screening Program, University of North Carolina, Chapel Hill, North Carolinar27599, United States",NIMH Psychoactive Drug Screening Program,False
+"Department of Plant Resources, G.P.O. Box 2270, Lalitpur, Kathmandu, Nepal",n/a,True
+"Duke University Medical Center, Box 2926, SORF, Durham, North Carolinar27710, United States",n/a,True
+"Faculty of Pharmaceutical Sciences, Toho University, Miyama 2-2-1, Funabashi, Chiba 274-8510,rJapan",n/a,True
+"Faculty of Pharmaceutical Sciences, Tokyo University of Science, 2641 Yamazaki, Noda, Chibar278-8510, Japan",n/a,True
+"Laboratoryrfor the Studying ofrComplementary and Medicinal Resources, The Kochi University of Technology, Tosayamada-cho, Kochi, 782-8502, Japan",n/a,True
+"Natural ProductsrResearch Laboratories,rUNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599-7568, UnitedrStates",Eshelman School of Pharmacy,False
+"Schoolrof Pharmaceutical Sciences, Kitasato University, 5-9-1 Shirokane, Minato-ku, Tokyor108-8641, Japan",n/a,True
+"Departmentrof Pharmacognosy,rSchool of Pharmacy, Fudan University, Shanghair201203, People’s Republic of China",n/a,True
+"Divisionrof Chemical Biology andrMedicinal Chemistry, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolinar27599-7568, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"Department of Biochemistry and MolecularrBiology, School of Medicine, Shandong University, Jinan 250012, People’s Republic of China",n/a,True
+"Department of NaturalrProducts Chemistry, Key Laboratory of Chemical Biology of the Ministryrof Education, School of Pharmaceutical Science, Shandong University, Jinan 250012, People’s Republic of China",n/a,True
+"School of Chemistry and Chemical Engineering, Shandong University, Jinan 250100, People’s Republic of China",n/a,True
+"Department of Pharmacognosy,rSchool of Pharmacy, Fudan University, Shanghai 201203, People’s Republic of China",n/a,True
+"Duke University Medical Center, Box 2926, SORF, Durham, North Carolina 27710, United States",n/a,True
+"Natural ProductsrResearch Laboratories, UNC Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599-7568, United States",Eshelman School of Pharmacy,False
+Department of Biological Sciences; Western Michigan University School of Medicine; Kalamazoo Michigan USA,n/a,True
+Department of Physiology and Pharmacology; Wake Forest School of Medicine; Winston-Salem North Carolina USA,n/a,True
+Departments of Psychiatry and Cell Biology and Physiology; University of North Carolina; Chapel Hill North Carolina USA,Department of Cell Biology and Physiology|Department of Psychiatry,False
+Department of Anesthesiology; Duke University Medical Center; Durham North Carolina USA,n/a,True
+Department of Dermatology; Johns Hopkins Medical Institutions; Baltimore Maryland USA,n/a,True
+Department of Genetics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina USA,Department of Genetics,False
+Department of Pathology; Duke University Medical Center; Durham North Carolina USA,n/a,True
+Preston Robert Tisch Brain Tumor Center; Duke University Medical Center; Durham North Carolina USA,n/a,True
+School of Medicine; Duke University; Durham North Carolina USA,n/a,True
+"Center for Functional GI and Motility Disorders, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",UNC Center for Functional GI and Motility Disorders,False
+"Department of Behavioral Medicine, Tohoku University Graduate School of Medicine, Sendai, Japan",n/a,True
+"Department of Gastroenterology, Tel Aviv Medical Center, Levahim, Israel",n/a,True
+"Department of Medicine, Gastroenterology and Health Care, Japan Community Health care Organization Shiga Hospital, Otsu, Shiga, Japan",n/a,True
+"Division of Upper Gastroenterology, Department of Internal Medicine, Hyogo College of Medicine, Nishinomiya, Hyogo, Japan",n/a,True
+Department of Computer and Information Science and Engineering; University of Florida; Gainesville,n/a,True
+Department of Mechanical Engineering; Universidad de Valladolid; Valladolid Spain,n/a,True
+"Department of Neurosurgery, Brigham and Women's Hospital; Harvard Medical School; Boston MA",n/a,True
+Department of Psychiatry and Computer Science; University of North Carolina at Chapel Hill; Chapel Hill NC,Department of Psychiatry|Department of Computer Science,False
+"Imaging Laboratories; Robarts Research Institute, Western University; London ON Canada",n/a,True
+International Neuroscience Institute (INI); Hannover Germany,n/a,True
+"Junior Group Medical Image Computing, Division of Medical and Biological Informatics; German Cancer Research Center; Heidelberg Germany",n/a,True
+"Laboratory of Mathematics in Imaging, Brigham and Women's Hospital; Harvard Medical School; Boston MA",n/a,True
+"Penn Image Computing and Science Laboratory, Department of Radiology; Perelman School of Medicine, University of Pennsylvania; Philadelphia",n/a,True
+"Program on Pediatric Imaging and Tissue Sciences; National Institute of Child Health and Human Development, National Institutes of Health; Bethesda",n/a,True
+Scientific Computing and Imaging Institute; University of Utah; Salt Lake City UT,n/a,True
+"Surgical Navigation and Robotics Laboratory, Department of Radiology, Brigham and Women's Hospital; Harvard Medical School; Boston MA",n/a,True
+"Surgical Planning Laboratory, Department of Radiology, Brigham and Women's Hospital; Harvard Medical School; Boston MA",n/a,True
+"University of Rennes I, VISAGES INSERM - U746 CNRS UMR6074 - INRIA; Rennes France",n/a,True
+"Division of Skull Base Surgery/Rhinology, Department of Otolaryngology-Head and Neck Surgery, UNC-Chapel Hill School of Medicine, Chapel Hill, North Carolina",Department of Otolaryngology/Head and Neck Surgery,False
+"Howard Hughes Medical Institute, and Computational Neurobiology Lab, Salk Institute, La Jolla, California 92037",n/a,True
+"Sloan-Swartz Center for Theoretical Neurobiology, Salk Institute, La Jolla, California 92037",n/a,True
+Department of Family Medicine; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Family Medicine,False
+"Associate Dean for Research and Professor, Emory University; Atlanta GA USA",n/a,True
+"Associate Professor, Duke University; Durham NC USA",n/a,True
+"Associate Professor, Emory University; Atlanta GA USA",n/a,True
+Beatrice Renfield Term Professor of Nursing; Yale School of Nursing; New Haven CT USA,n/a,True
+"Director, National Institute of Nursing Research, NIH; Bethesda MD USA",n/a,True
+"Edward J. and Louise Mellen Professor of Nursing and Associate Dean for Research, Case Western Reserve University; Cleveland OH USA",n/a,True
+"Lead Program Director, National Institute of Nursing Research; NIH; Bethesda MD USA",n/a,True
+"Professor and Associate Dean for Research, University of North Carolina-Chapel Hill; Chapel Hill NC USA",University of North Carolina at Chapel Hill,False
+"Professor and Associate Dean for Research, University of Wisconsin-Milwaukee; Milwaukee WI USA",n/a,True
+"Professor and Chair, Department of Pain and Translational Symptom Science, University of Maryland; Baltimore MD USA",n/a,True
+"Professor and Department Chairperson, University of Washington; Seattle WA USA",n/a,True
+"Professor of Epidemiology and Population Health, Albert Einstein College of Medicine; New York NY USA",n/a,True
+"Professor, University of Nebraska Medical Center; Omaha NB USA",n/a,True
+"The Alumni Professor of Nursing and Professor of Biomedical Informatics, Columbia University; New York NY USA",n/a,True
+"Alpha Alpha and Alpha Chi , Assistant Professor, William F. Connell School of Nursing; Boston College; Boston MA USA",n/a,True
+"Beta Upsilon , Assistant Professor, Co-Director, Hartford Center of Gerotologic al Nursing Excellence, College of Nursing and Health Innovation; Arizona State University; Phoenix AZ USA",n/a,True
+"Gamma Rho , Assistant Professor, Associate Director, Hartford Center of Geriatric Nursing Excellence, College of Nursing; University of Utah; Salt Lake City UT USA",n/a,True
+"Gamma Zeta , Assistant Professor, School of Nursing; The University of North Carolina at Chapel Hill; Chapel Hill NC USA",School of Nursing,False
+"Omicron Upsilon , Nursing Academic Program Director; Western Washington University; Bellingham WA USA",n/a,True
+"Robert Wood Johnson Foundation Nurse Faculty Alumna and Assistant Professor, Betty Irene Moore School of Nursing; University of California-Davis; Sacramento CA USA",n/a,True
+"Upsilon and Alpha Eta , Assistant Professor and Associate Director, Hartford Institute for Geriatric Nursing, College of Nursing; New York University and James J. Peters Bronx VAMC, GRECC; New York NY USA",n/a,True
+"Xi Rho , Associate Professor, School of Nursing; Clayton State University; Morrow GA USA",n/a,True
+"UNC Lineberger Comprehensive Cancer Center, Chapel Hill, NC",UNC Lineberger Comprehensive Cancer Center,False
+"UNC Eshelman School of Pharmacy; University of North Carolina at Chapel Hill, Gillings School of Global Public Health; UNC Lineberger Comprehensive Cancer Center; Cecil G. Sheps Center for Health Services Research, Chapel Hill, NC; University of Kansas School of Medicine, Kansas City, KS; Dana-Farber Cancer Institute; Tufts Medical Center Institute for Clinical Research and Health Policy Studies; Harvard Medical School; Brigham and Women's Hospital, Boston, MA; University of Chicago, Chicago, IL; Center...",n/a,True
+"Abramson Cancer Center of the University of Pennsylvania, Philadelphia, PA; LIVESTRONG, Austin, TX; Fred Hutchinson Cancer Research Center, Seattle, WA; University of California, Los Angeles, Jonsson Comprehensive Cancer Center, Los Angeles, CA; Memorial Sloan Kettering Cancer Center, New York, NY; Dana-Farber Cancer Institute, Boston, MA; University of Colorado Cancer Center, Denver, CO; and University of North Carolina Lineberger Comprehensive Cancer Center, Chapel Hill, NC",n/a,True
+"University of Iowa College of Public Health, Iowa City, IA; UNC Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC; University of Nebraska Medical Center, Omaha, NE; and Mayo Clinic Cancer Center, Scottsdale, AZ",n/a,True
+"National Cancer Institute, Bethesda; Johns Hopkins University School of Medicine, Armstrong Institute for Patient Safety &amp; Quality, Baltimore, MD; University of North Carolina, Chapel Hill, NC; Virginia Mason Hospital and Medical Center, Seattle, WA; Brigham and Women's Hospital, Boston, MA; Abramson Cancer Center, University of Pennsylvania, Philadelphia, PA; American Society of Clinical Oncology, Alexandria, VA; and University of Central Florida, Orlando, FL",n/a,True
+"Bascom Palmer Eye Institute, Department of Ophthalmology, Miller School of Medicine, University of Miami, 900 N.W. 17th Street, Miami, FL 33136, USA",n/a,True
+"Robert Cizik Eye Clinic, 6400 Fannin Street, Suite 1800, Houston, TX 77030, USA",n/a,True
+"Ruiz Department of Ophthalmology and Visual Science, The University of Texas Medical School at Houston, 6431 Fannin Street, MSB 7.024, Houston, TX 77030, USA",n/a,True
+"West Virginia School of Osteopathic Medicine, 400 North Lee Street, Lewisburg, WV 24901, USA",n/a,True
+"Department of International Health, Bloomberg School of Public Health, Johns Hopkins University, Baltimore, MD 21209, USA",n/a,True
+"Department of Ophthalmology and Visual Sciences, John A. Moran Eye Center, University of Utah, Salt Lake City, UT 84132, USA",n/a,True
+"Department of Ophthalmology, Emory University School of Medicine, Atlanta, GA 30322, USA",n/a,True
+"Department of Ophthalmology, School of Medicine, Duke University, Durham, NC 27710, USA",n/a,True
+"Department of Science and Mathematics, Institutional Research, Husson University, Bangor, ME 04401, USA",n/a,True
+"Division of Pharmaceutical Outcomes and Policy, UNC Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Division of Pharmaceutical Outcomes and Policy,False
+"Glaucoma Service and Research Center, UNC Kittner Eye Center, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Department of Ophthalmology,False
+"UNC Eshelman School of Pharmacy and Cecil G. Sheps Center for Health Services Research, University of North Carolina at Chapel Hill, CB No. 7590, Chapel Hill, NC 27599-7590, USA",Cecil G. Sheps Center for Health Services Research|Eshelman School of Pharmacy,False
+Department of Dental Ecology; School of Dentistry; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Dental Ecology,False
+Office of Science Policy and Analysis; NIH-NIDCR; Bethesda; MD; USA,n/a,True
+"Department of Cariology; Graduate School of Biomedical Sciences, Nagasaki University; Nagasaki Japan",n/a,True
+NC Oral Health Institute; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,School of Dentistry,False
+Teijin Institute for Bio-Medical Research; Teijin Pharma Ltd.; Tokyo Japan,n/a,True
+Department of Orthopaedic Surgery; Duke University Medical Center; Durham North Carolina,n/a,True
+"Flexcell International Corp.; 2730 Tucker St., Suite 200 Burlington North Carolina",n/a,True
+Laboratory for Comparative Orthopaedic Research; College of Veterinary Medicine Michigan State University; East Lansing Michigan,n/a,True
+"Blood &amp; Marrow Transplant Information Network, BMT Newsletter",n/a,True
+"Health Institute and the Center on Child and Family Outcomes at the Institute for Clinical Research and Health Policy Studies at Tufts Medical Center, Tufts University School of Medicine",n/a,True
+Institute for Clinical Research and Health Policy Studies at the Tufts Medical Center,n/a,True
+Office of Patient Advocacy of the National Marrow Donor Program,n/a,True
+"School of Nursing, University of North Carolina at Chapel Hill, , UNC Lineberger Comprehensive Cancer Center",School of Nursing|UNC Lineberger Comprehensive Cancer Center,False
+"Tufts University School of Medicine and the Sackler School of Graduate Biomedical Sciences, Institute for Clinical Research and Health Policy Studies at Tufts Medical Center",n/a,True
+Department of Dental Ecology; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Dental Ecology,False
+Department of Periodontology; Shanghai Stomatological Disease Center; Shanghai China,n/a,True
+Department of Periodontology; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Periodontology,False
+Faculty of Dentistry; University of Chile; Santiago Chile,n/a,True
+Interleukin Genetics Inc.; Waltham MA USA,n/a,True
+Shanghai BioAsia Institute of Life Science; Shanghai China,n/a,True
+"Chemistry, ‡Biochemistry and Biophysics, and §Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, North Carolina 27599, United States",University of North Carolina at Chapel Hill,False
+"Department of Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599-329,rUnited States",Department of Chemistry,False
+"ResearchrComputing Center, University of North Carolina, Chapel Hill, North Carolina 27599-3420, United States",University of North Carolina at Chapel Hill,False
+"Cystic Fibrosis and Pulmonary ResearchrCenter, Department of Biochemistry and Biophysics, University of North Carolina at Chapel Hill, North Carolina, UnitedrStates",Cystic Fibrosis and Pulmonary Diseases Research and Treatment Center|Department of Biochemistry and Biophysics,False
+"Department of ChemistryrandrInstitutes of Biomedical Sciences, Fudan University, Shanghai, China",n/a,True
+"Tourismrand Food College, Shanghai Business School, Shanghai, China",n/a,True
+"Department of Biochemistry &amp;rBiophysics, UNC School of Medicine, ChapelrHill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Department of BiochemistryrandrMolecular &amp; Cellular Biology, Georgetown University Medical Center, Washington, DC 20007, United States",n/a,True
+"Departmentrof Biochemistry and Biophysics, University of North Carolina at Chapel Hill, 120 Mason Farm Road, Campus Box 7260 3rd Floor, Genetic MedicinerBuilding, Chapel Hill, NorthrCarolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Departmentrof Microbiology and Immunology, University of North Carolina at Chapel Hill, 804 Mary Ellen Jones, 116 Manning Drive, ChapelrHill, North Carolina 27599, United States",Department of Microbiology and Immunology,False
+"College of Arts and Sciences, Boise State University, Boise, Idaho 83725, UnitedrStates",n/a,True
+"Department of Chemistryrand Institute of Biomedical Sciences, Fudan University, 138 Yi Xue Yuan Road, Shanghai 200032, China",n/a,True
+"Key Laboratory of Medical MolecularrVirology, Institute of Biomedical Sciences and Instituterof Medical Microbiology, Shanghai Medical College, Fudan University, Shanghai 200032, China",n/a,True
+"Biostatistics Center, Massachusetts General Hospital Cancer Center, Boston, Massachusetts 02114, United States",n/a,True
+"Department of Laboratory Medicine, Children’s Hospital Boston, Boston, Massachusetts 02115, United States",n/a,True
+"Division of Biomedical Statistics and Informatics, Departmentrof Health Sciences Research, Mayo Clinic, Rochester, Minnesota 55905, United States",n/a,True
+"Division of Cancer Epidemiology and Genetics, NationalrCancer Institute, National Institutes of Health, Department of Health &amp; Human Services, Bethesda, Maryland 20892, United States",n/a,True
+"Divisionrof Gastroenterology and Hepatology, Department of Medicine, University of North Carolina, Chapel Hill, North Carolina 27514, United States",Division of Gastroenterology and Hepatology,False
+"Fujirebio Diagnostics, Inc., Malvern, Pennsylvania 19355, United States",n/a,True
+"Jim Ayers Institute for Precancer Detectionrand Diagnosis and Department of Biochemistry, Vanderbilt University, School of Medicine, Nashville, Tennessee 37232, United States",n/a,True
+"Office of Cancer Clinical Proteomics Research, Center for StrategicrScientific Initiatives, National Cancer Institute, National Institutes of Health, Department of Health &amp; Human Services, Bethesda, Maryland 20892, United States",n/a,True
+"Office of In Vitro Diagnostics and Radiological Health, Center forrDevices and Radiological Health, Food and Drug Administration, Department of Health and Human Services, Silver Spring, Maryland 20993, United States",n/a,True
+"PersonalizedrDiagnostics, The Biodesign Institute, Arizona State University, Tempe, Arizona 85287, United States",n/a,True
+"ProteomicsrPlatform, Broad Institute of Massachusetts Institute of Technology and Harvard, Cambridge, Massachusetts 02142, United States",n/a,True
+"SISCAPA Technologies, Inc., Washington, D.C. 20009, United States",n/a,True
+"The Plasma Proteome Institute, Washington, D.C. 20009, United States",n/a,True
+"Centerrfor Gastrointestinal Biology and Disease and Division of Gastroenterologyrand Hepatology, Department of Medicine, University of North Carolina at Chapel Hill, 103 Mason Farm Road, ChapelrHill, North Carolina 27599, United States",Center for Gastrointestinal Biology and Disease|Division of Gastroenterology and Hepatology,False
+"Departmentrof Nutrition, University of North Carolina at Greensboro, 319 CollegerAvenue, Greensboro, NorthrCarolina 27412, United States",n/a,True
+"Schoolrof Medicine, University of North Carolina at Chapel Hill, 321 SouthrColumbia Street, Chapel Hill, North Carolina 27599, United States",School of Medicine,False
+"Departmentrof Chemistry, University of North Carolina at Chapel Hill, 320 CaudillrHall, Chapel Hill, NorthrCarolina 27599, United States",Department of Chemistry,False
+"LinebergerrComprehensive Cancer Center, University of North Carolina at Chapel Hill, 450 West Drive, 21-244, Chapel Hill, North Carolina 27599, United States",UNC Lineberger Comprehensive Cancer Center,False
+"Departmentrof Cell Biology and Physiology, Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill School of Medicine, Box #7295, ChapelrHill, North Carolina 27599, United States",UNC Lineberger Comprehensive Cancer Center|Department of Cell Biology and Physiology,False
+"Departmentrof Computer Science, University of North Carolina at Chapel Hill, Box #3175, Chapel Hill, North Carolina 27599, United States",Department of Computer Science,False
+"Cystic Fibrosis Foundation, Bethesda, Maryland 20814, United States",n/a,True
+"Departmentrof Biochemistry and Biophysics, Cystic Fibrosis Treatment and ResearchrCenter, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Cystic Fibrosis and Pulmonary Diseases Research and Treatment Center|Department of Biochemistry and Biophysics,False
+"Departmentrof Chemistry, University of Connecticut, Storrs, Connecticut 06269, United States",n/a,True
+"Departmentrof Microbiology and Immunology, Geisel School of Medicine at Dartmouth, Hanover, New Hampshire 03755, United States",n/a,True
+" a   Center for Health Services Research in Primary Care, Durham Veterans Affairs Medical Center, Durham, NC, USA, and Department of Psychology , Virginia State University , Petersburg, VA,  USA",n/a,True
+" b   Center for Health Services Research in Primary Care, Durham Veterans Affairs Medical Center and Division of General Internal Medicine , Duke University Medical Center , Durham, NC,  USA",n/a,True
+" c   Center for Health Services Research in Primary Care , Durham Veterans Affairs Medical Center , Durham, NC,  USA",n/a,True
+" d   Center for Health Services Research in Primary Care, Durham Veterans Affairs Medical Center, Durham, NC, USA, and Department of Health Policy and Management , University of North Carolina at Chapel Hill , Chapel Hill, NC,  USA",n/a,True
+" e   Center for Health Services Research in Primary Care, Durham Veterans Affairs Medical Center and Division of Gastroenterology , Duke University Medical Center , Durham, NC,  USA",n/a,True
+"Center to Address Disparities in Children's Oral Health; University of California, San Francisco School of Dentistry; San Francisco CA USA",n/a,True
+Department of Health Management and Policy; University of Michigan; Ann Arbor; MI; USA,n/a,True
+Health Policy and Management; University of North Carolina; Chapel Hill; NC; USA,Department of Health Policy and Management,False
+Pediatric Dentistry; UNC; Chapel Hill; NC; USA,Department of Pediatric Dentistry,False
+RAND Corporation; Los Angeles; CA; USA,n/a,True
+Department of Periodontics and Dental Hygiene; University of Texas Health Science Center at Houston School of Dentistry; Houston TX USA,n/a,True
+Departments of Pediatric Dentistry; Health Policy and Management; School of Dentistry; School of Public Health; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Health Policy and Management|Department of Pediatric Dentistry,False
+Radboud University Nijmegen,n/a,True
+African Population and Health Research Center,n/a,True
+University of Colorado at Boulder,n/a,True
+"Department of Epidemiology and Biostatistics, Jack, Joseph, and Morton Mandel School for Applied Social Sciences; Case Western Reserve University; 11000 Cedar Ave., BioEnterprise Bldg., Room 443 Cleveland OH 44106",n/a,True
+"Department of Exercise Science, Arnold School of Public Health; University of South Carolina; 921 Assembly St., GA05 Columbia SC 29208",n/a,True
+"Department of Exercise Science, Arnold School of Public Health; University of South Carolina; 921 Assembly St., Room 130 Columbia SC 29208",n/a,True
+"Department of Exercise Science, Arnold School of Public Health; University of South Carolina; 921 Assembly St., Room 131 Columbia SC 29208",n/a,True
+"Department of Health Promotion, Education, and Behavior, Arnold School of Public Health; University of South Carolina; 915 Greene St., Discovery I, Room 552 Columbia SC 29208",n/a,True
+"Department of Nutrition, Gillings School of Global Public Health; University of North Carolina at Chapel Hill; 1700 Martin Luther King Jr. Blvd. Chapel Hill NC 27599",Department of Nutrition,False
+"Exercise and Wellness, School of Nutrition and Health Promotion; College of Health Solutions, Arizona State University; 500 North 3rd St. Phoenix AZ 85004",n/a,True
+"Behavioral Research Program, Division of Cancer Control and Population Sciences; National Cancer Institute; 9609 Medical Center Dr., Room 3E104 Rockville MD 20850",n/a,True
+Gillings School of Global Public Health; University of North Carolina at Chapel Hill; 2104B McGavran-Greenberg Hall Chapel Hill NC 27599-7435,Gillings School of Global Public Health,False
+University of Illinois at Chicago; 1747 W. Roosevelt Rd. Chicago IL 60608,n/a,True
+"University of Texas Health Science Center at Houston-Austin Regional Campus; 1616 Guadalupe St., Suite 6.300 Austin TX 78701",n/a,True
+"RTI International, USA",n/a,True
+"University of North Carolina, USA, ",University of North Carolina at Chapel Hill,False
+"University of Maryland, USA",n/a,True
+"Brigham Young University, Provo, UT",n/a,True
+"Case Western Reserve University, Cleveland, OH",n/a,True
+"The Ohio State University, Columbus",n/a,True
+University of Illinois at Urbana-Champaign,n/a,True
+"Virginia Polytechnic Institute and State University, Blacksburg",n/a,True
+Biostatistical Sciences; Wake Forest School of Medicine; Winston-Salem North Carolina,n/a,True
+Department of Gastrointestinal Medical Oncology; The University of Texas MD Anderson Cancer Center; Houston Texas,n/a,True
+Department of General Surgery; Wake Forest School of Medicine; Winston-Salem North Carolina,n/a,True
+Department of Pathology; Wake Forest School of Medicine; Winston-Salem North Carolina,n/a,True
+Piedmont Pathology Associates; Hickory North Carolina,n/a,True
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Epidemiology,False
+"Vanderbilt Institute for Global Health, Vanderbilt University, Nashville, Tennessee, USA",n/a,True
+"Witkoppen Health and Welfare Centre, Johannesburg, South Africa",n/a,True
+" a   Department of Environmental Sciences and Engineering , University of North Carolina at Chapel Hill ,  Chapel Hill ,  NC ,  USA",Department of Environmental Sciences and Engineering,False
+"Department of Chemistry, CB#3290, University of North Carolina, Chapel Hill, North Carolina 27599",Department of Chemistry,False
+"Departmentrof Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599-3290, United States",Department of Chemistry,False
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina,r2799-3290, United States",Department of Chemistry,False
+"Department of Chemistry, Georgia State University, Atlanta, Georgia 30302-4098,rUnited States",n/a,True
+"Departmentrof Pathology, University of North Carolina, Chapel Hill, North Carolinar27599, United States",Department of Pathology and Laboratory Medicine,False
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina,r27599-3290, United States",Department of Chemistry,False
+"Department of Biochemistry andrBiophysics, University of North Carolina School of Medicine, Chapel Hill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Department of Physics, Departmentrof Chemistry and Biochemistry, and Programs of Biophysics, ChemicalrPhysics, and Biochemistry, The Ohio State University, Columbus, Ohio 43210, United States",n/a,True
+"Departmentrof Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599-3290,rUnited States",Department of Chemistry,False
+"Department of Chemical and BiomolecularrEngineering, North Carolina State University, Raleigh, North Carolina 27695, United States",n/a,True
+"Caudill Laboratories,rDepartmentrof Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"French Family Science Center, Duke University, Durham, North Carolina 27708-0346,rUnited States",n/a,True
+"Departmentrof Biochemistry and Biophysics, School of Medicine, and ‡Division of Chemical Biology andrMedicinal Chemistry, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",n/a,True
+"Department of Chemical Engineering, Massachusetts Institute of Technology, Cambridge, Massachusettsr02319, United States",n/a,True
+"Departmentrof Chemical and BiomolecularrEngineering, North Carolina State University, Raleigh, North Carolina 27695, United States",n/a,True
+"Departmentrof Pharmacology, Baylor College of Medicine, Houston, Texas 77030, UnitedrStates",n/a,True
+"Diagnostics For All, Cambridge, Massachusetts 02139, United States",n/a,True
+"Liquidia Technologies, Research Triangle Park, North Carolina 22709, United States",n/a,True
+"Liquidia Technologies Inc., Morrisville, North Carolina 27560, United States",n/a,True
+"Department of Chemistry, University of North Carolina, Chapel Hill, North Carolinar27599-3290, United States",Department of Chemistry,False
+"Departments of Chemistry andrMolecular and Cell Biology, University of California, Berkeley, California 94720-3220, United States",n/a,True
+"Laboratory of Structural Biology,rNational Institute of Environmental Health Sciences, National Institutes of Health, P.O. Box 12233, ResearchrTriangle Park, North Carolina 27709-12233, United States",n/a,True
+"Penn State University, 320rSteidle PSU, University Park, Pennsylvania 16802, United States",n/a,True
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599-3290, United States",Department of Chemistry,False
+"Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"Department of Chemistry, University of North Carolina at Chapel Hill, CB # 3290, Chapel Hill,rNorth Carolina 27599, United States",Department of Chemistry,False
+"Department ofrChemistry, University of Chicago, 929 E. 57th Street, Chicago, Illinois 60637, United States",n/a,True
+"Department of Biochemistry andrBiophysics, University of California, SanrFrancisco, California 94158, United States",n/a,True
+"Department of Chemistry, University of Iowa, Iowa City, Iowa 52242, United States",n/a,True
+"Division of Chemical Biologyrand Medicinal Chemistry, UNC Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"Department of Biochemistry,rYong Loo Lin School of Medicine, National University of Singapore, National University Health System, 8 MedicalrDrive, Singapore 117597, Singapore",n/a,True
+"Department of Chemistry, National University of Singapore, 3 Science Drive 3,rSingapore 117543, Singapore",n/a,True
+"Division of Molecular Pharmaceutics,rEshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, UnitedrStates",Division of Molecular Pharmaceutics,False
+"Institute of Intelligent Machines, Chinese Academy of Sciences, Hefei, Anhui 230031, China",n/a,True
+"Department of Chemical Engineeringrand Applied Chemistry, University of Toronto, 200 College Street, Toronto, Ontario M5S 3E5, Canada",n/a,True
+"Department of Chemistry, University of Toronto, 80 Saint George Street, Toronto,rOntario M5S 3H6, Canada",n/a,True
+"Departmentsrof Molecular Genetics, Biochemistry, and Chemistry, The University of Toronto, Toronto, Ontario M5S 1A8, Canada",n/a,True
+"JointrDepartment of Biomedical Engineering, University of North Carolina at Chapel Hill and North Carolina State University, Raleigh, North Carolina 27695, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Departmentrof Chemical and Biomolecular Engineering, North Carolina State University, Raleigh, North Carolina 27695, United States",n/a,True
+"Caudill Laboratories, Departmentrof Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"Department of Chemistry, ‡Division of ChemicalrBiology and Medicinal Chemistry, and § Department ofrPharmacology, University of North Carolina, Chapel Hill, North Carolina 27599, United States",n/a,True
+"Division of Chemical Biology and Medicinal Chemistry,rUNC Eshelman School of Pharmacy and ‡Department of Biochemistry and Biophysics, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",n/a,True
+"BoycerThompson Institute and Department of Chemistry and Chemical Biology, Cornell University, Ithaca, New York 14853, United States",n/a,True
+"Divisionrof Chemical Biology and Medicinal Chemistry, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"Departmentrof Chemistry, North Carolina State University, Raleigh, North Carolina 27695, United States",n/a,True
+"Departmentrof Chemistry, University of Pittsburgh, Pittsburgh, Pennsylvania 15260, United States",n/a,True
+"Departmentrof Developmental Biology, University of Pittsburgh, School of Medicine, Pittsburgh, Pennsylvania 15260, United States",n/a,True
+"Divisionrof Molecular Pharmaceutics, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Division of Molecular Pharmaceutics,False
+"Department of Biochemistry andrBiophysics and ‡Department of Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Departmentsrof Genetics, Biochemistry &amp; Biophysics, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Department of Biochemistry and Biophysics|Department of Genetics,False
+"Department of Chemistry, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Department of Chemistry,False
+"C. Sue Carter, PhD, University of North Carolina, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"Hossein Pournajafi-Nazarloo, MD, PhD, University of North Carolina, Chapel Hill, NC, USA",University of North Carolina at Chapel Hill,False
+"Julia S. Seng, PhD, CNM, FAAN, University of Michigan, Ann Arbor, MI, USA",n/a,True
+"Michelle L. Munro, MS, CNM, FNP-BC, University of Michigan, Ann Arbor, MI, USA",n/a,True
+"Stephanie L. Brown, PhD, Stony Brook University, Stony Brook, NY, USA",n/a,True
+"William D. Lopez, MPH, University of Michigan, Ann Arbor, MI, USA",n/a,True
+" Haitao Chu is Research Associate Professor, Department of Biostatistics and the Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC 27516 . Lei Nie is Mathematical Statistician, Office of Biostatistics, Food and Drug Administration, Silver Spring, MD 20993 . Dr. Chu was supported in part by Lineberger Cancer Center Core Grant CA16086 from the U.S. National Cancer Institute. The authors thank the editor for his helpful comments and suggestions.",n/a,True
+" Joseph G. Ibrahim is Alumni Distinguished Professor  and Hongtu Zhu is Associate Professor , Department of Biostatistics, University of North Carolina, Chapel Hill. Niansheng Tang is Professor, Department of Statistics, Yunnan University, Kunming . The authors wish to deeply thank the editor, the associate editor, and three referees for extremely helpful comments and suggestions that have substantially improved the article. Dr. Ibrahim’s research was supported in part by National Institutes of Health...",n/a,True
+" Ming-Hui Chen is Professor, Department of Statistics, University of Connecticut, Storrs, CT 06269 . Joseph G. Ibrahim is Alumni Distinguished Professor, Department of Biostatistics, University of North Carolina, Chapel Hill, NC 27599 . Sungduk Kim is Research Fellow, Division of Epidemiology, Statistics and Prevention Research, National Institute of Child Health and Human Development, NIH Rockville, MD 20852 . The authors thank the editor, the associate editor, and three referees for helpful comments...",n/a,True
+" a   Department of Biostatistics , University of North Carolina ,  Chapel Hill ,  NC ,  27599",Department of Biostatistics,False
+" b   Office of Clinical Sciences , Duke-National University of Singapore Graduate Medical School ,  Singapore ,  169857",n/a,True
+" c   Department of Biostatistics, and Professor, Department of Statistics and Operations Research , University of North Carolina at Chapel Hill ,  Chapel Hill ,  NC ,  27599",Department of Biostatistics|Department of Statistics and Operations Research,False
+Renmin University of China; Beijing People's Republic of China,n/a,True
+University of North Carolina at Chapel Hill; USA,University of North Carolina at Chapel Hill,False
+Duke University; Durham USA,n/a,True
+University of North Carolina; Chapel Hill USA,University of North Carolina at Chapel Hill,False
+University of Washington; Seattle USA,n/a,True
+University of Chicago; USA,n/a,True
+West Virginia University; Morgantown USA,n/a,True
+"Department of Sociology, University of North Carolina, USA",Department of Sociology,False
+"Institute for Behavioral Genetics, University of Colorado at Boulder, USA",n/a,True
+"Institute of Behavioral Science and Department of Sociology, University of Colorado at Boulder, USA",n/a,True
+"Institute of Behavioral Science and School of Education, University of Colorado at Boulder, USA",n/a,True
+"Institute of Behavioral Science, University of Colorado at Boulder, USA",n/a,True
+Department of Product Research; Fuji-Gotemba Research Laboratories; Chugai Pharmaceutical Co. Ltd; Shizuoka; Japan,n/a,True
+Departments of Biomedical Engineering and Radiation Oncology; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,UNC/NCSU Joint Department of Biomedical Engineering|Department of Radiation Oncology,False
+Gene Therapy Center; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Gene Therapy Center,False
+North Carolina Translational and Clinical Sciences Institute; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,North Carolina Translational and Clinical Sciences Institute,False
+BioCytex; Marseille; France,n/a,True
+Department of Medicine; University of North Carolina; Chapel Hill; NC; USA,Department of Medicine,False
+Unité d'Aide Méthodologique à la Recherche Clinique; Laboratoire de Santé Publique; UFR de Médecine; Marseille; France,n/a,True
+Thrombosis and Hemostasis Unit; Amalia Biron Research Institute of Thrombosis and Hemostasis; Sheba Medical Center; Tel Hashomer and Sackler Faculty of Medicine; Tel Aviv University; Tel Aviv Israel,n/a,True
+Cardeza Foundation for Hematological Research; Thomas Jefferson University; Philadelphia PA USA,n/a,True
+Center for Thrombosis Research; Florida Hospital; Winter Park FL USA,n/a,True
+Department of Biochemistry and Biophysics; University of North Carolina; Chapel Hill NC USA,Department of Biochemistry and Biophysics,False
+Blood Research Institute; Blood Center of Wisconsin; Milwaukee WI USA,n/a,True
+Department of Immunology and Microbial Science; The Scripps Research Institute; La Jolla CA USA,n/a,True
+Department of Molecular and Experimental Medicine; The Scripps Research Institute; La Jolla CA USA,n/a,True
+Department of Pathology; University of California San Diego; La Jolla CA USA,n/a,True
+Departments of Biomedical Engineering and Medicine; Oregon Health and Science University; Portland OR USA,n/a,True
+Division of Hematology/Oncology; University of Cincinnati College of Medicine; Cincinnati OH USA,n/a,True
+W. M. Keck Center for Transgene Research; University of Notre Dame; Notre Dame IN USA,n/a,True
+Department of Epidemiology; School of Public Health; University of North Carolina; Chapel Hill NC USA,Department of Epidemiology,False
+Department of Epidemiology; University of Washington; Seattle WA USA,n/a,True
+"Department of Medicine; University of Vermont; Burlington, VT VT USA",n/a,True
+Division of Biostatistics; School of Public Health; University of Minnesota; Minneapolis MN USA,n/a,True
+Division of Epidemiology & Community Health; School of Public Health; University of Minnesota; Minneapolis MN USA,n/a,True
+Department of Medicine; UNC McAllister Heart Institute; University of North Carolina; Chapel Hill NC USA,Department of Medicine|UNC McAllister Heart Institute,False
+Medizinische Klinik und Poliklinik I; LMU Munich; München Germany,n/a,True
+Pathology and Laboratory Medicine; University of North Carolina; Chapel Hill NC USA,Department of Pathology and Laboratory Medicine,False
+Department of Biochemistry and Biophysics; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Biochemistry and Biophysics,False
+Department of Biostatistics; North Carolina Translational and Clinical Sciences Institute; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Biostatistics|North Carolina Translational and Clinical Sciences Institute,False
+Erasmus University Medical Center; Rotterdam the Netherlands,n/a,True
+Department of Biochemistry; University of Vermont College of Medicine; Burlington VT USA,n/a,True
+Department of Genetics; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Genetics,False
+Department of Hematology; Institute of Biomedical Research (IIB-Sant Pau); Hospital de la Santa Creu i Sant Pau; Barcelona Spain,n/a,True
+Department of Neurology; Boston University School of Medicine; Boston MA USA,n/a,True
+Department of Neurology; University of Washington; Seattle WA USA,n/a,True
+Department of Pathology and Laboratory Medicine; University of Vermont College of Medicine; Burlington VT USA,n/a,True
+Division of Geriatric Medicine and Gerontology; Johns Hopkins University School of Medicine; Baltimore MD USA,n/a,True
+INSERM U897; University of Bordeaux; Bordeaux France,n/a,True
+Unit of Genomics of Complex Diseases; Institute of Biomedical Research (IIB-Sant Pau); Hospital de la Santa Creu i Sant Pau; Barcelona Spain,n/a,True
+Gene Therapy Center; University of North Carolina; Chapel Hill NC USA,Gene Therapy Center,False
+Children's Hospital of Los Angeles; University of Southern California Keck School of Medicine; Los Angeles CA USA,n/a,True
+Children's Hospital of Michigan; Detroit MI USA,n/a,True
+Children's Hospital of Philadelphia; Philadelphia PA USA,n/a,True
+Children's Mercy Hospital; Kansas City MO USA,n/a,True
+Children's National Medical Center; Washington DC USA,n/a,True
+Department of Hematology and Medical Oncology; Emory University; Atlanta GA USA,n/a,True
+Department of Medicine; Tulane University; New Orleans LA USA,n/a,True
+Department of Medicine; University of Pittsburgh Medical Center and Hemophilia Center of Western Pennsylvania; Pittsburgh PA USA,n/a,True
+Department of Pediatrics; Emory University; Atlanta GA USA,n/a,True
+Department of Pediatrics; University of Miami; Miami FL USA,n/a,True
+Phoenix Children's Hospital; Phoenix AZ USA,n/a,True
+McAllister Heart Institute; University of North Carolina; Chapel Hill NC USA,UNC McAllister Heart Institute,False
+Department of Medicine; University of Vermont; Burlington VT USA,n/a,True
+Division of Hematology/Oncology; Department of Medicine; University of North Carolina; Chapel Hill NC USA,Division of Hematology/Oncology,False
+Division of Hematology; Department of Medicine; Johns Hopkins University; Baltimore MD USA,n/a,True
+Division of Nephrology and Hypertension; Department of Medicine; UNC Kidney Center; School of Medicine; University of North Carolina; Chapel Hill NC USA,Division of Nephrology and Hypertension|UNC Kidney Center,False
+"School of Public Health; Human Genetics Center; The University of Texas, Health Science Center at Houston; Houston TX USA",n/a,True
+Department of Medicine I; Medical University of Vienna; Vienna Austria,n/a,True
+Division of Hematology and Oncology; Department of Medicine; Thrombosis and Hemostasis Program; UNC McAllister Heart Institute; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Division of Hematology/Oncology|UNC McAllister Heart Institute,False
+"Biostatistics, University of North Carolina Gillings School of Global Public Health, Chapel Hill, NC, USA",Department of Biostatistics,False
+"Centro de Ciencias de la Atm&oacute;sfera, Universidad Nacional Aut&oacute;noma de M&eacute;xico, Mexico City, Mexico 04510",n/a,True
+"Davidson Honors College, The University of Montana, Missoula, MT 59812, USA",n/a,True
+"Forensic Science Division, Missoula, MT 59812, USA",n/a,True
+"Instituto Nacional de Pediatr&iacute;a, Mexico City, Mexico",n/a,True
+"Pathology Department, Instituto Nacional de Cancerologia, Mexico City, Mexico 04530",n/a,True
+"The University of Montana, Missoula, MT 59812, USA",n/a,True
+Department of Clinical Sciences; College of Veterinary Medicine; North Carolina State University; Raleigh NC,n/a,True
+California Veterinary Specialists; Ontario CA,n/a,True
+Division of Hematology/Oncology; Department of Medicine; University of North Carolina at Chapel Hill; Chapel Hill NC,Division of Hematology/Oncology,False
+Francis Owen Blood Research Laboratory Department of Pathology and Laboratory Medicine; University of North Carolina at Chapel Hill; Chapel Hill NC,Department of Pathology and Laboratory Medicine,False
+Western University of Health Sciences College of Veterinary Medicine; Pomona CA,n/a,True
+Department of Biostatistics; Gillings School of Public Health; University of North Carolina; Chapel Hill; NC; USA,Department of Biostatistics,False
+Division of Gastroenterology and Hepatology; University of North Carolina; Chapel Hill; NC; USA,Division of Gastroenterology and Hepatology,False
+"Baylor College of Medicine, Houston, Texas",n/a,True
+"Duke University Independence Park Facility, Durham, North Carolina",n/a,True
+"Jean Mayer-USDA-HNRCA at Tufts University, Madrid, Spain",n/a,True
+"University of North Carolina at Chapel Hill, Kannapolis, North Carolina",Nutrition Research Institute,False
+"University of North Carolina at Charlotte, Charlotte, North Carolina",n/a,True
+"University of North Carolina at Greensboro, Kannapolis, North Carolina",n/a,True
+"Columbia University College of Physicians and Surgeons, Department of Medicine, Division of Nephrology, New York, NY, USA, ",n/a,True
+"UNC Kidney Center, Department of Medicine, Division of Nephrology and Hypertension, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",UNC Kidney Center|Division of Nephrology and Hypertension,False
+"Department of Anesthesiology, University of North Carolina, Chapel Hill, NC, USA.",Department of Anesthesiology,False
+"Institute of Cardiovascular Research Center, Pusan National University Yangsan Hospital, Yangsan, Korea.",n/a,True
+"Institute of Medical Science, Keimyung University, Daegu, Korea.",n/a,True
+"Department of Pathology, Chonnam National University Medical School, Chonnam National University Hwasun Hospital, Hwasun 519-763, Korea.",n/a,True
+"Department of Radiology, Chonnam National University Medical School, Chonnam National University Hwasun Hospital, Hwasun 519-763, Korea.",n/a,True
+"Department of Radiology, University of North Carolina at Chapel Hill, NC 27599-7510, USA.",Department of Radiology,False
+"Department of Surgery, Chonnam National University Medical School, Chonnam National University Hwasun Hospital, Hwasun 519-763, Korea.",n/a,True
+Research Center for Analytical Sciences,n/a,True
+High Point University,n/a,True
+Rheomics Inc.,n/a,True
+University of North Carolina at Chapel Hill Department of Physics & Astronomy,Department of Physics and Astronomy,False
+UNC Department of Cell Biology and Physiology,Department of Cell Biology and Physiology,False
+"CondensedrMatter Physics Department, Laboratory of Biophysics, “Jožef Stefan” Institute, Ljubljana 1001, Slovenia",n/a,True
+"Department of Brain and Cognitive Sciences, University of Rochester, USA",n/a,True
+"Department of Linguistics, University of Toronto, Canada",n/a,True
+"Department of Psychology, University of North Carolina at Chapel Hill, USA",Department of Psychology and Neuroscience,False
+"Office of Research Protections, US Army Medical Research and Materiel Command, USA",n/a,True
+"Cecil G. Sheps Center for Health Services Research, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Cecil G. Sheps Center for Health Services Research,False
+"Department of Biostatistics, School of Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Biostatistics,False
+"Department of Ophthalmology, School of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Ophthalmology,False
+"Lighting Research Center, Rensselaer Polytechnic Institute, Troy, NY, USA",n/a,True
+Division of Gastroenterology and Hepatology; UNC Liver Center; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Division of Gastroenterology and Hepatology,False
+AbbVie Inc.; North Chicago IL USA,n/a,True
+Hannover Medical School; Hannover Germany,n/a,True
+La Fe University Hospital and CIBERehd; Valencia Spain,n/a,True
+Liver Institute of Virginia; Bon Secours Health System; Newport News VA USA,n/a,True
+Liver Unit; Hospital Clinic; CIBERehd; IDIBAPS; Barcelona Spain,n/a,True
+Medical University of Vienna; Vienna Austria,n/a,True
+The Texas Liver Institute/University of Texas Health Science Center; San Antonio TX USA,n/a,True
+University of Colorado Denver School of Medicine; Aurora CO USA,n/a,True
+University of North Carolina at Chapel Hill; UNC Liver Center; Chapel Hill NC USA,Division of Gastroenterology and Hepatology,False
+Centre for Infectious Disease Research in Zambia; Lusaka Zambia,n/a,True
+Department of Medicine; University of Zambia; Lusaka Zambia,n/a,True
+Institute of Social and Preventive Medicine; University of Bern; Bern Switzerland,n/a,True
+Arbor Research Collaborative for Health; Ann Arbor; MI,n/a,True
+Department of Biostatistics; University of Michigan; Ann Arbor; MI,n/a,True
+Department of Surgery; University of Pennsylvania; Philadelphia; PA,n/a,True
+Division of Radiological Sciences; University of California Irvine; Irvine; CA,n/a,True
+National Institute of Diabetes and Digestive and Kidney Diseases; National Institutes of Health; Department of Health and Human Services; Bethesda; MD,n/a,True
+School of Pharmacy; University of North Carolina; Chapel Hill; NC,Eshelman School of Pharmacy,False
+Section of Hepatology; Division of Gastroenterology and Hepatology; University of Colorado Denver; Aurora; CO,n/a,True
+Department of Medicine; Baylor University; Dallas TX,n/a,True
+"Department of Medicine; College of Physicians and Surgeons, Columbia University; New York NY",n/a,True
+Department of Medicine; Mayo Clinic; Rochester MN,n/a,True
+Department of Medicine; Perelman School of Medicine at the University of Pennsylvania; Philadelphia PA,n/a,True
+Department of Medicine; Tufts-New England Medical Center; Boston MA,n/a,True
+Department of Medicine; University of North Carolina; Chapel Hill NC,Department of Medicine,False
+Departments of Medicine; University of Texas Health Science Center; Houston TX,n/a,True
+Departments of Surgery; University of Texas Health Science Center; Houston TX,n/a,True
+"Department of Medicine, Hospital for Special Surgery, Weill Medical College of Cornell University, New York ",n/a,True
+"Department of Medicine, University of North Carolina at Chapel Hill, North Carolina",Department of Medicine,False
+"Department of Medicine and Thurston Arthritis Research Center, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Medicine|Thurston Arthritis Research Center,False
+"Department of Pathology and Laboratory Medicine, Weill Medical College of Cornell University, New York, New York, USA; Department of Mechanical and Aerospace Engineering, Oklahoma State University, Stillwater, Oklahoma, USA",n/a,True
+"Department of Pathology and Laboratory Medicine, Weill Medical College of Cornell University, New York, New York, USA; Department of Pathology, The Mount Sinai School of Medicine, New York, New York, USA ",n/a,True
+"Departments of Medicine and Pathology, Stony Brook University, Stony Brook, New York, New York, USA",n/a,True
+"The Hospital for Special Surgery, Weill Medical College of Cornell University, New York, New York, USA",n/a,True
+"The Hospital for Special Surgery, Weill Medical College of Cornell University, New York, New York, USA; Jersey Shore University Medical Center, Neptune, New Jersey, USA",n/a,True
+"Division of Hematology/Oncology, Department of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Division of Hematology/Oncology,False
+"Division of Hematology/Oncology, Department of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA, ",Division of Hematology/Oncology,False
+"Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, USA",Department of Epidemiology,False
+"Epidemiology Branch, National Institute of Environmental Health Sciences, NIH, DHHS, Durham, USA",n/a,True
+"National Center for Environmental Assessment, United States Environmental Protection Agency, Washington, DC, USA",n/a,True
+"Arthritis Research UK Centre for Epidemiology, Centre for Musculoskeletal Research, Institute of Inflammation and Repair, Manchester Academic Health Sciences Centre, The University of Manchester, Manchester, UK",n/a,True
+"Autoimmune Diseases Research Unit, Hospital Universitario Cruces Universidad del Pais Vasco, Barakaldo, Spain",n/a,True
+"Cedars-Sinai Medical Center, David Geffen School of Medicine, University of California, Los Angeles, CA, USA",n/a,True
+"Centre for Rheumatology, Research Division of Medicine, London, UK",n/a,True
+"Department of Clinical Pharmacology, Oklahoma Medical Research Foundation, Oklahoma City, OK, USA",n/a,True
+"Department of Laboratory Medicine, Section of Microbiology, Immunology and Glycobiology, Lund University, Lund, Sweden",n/a,True
+"Department of Medicine, Division of Clinical Immunology and Rheumatology, University of Alabama at Birmingham, Birmingham, AL, USA",n/a,True
+"Department of Medicine, Division of Rheumatology, Allegheny Singer Research Institute, Allegheny General Hospital, Pittsburgh, PA, USA",n/a,True
+"Department of Rheumatology, Hanyang University Hospital for Rheumatic Diseases, Seoul, Korea",n/a,True
+"Department of Rheumatology, Skåne University Hospital, Lund, Sweden",n/a,True
+"Division of Rheumatology, Allergy and Immunology, UCSD School of Medicine, La Jolla, CA, USA",n/a,True
+"Division of Rheumatology, Department of Medicine, Centre Hospitalier Universitaire (CHU) de Québec Axe Maladies Infectieuses et Immunitaires, CRCHU de Québec, Université Laval, Quebec City, Quebec, Canada",n/a,True
+"Division of Rheumatology, Departments of Medicine and Pathology Capital Health and Dalhousie University, Halifax, Nova Scotia, Canada",n/a,True
+"Division of Rheumatology, Johns Hopkins University School of Medicine, Baltimore, MD, USA",n/a,True
+"Divisions of Clinical Epidemiology and Rheumatology, McGill University Health Centre, Montreal, Quebec, Canada",n/a,True
+"Feinstein Institute for Medical Research, Manhasset, NY, USA",n/a,True
+"Lanarkshire Centre for Rheumatology and Hairmyres Hospital, East Kilbride, UK",n/a,True
+"Mount Sinai Hospital and University Health Network, Toronto, Ontario, Canada",n/a,True
+"New York University, New York, NY, USA",n/a,True
+"North Dallas Dermatology Associates, Dallas, TX, USA",n/a,True
+"Northwestern University, Feinberg School of Medicine, Chicago, IL, USA",n/a,True
+"Philadelphia VA Medical Center and University of Pennsylvania, Philadelphia, PA, USA",n/a,True
+"Rayne Institute and St Thomas' Hospital London, UK",n/a,True
+"Rheumatology Research Group, School of Immunity and Infection, College of Medical and Dental Sciences University of Birmingham, Birmingham, UK",n/a,True
+"Rigshospitalet, Copenhagen University Hospital, Copenhagen, Denmark",n/a,True
+"Toronto Western Hospital Toronto, Ontario, Canada",n/a,True
+"Ysbyty Gwynedd, Bangor, UK",n/a,True
+Center for Nanotechnology in Drug Delivery; Division of Molecular Pharmaceutics; Eshelman School of Pharmacy; University of North Carolina at Chapel Hill; NC 27599 USA,Center for Nanotechnology in Drug Delivery|Division of Molecular Pharmaceutics,False
+Department Chemie; Technische Universität Dresden; Mommsenstr. 4 01069 Dresden Germany,n/a,True
+Functional Polymer Materials; Chair for Chemical Technology of Materials Synthesis; Universität Würzburg; 97070 Würzburg Germany,n/a,True
+Laboratory for Chemical Design of Bionanomaterials; Faculty of Chemistry; M.V. Lomonosov Moscow State University; Moscow 119899 Russia,n/a,True
+"MatièrerMolle et Chimie (UMR 7167 ESPCI/CNRS), ESPCI, 10 rue Vauquelin, 75005 Paris, France",n/a,True
+"Departmentrof Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"Instituterof Macromolecular Compounds, Russian Academy of Sciences, Saint Petersburg 199004, Russia",n/a,True
+"Departmentrof Chemical Engineering, Columbia University, New York, New York 10027, United States",n/a,True
+"Sandia NationalrLaboratories, Albuquerque, New Mexico 87185, United States",n/a,True
+"Departmentrof Biomedical Engineering, Duke University, Durham, North Carolina 27708, United States",n/a,True
+"Instituterof Macromolecular Compounds, Russian Academy of Sciences, St. Petersburg, Russia",n/a,True
+"Departmentrof Applied Physical Sciences, University of North Carolina, Chapel Hill, North Carolina 27599-3287, United States",Department of Applied Physical Sciences,False
+"P. N.rLebedev Physics Institute, Russian Academy of Sciences, Moscow 117924, Russia",n/a,True
+"Department of Chemistry, University of North Carolina, Chapel Hill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"Divisionrof Advanced MaterialsrScience and Department of Chemistry, Pohang University of Science &amp; Technology, Pohang 790784, Korea",n/a,True
+"Forschungszentrum Jülich, JCNS-1/ICS-1, Jülich 52425, Germany",n/a,True
+"Institut Charles Sadron,rCNRS UPR 22, University of Strasbourg, 23, rue du Loess, 67034, Strasbourg, France",n/a,True
+"Institute for EnvironmentalrChemistry, National Research Council of Canada, Ottawa, Canada",n/a,True
+"Institute of ElectronicrStructure and Laser, Foundation for Research and Technology−Hellas (FORTH),rP.O. Box 1527, Heraklion, Crete 71110, Greece",n/a,True
+Beijing Key Laboratory of Active Substance Discovery and Druggability Evaluation,n/a,True
+Natural Products Research Laboratories,n/a,True
+"Department of Cell Biology and Immunology, Faculty of Medicine, Vrije Universiteit, Van der Boechorststraat 7, Amsterdam 1081 BT, The Netherlands",n/a,True
+"Department of Chemistry and Biochemistry, San Francisco State University, San Francisco, USA",n/a,True
+"Division of Digestive Disease and Nutrition, University of North Carolina School of Medicine, Chapel Hill, NC, USA",School of Medicine,False
+"North Carolina Oral Health Institute, The University of North Carolina at Chapel Hill, CB#7454, Chapel Hill, NC 27599-7454, USA",School of Dentistry,False
+"University of Michigan, ",n/a,True
+"University of North Carolina at Chapel Hill, University of Toronto, Ontario, Canada",n/a,True
+"University of Toronto, Ontario, Canada Government of Ontario",n/a,True
+"Ohio State University, Columbus, OH, ",n/a,True
+"University of California, San Francisco, San Francisco, CA, USA",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC, USA, ",University of North Carolina at Chapel Hill,False
+"Virginia Commonwealth University, Richmond, VA, USA",n/a,True
+"University at Albany, SUNY, Albany, NY",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC, ",University of North Carolina at Chapel Hill,False
+"The University of Chicago, Chicago, IL, USA",n/a,True
+"Washington University School of Medicine, St. Louis, MO, USA",n/a,True
+"Children’s Hospital of Philadelphia, Philadelphia, PA, USA",n/a,True
+"Cincinnati Children’s Hospital Medical Center, Cincinnati, OH, USA",n/a,True
+"City of Hope National Medical Center, Duarte, CA, USA",n/a,True
+"Department of Pediatric Oncology, Dana-Farber Cancer Institute and Division of Hematology/Oncology, Childrens Hospital, Boston, MA, USA",n/a,True
+"Medical College of Wisconsin, Milwaukee, WI, USA",n/a,True
+"Tufts Medical Center, Boston, MA, USA",n/a,True
+"University of Oregon, Eugene, OR, USA",n/a,True
+"Philadelphia Veterans Affairs Medical Center, Philadelphia, PA, USA",n/a,True
+"University of Michigan School of Medicine, Ann Arbor, MI, USA",n/a,True
+"University of Pittsburgh School of Medicine, Pittsburgh, PA, USA",n/a,True
+"University of Evansville, Evansville, IN, USA",n/a,True
+"University of Michigan, Ann Arbor, MI, USA",n/a,True
+"Cecil G. Sheps Center for Health Services Research University of North Carolina, Chapel Hill",Cecil G. Sheps Center for Health Services Research,False
+"Division of General Medicine and Clinical Epidemiology, University of North Carolina",Division of General Medicine and Clinical Epidemiology,False
+"Division of General Medicine and Clinical Epidemiology, University of North Carolina, , Cecil G. Sheps Center for Health Services Research University of North Carolina, Chapel Hill",Division of General Medicine and Clinical Epidemiology|Cecil G. Sheps Center for Health Services Research,False
+"Division of General Medicine and Clinical Epidemiology, University of North Carolina, Cecil G. Sheps Center for Health Services Research University of North Carolina, Chapel Hill",Division of General Medicine and Clinical Epidemiology|Cecil G. Sheps Center for Health Services Research,False
+"Department for Clinical Epidemiology and Evidence-based Medicine, Danube University, Krems, Austria",n/a,True
+"University of North Carolina-School of Medicine, Chapel Hill",School of Medicine,False
+"University of North Carolina-School of Pharmacy, Chapel Hill",Eshelman School of Pharmacy,False
+"University of North Carolina-School of Pharmacy, Chapel Hill, ",Eshelman School of Pharmacy,False
+University of Pittsburgh-School of Medicine,n/a,True
+"Division of General Medicine and Clinical Epidemiology, University of North Carolina, Chapel Hill, ",Division of General Medicine and Clinical Epidemiology,False
+"Division of General Medicine and Clinical Epidemiology, University of North Carolina, Chapel Hill, Center for Health Promotion and Disease Prevention, University of North Carolina, Chapel Hill, Sheps Center for Health Services Research, University of North Carolina, Chapel Hill",Cecil G. Sheps Center for Health Services Research|Division of General Medicine and Clinical Epidemiology|UNC Center for Health Promotion and Disease Prevention,False
+"Department of Medicine, University of North Carolina-Chapel Hill, ",Department of Medicine,False
+"Department of Medicine,University of North Carolina-Chapel Hill",Department of Medicine,False
+"Department of MedicineUniversity of North Carolina-Chapel Hill, School of Pharmacy University of North Carolina-Chapel Hill",Eshelman School of Pharmacy|Department of Medicine,False
+"School of Pharmacy, University of North Carolina-Chapel Hill",Eshelman School of Pharmacy,False
+"Department of Medicine, Boston University School of Medicine, Boston, MA (PCS, JTG, PAR, MAL, SM, PD)",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC (NTB, MBG, SEL, SLS)",University of North Carolina at Chapel Hill,False
+"Department of Systems Engineering &amp; Operations Research, George Mason University, Fairfax, Virginia (BPB)",n/a,True
+"Department of Medicine, Division of General Internal Medicine, University of Colorado Anschutz Medical Campus, Aurora, CO (AFD, CLL)",n/a,True
+Environmental and Municipal Engineering School; Lanzhou Jiaotong University; Lanzhou 730000 P. R. China,n/a,True
+"Natural Products Research Laboratories, Eshelman School of Pharmacy; University of North Carolina; Chapel Hill NC 27599",Eshelman School of Pharmacy,False
+Provincial Engineering Laboratory of Biopesticide Preparation; Zhejiang A&F University; Lin'an 311300 P. R. China,n/a,True
+"School of Pharmacy, Lanzhou University; Lanzhou 730000; P. R. China",n/a,True
+Environmental and Municipal Engineering School; Lanzhou Jiaotong University; Lanzhou P.R. China,n/a,True
+"Natural Products Research Laboratories; UNC Eshelman School of Pharmacy, University of North Carolina; Chapel Hill North Carolina",Eshelman School of Pharmacy,False
+School of Pharmacy; Lanzhou University; Lanzhou P.R. China,n/a,True
+State Key Laboratory of Applied Organic Chemistry; Lanzhou University; Lanzhou P.R. China,n/a,True
+Department of Medicine and Center for GI Biology and Diseases; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599,Center for Gastrointestinal Biology and Disease|Department of Medicine,False
+Department of Pediatrics; Division of Neonatal and Developmental Medicine; Stanford University School of Medicine; Palo Alto California 94305,n/a,True
+"Department of Surgery, Beth Israel Deaconess Medical Center; Harvard Medical School; Boston Massachusetts 02115 USA",n/a,True
+Department of Physics and Astronomy; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Physics and Astronomy,False
+DoD Biotechnology High Performance Computing Software Applications Institute,n/a,True
+David H. Murdock Research Institute,n/a,True
+"Bonei Olam, Center for Rare Jewish Genetic Disorders; Brooklyn New Jersey",n/a,True
+Department of Medicine; University of North Carolina School of Medicine; Chapel Hill North Carolina,Department of Medicine,False
+Department of Microbiology and Molecular Genetics; Rutgers-Robert Wood Johnson Medical School; Piscataway New Jersey,n/a,True
+Department of Pathology/Lab Medicine; University of North Carolina School of Medicine; Chapel Hill North Carolina,Department of Pathology and Laboratory Medicine,False
+"From the Joint Department of Biomedical Engineering, University of North Carolina-North Carolina State University, Chapel Hill, NC.",UNC/NCSU Joint Department of Biomedical Engineering,False
+"From the Joint Department of Biomedical Engineering, University of North Carolina/North Carolina State University, Chapel Hill, NC",UNC/NCSU Joint Department of Biomedical Engineering,False
+"From the Department of Mechanical Engineering, University of Colorado, Boulder, CO; Joint Department of Biomedical Engineering, North Carolina State University, Raleigh, NC, University of North Carolina, Chapel Hill, NC",n/a,True
+Department of Biochemistry; Duke University Medical Center; Durham NC USA,n/a,True
+Department of Biology; Center for Diagnostics and Therapeutics; Georgia State University; Atlanta GA USA,n/a,True
+Department of Microbiology and Immunology; Microbiology and Molecular Genetics Program; Emory University; Atlanta GA USA,n/a,True
+Department of Microbiology and Immunology; School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Microbiology and Immunology,False
+Department of Microbiology and Molecular Genetics; University of Pittsburgh School of Medicine; Pittsburgh PA USA,n/a,True
+"Department of Microbiology, Immunology, and Biochemistry; The University of Tennessee Health Science Center; Memphis TN USA",n/a,True
+Emory Vaccine Center; Emory University; Atlanta GA USA,n/a,True
+Department of Microbiology and Immunology; School of Medicine; University of North Carolina; Chapel Hill; NC; 27599-7290; USA,Department of Microbiology and Immunology,False
+"Department of Molecular, Cellular and Developmental Biology; University of California; Santa Barbara; CA; 93106-9610; USA",n/a,True
+Center for Predictive Medicine for Biodefense and Emerging Infectious Diseases; Department of Microbiology and Immunology; University of Louisville School of Medicine; Louisville KY USA,n/a,True
+Department of Microbiology and Immunology; University of North Carolina; Chapel Hill; NC; 27599; USA,Department of Microbiology and Immunology,False
+Centre for Oral Health and Systemic Disease; University of Louisville; Louisville; KY; USA,n/a,True
+Department of Pediatrics; Washington University School of Medicine; St. Louis; MO; USA,n/a,True
+School of Dental Medicine; University of Pennsylvania; Philadelphia; PA; USA,n/a,True
+School of Dentistry; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,School of Dentistry,False
+"Department of Medicine (Hematology/Oncology), Mount Sinai School of Medicine, New York, NY, USA",n/a,True
+"Department of Neurosciences, Mount Sinai School of Medicine, New York, NY, USA",n/a,True
+"Gene Therapy Center, University of North Carolina, Chapel Hill, NC, USA",Gene Therapy Center,False
+" Department of Neurology, University of Michigan and VA Ann Arbor Healthcare System, Ann Arbor, MI, USA",n/a,True
+"Department of Chemistry, ‡Department of Biochemistryrand Biophysics, and §Lineberger Comprehensive Cancer Center, The University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599, United States",University of North Carolina at Chapel Hill,False
+"Division of Molecular Pharmaceutics,rEshelman Schoolrof Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill,rNorth Carolina 27599, United States",Division of Molecular Pharmaceutics,False
+"Division of MolecularrPharmaceutics, UNC Eshelman Schoolrof Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Division of Molecular Pharmaceutics,False
+"Division of Molecular Pharmaceutics, Eshelman School ofrPharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Division of Molecular Pharmaceutics,False
+"FunctionalrPolymer Materials,rChemical Technology of Advanced Materials, Universität Würzburg,r97070 Würzburg, Germany",n/a,True
+"GRECC—Veterans Affairs PugetrSound Health Care System, and Division of Gerontology &amp; GeriatricrMedicine, Department of Medicine, University of Washington, Seattle,rWashington 98104, United States",n/a,True
+"Professur für MakromolekularerChemie, Department Chemie, Technische Universität Dresden,r01062 Dresden, Germany",n/a,True
+"UNC EshelmanrSchool of Pharmacy,rUniversity of North Carolina at Chapel Hill, Chapel Hill, North Carolinar27599, United States",Eshelman School of Pharmacy,False
+"Division of Molecular Pharmaceuticsrand Center for Nanotechnology in Drug Delivery, Eshelman School ofrPharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-7571, United States",Division of Molecular Pharmaceutics|Center for Nanotechnology in Drug Delivery,False
+"Division of Molecular Pharmaceutics, EshelmanrSchool of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Division of Molecular Pharmaceutics,False
+"School of Pharmacy, Harbin Medical University, Harbin, China",n/a,True
+"Shenyang Pharmaceutical University, Shenyang, China",n/a,True
+"Department of Chemical and BiomolecularrEngineering, North Carolina State University, Raleigh, North Carolinar27695, United States",n/a,True
+"Joint Department of BiomedicalrEngineering, University of North Carolina, Chapel Hill, North Carolinar27599, United States, and North Carolina State University, Raleigh,rNorth Carolina 27695, United States",UNC/NCSU Joint Department of Biomedical Engineering,False
+"LiquidiarTechnologies, Morrisville,rNorth Carolina 27560, United States",n/a,True
+"Division of Pharmacotherapyrand Experimental Therapeutics, UNC EshelmanrSchool of Pharmacy, §Curriculum in Toxicology, and ⊥Department of Biostatistics, UNC GillingsrSchool of Public Health, University of North Carolina at Chapel Hill, ChapelrHill, North Carolina, 27599-7569, United States",n/a,True
+"Collegerof Natural Sciences, Division of Statistics and Scientific Computation, The University of Texas at Austin, Austin, Texas 78712, United States",n/a,True
+"Collegerof Pharmacy, Pharmaceutics Division, The University of Texas at Austin, Austin, Texas 78712, United States",n/a,True
+"GillingsrSchool of Global Public Health, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Gillings School of Global Public Health,False
+"InnerrMongolia Key Laboratory of Molecular Biology, Inner Mongolia Medical University, Hohhot, Inner Mongolia, China",n/a,True
+"Division of MolecularrPharmaceutics and Center for Nanotechnology in Drug Delivery, EshelmanrSchool of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Division of Molecular Pharmaceutics|Center for Nanotechnology in Drug Delivery,False
+"Schoolrof Chinese Materia Medica, Guangzhou University of Chinese Medicine, Guangzhou 510006, China",n/a,True
+"Shenyang Pharmaceutical University, Shenyang 110016, China",n/a,True
+"Centerrfor Nanotechnology in Drug Delivery and Division of Molecular Pharmaceutics,rUNC Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-7362, United States",Center for Nanotechnology in Drug Delivery|Division of Molecular Pharmaceutics,False
+"Divisionrof Molecular Pharmaceutics, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Pharmacy Lane, Chapel Hill, North Carolina27599, United States",Division of Molecular Pharmaceutics,False
+"KeyrLaboratory of Structure-Based Drug Design and Discovery, Ministryrof Education, Shenyang Pharmaceutical University, 103 Wenhua Road, Shenyang 110016, China",n/a,True
+"Schoolrof Chinese Materia Medica, Guangzhou University of Chinese Medicine, 232 Waihuan East Road, Guangzhou 510006, China",n/a,True
+"Schoolrof Pharmacy, Shenyang Pharmaceutical University, 103 Wenhua Road, Shenyang 110016, China",n/a,True
+"Departmentrof Neuroscience, The Wexner Medical Center, The Ohio State University, Columbus, Ohio, 43210, United States",n/a,True
+"Departmentrof Pharmaceutical Sciences, College of Pharmacy, The Ohio State University, Columbus, Ohio, 43210, United States",n/a,True
+"MicrobialrInfection and Immunity, The Wexner Medical Center, The Ohio State University, Columbus, Ohio, 43210, United States",n/a,True
+"Molecular,rCellular and Developmental Biology Graduate Program, The Ohio State University, Columbus, Ohio, 43210, United States",n/a,True
+"TherCollege of Veterinary Medicine, The Ohio State University, Columbus, Ohio, 43210, United States",n/a,True
+"BiomedicalrResearch Imaging Center, Department of Radiology, University of North Carolina, Chapel Hill, North Carolina 27514, United States",Department of Radiology|Biomedical Research Imaging Center,False
+"Departmentrof Pathology, University of Southern California, Los Angeles, California 90033, United States",n/a,True
+"Departmentrof Radiology, The Third Affiliated Hospital of Sun Yat-sen University, Guangzhou 510630, China",n/a,True
+"Novartis Institutes for BioMedical Research, Cambridge, Massachusetts 02139, United States",n/a,True
+"Schoolrof Pharmaceutical Science, Shandong University, Jinan 250012, China",n/a,True
+"BiomedicalrResearch Imaging Center and Department of Radiology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, United States",Biomedical Research Imaging Center|Department of Radiology,False
+"Biostatistics Branch; National Institute of Environmental Health Sciences, NIH; Research Triangle Park North Carolina USA",n/a,True
+Department of Neurology; Pennsylvania State University-Milton S. Hershey Medical Center; Hershey Pennsylvania USA,n/a,True
+"Division of Cancer Epidemiology and Genetics; National Cancer Institute, NIH; Rockville Maryland USA",n/a,True
+"Epidemiology Branch; National Institute of Environmental Health Sciences, NIH; Research Triangle Park North Carolina USA",n/a,True
+"Liquidia Technologies Inc., 419 Davis Drive, Suite 100, Morrisville, NorthrCarolina 27560, United States",n/a,True
+"Center forrNanophase MaterialsrSciences, Oak Ridge National Laboratory, Oak Ridge, Tennessee 37831, United States",n/a,True
+"Department of Physicsrand Astronomy, The University of Tennessee, Knoxville, Tennessee 37966,rUnited States",n/a,True
+"Departmentrof Chemical and Biomolecular Engineering, North Carolina State University, Raleigh,rNorth Carolina 27607, United States",n/a,True
+"Department ofrChemical and Biomolecular Engineering, North Carolina State University, Raleigh, North Carolina 27695, United States",n/a,True
+"Department of Pharmaceutics, School of Pharmacy, Shenyang Pharmaceutical University, Shenyang, 110016, China",n/a,True
+"Division of Molecular Pharmaceutics, Eshelman School of Pharmacy, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Division of Molecular Pharmaceutics,False
+"Key Laboratory of Structure-Based Drug Design &amp; Discovery, Ministry of Education, Shenyang Pharmaceutical University, Shenyang, 110016,China",n/a,True
+"School of Pharmacy, Harbin Medical University, Harbin, 150081, China",n/a,True
+Carolina Center for Cancer Nanotechnology Excellence,n/a,True
+Department of Nanoengineering,n/a,True
+Laboratory of Nano- and Translational Medicine,n/a,True
+Division of Molecular Pharmaceutics and Center for Nanotechnology in Drug Delivery,Division of Molecular Pharmaceutics|Center for Nanotechnology in Drug Delivery,False
+UNC and NCSU Joint Department of Biomedical Engineering,UNC/NCSU Joint Department of Biomedical Engineering,False
+Department of Chemistry and Chemical Biology,n/a,True
+Department of Biological Chemistry and Molecular Pharmacology,n/a,True
+Department of Neurological Sciences; University of Vermont College of Medicine; Burlington VT USA,n/a,True
+Department of Palliative Care; Freiburg University Medical Center; Freiburg Germany,n/a,True
+Department of Supportive and Palliative Care; The Royal Surrey County Hospital; Guildford Surrey UK,n/a,True
+Division of Gastroenterology and Hepatology; Mayo Clinic; Rochester MN USA,n/a,True
+Drossman Gastroenterology; PLLC; UNC Center for Functional GI and Motility Disorders; Chapel Hill NC USA,UNC Center for Functional GI and Motility Disorders,False
+PRA Health Sciences; Salt Lake City UT USA,n/a,True
+Center for Functional GI and Motility Disorders; University of North Carolina at Chapel Hill; Chapel Hill NC USA,UNC Center for Functional GI and Motility Disorders,False
+Department of Behavioral Medicine; Tohoku University Graduate School of Medicine; Sendai Japan,n/a,True
+Department of Gastroenterology; Mayo Clinic; Rochester MN USA,n/a,True
+Department of Pediatric Gastroenterology; Emma Children's Hospital/Academic Medical Centre; Amsterdam The Netherlands,n/a,True
+Department of Pediatric Gastroenterology; Nationwide Children's Hospital; Columbus OH USA,n/a,True
+Division of Gastroenterology of the University of Verona; A.O.U.I. Verona; Verona Italy,n/a,True
+Division of Gastroenterology/Hepatology; University of North Carolina; Chapel Hill NC USA,Division of Gastroenterology and Hepatology,False
+Section of Gastroenterology/Hepatology; Georgia Regents University; Augusta GA USA,n/a,True
+Center for Functional GI and Motility Disorders; University of North Carolina School of Medicine; Chapel Hill NC USA,UNC Center for Functional GI and Motility Disorders,False
+Communication for Health Application and Interventions (CHAI) Core; University of North Carolina; Chapel Hill NC USA,University of North Carolina at Chapel Hill,False
+Department of Health Policy and Management; University of North Carolina School of Public Health; Chapel Hill NC USA,Department of Health Policy and Management,False
+Division of Gastroenterology; University of North Carolina School of Medicine; Chapel Hill NC USA,Division of Gastroenterology and Hepatology,False
+Department of Genetics; University of North Carolina; Chapel Hill; NC; USA,Department of Genetics,False
+Department of Nutrition; University of North Carolina; Chapel Hill; NC; USA,Department of Nutrition,False
+USC-Office of Population Studies Foundation Inc.; University of San Carlos; Cebu City; Philippines,n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina at Chapel Hill, NC, USA",UNC Lineberger Comprehensive Cancer Center,False
+"National Evolutionary Synthesis Center, Durham, NC, USA",n/a,True
+"Ecology, Evolution and Organismic Biology, University of North Carolina, Chapel Hill, NC, United States",Department of Biology,False
+"Department of Biology, The University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Biology,False
+"Department of Cell Biology and Physiology, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Cell Biology and Physiology,False
+"UNC/NCSU Joint Department of Biomedical Engineering, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Centro de Investigaciones de Ecosistemas Costeros, Cayo Coco, Morón, Ciego de Ávila, Cuba",n/a,True
+"Department of Biology, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Biology,False
+"Department of Studies for Sustainable Development of the Coastal Zone, University of Guadalajara, Jalisco, Mexico",n/a,True
+"Florida Fish and Wildlife Conservation Commission, Fish and Wildlife Research Institute, Tequesta, FL, USA",n/a,True
+"Australian Research Council Centre of Excellence for Coral Reef Studies, James Cook University, Townsville, QLD, Australia",n/a,True
+"Department of Biology and Marine Biology, University of North Carolina at Wilmington, Wilmington, NC, USA",n/a,True
+"The Betty and Gordon Moore Center for Ecosystem Science and Economics, Conservation International, Arlington, VA, USA",n/a,True
+"Colegio de Ciencias biologicas y ambientales, Universidad San Francisco de Quito, Cumbayá, Diego de Robles y Vía Interoceánica, Quito, Ecuador",n/a,True
+"Department of Biology, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Biology,False
+"Department of Geology, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Geological Sciences,False
+"Department of Marine Science, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",Department of Marine Sciences,False
+"Institute for the Environment, The University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",UNC Institute for the Environment,False
+"Department of Animal Science, University of Nebraska, Lincoln, NE, USA",n/a,True
+"Department of Biological Sciences, University of North Carolina at Charlotte, Charlotte, NC, USA",n/a,True
+"Department of Genetics, University of North Carolina, Chapel Hill, NC, USA",Department of Genetics,False
+"Department of Zoology, Oregon State University, Corvallis, OR, USA",n/a,True
+"Department of Integrative Biology, University of California, Berkeley, United States",n/a,True
+"Department of Mathematics, University of North Carolina at Chapel Hill, United States",Department of Mathematics,False
+"AICBT Ltd, Oxford, UK",n/a,True
+"Department of Biomedical Engineering, Mayo Clinic, Rochester, MN, USA",n/a,True
+"Department of Computer Science, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Computer Science,False
+"Department of Mechanical and Aerospace Engineering, Princeton University, Princeton, NJ, USA",n/a,True
+"Enthought, Inc., Austin, TX, USA",n/a,True
+"Joint Unit, CNRS/Saint-Gobain, Cavaillon, France",n/a,True
+"Stellenbosch University, Stellenbosch, South Africa",n/a,True
+"Victorian Life Sciences Computation Initiative, Carlton, VIC, Australia",n/a,True
+"Department of Bioengineering, University of California, Berkeley, CA, USA",n/a,True
+"Department of Integrative Biology, University of California, Berkeley, CA, USA",n/a,True
+"Department of Mechanical Engineering, University of California, Berkeley, CA, USA",n/a,True
+"College of Veterinary Medicine, North Carolina State University, Raleigh, NC, USA",n/a,True
+"Joint Department of Biomedical Engineering at the University of North Carolina Chapel Hill, North Carolina State University, Raleigh, NC, USA",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Veterinary Neurology Center, Tustin, CA, USA",n/a,True
+"Center for Comparative Medicine and Translational Research, Department of Clinical Sciences, College of Veterinary Medicine, North Carolina State University, Raleigh, NC, USA",n/a,True
+"Comparative Pain Research Laboratory, Department of Clinical Sciences, College of Veterinary Medicine, North Carolina State University, Raleigh, NC, USA",n/a,True
+"Bastian Voice Institute, Downers Grove, IL, USA",n/a,True
+"Department of Otolaryngology-Head and Neck Surgery, University of North Carolina, Chapel Hill, NC, USA",Department of Otolaryngology/Head and Neck Surgery,False
+Department of Global Community Health and Behavioral Sciences; Tulane University School of Public Health and Tropical Medicine; New Orleans,n/a,True
+"Department of Maternal and Child Health, and Carolina Population Center; University of North Carolina; Chapel Hill",Department of Maternal and Child Health|Carolina Population Center,False
+Health Promotion Centre; School of Health Sciences; National University of Ireland; Galway,n/a,True
+Institut National de la Santé et de la Recherche Médicale U1027; University of Toulouse III; France,n/a,True
+Prevention Research Branch; Division of Epidemiology; Statistics and Prevention Research; Eunice Kennedy Shriver National Institute of Child Health and Human Development; Bethesda; MD,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill,Department of Biostatistics,False
+Department of Maternal and Child Health; University of North Carolina at Chapel Hill,Department of Maternal and Child Health,False
+Department of Psychology; University of North Carolina at Chapel Hill,Department of Psychology and Neuroscience,False
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Biostatistics,False
+Vanda Pharmaceutical Inc.; Washington; DC 20037; USA,n/a,True
+Berry Consultants; Austin TX USA,n/a,True
+Biogen IDEC; Cambridge MA USA,n/a,True
+Eli Lilly & Company; Indianapolis IN USA,n/a,True
+F. Hoffman La Roche; Welwyn Garden City Hertfordshire UK,n/a,True
+LA-SER Analytica; London UK,n/a,True
+MD Anderson; Houston TX USA,n/a,True
+Novartis Pharma; CIS; Basel Switzerland,n/a,True
+Novartis; East Hanover NJ USA,n/a,True
+SAS; Cary NC USA,n/a,True
+Sanofi-Aventis R&D; Paris France,n/a,True
+US Food and Drug Administration; Rockville MD USA,n/a,True
+Department of Epidemiology; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Epidemiology,False
+"Division of Cardiology, Department of Medicine; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA",Division of Cardiology,False
+"Division of Nephrology, Department of Medicine; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA",Division of Nephrology and Hypertension,False
+Amgen Inc; Thousand Oaks; CA; USA,n/a,True
+"Department of Epidemiology, Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA",Department of Epidemiology,False
+"Division of Pharmaceutical Outcomes and Policy, UNC Eshelman School of Pharmacy; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA",Division of Pharmaceutical Outcomes and Policy,False
+"Department of Epidemiology, UNC Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA",Department of Epidemiology,False
+"Division of Pharmacoepidemiology and Pharmacoeconomics, Department of Medicine; Brigham and Women's Hospital and Harvard Medical School; Boston; MA; USA",n/a,True
+Leslie Dan Faculty of Pharmacy; University of Toronto; Toronto; ON; Canada,n/a,True
+Cecil G. Sheps Center for Health Services Research; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina; USA,Cecil G. Sheps Center for Health Services Research,False
+"Department of Pharmacy Care Systems, Harrison School of Pharmacy; Auburn University; Auburn; Alabama; USA",n/a,True
+Eshelman School of Pharmacy; University of North Carolina at Chapel Hill; Chapel Hill; North Carolina; USA,Eshelman School of Pharmacy,False
+"Department of Epidemiology, Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapell Hill; NC; USA",Department of Epidemiology,False
+"Department of Epidemiology, Merck Research Laboratories; Merck Sharp & Dohme Corp.; Whitehouse Station; NJ; USA",n/a,True
+Center for Health Research; Geisinger Health System; Danville PA USA,n/a,True
+Department of Epidemiology; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Epidemiology,False
+"Department of Medicine, Division of Infectious Diseases; University of North Carolina at Chapel Hill; Chapel Hill NC USA",Division of Infectious Diseases,False
+Department of Pharmacy Practice and Science; University of Kentucky; Lexington KY USA,n/a,True
+The Cecil G. Sheps Center for Health Services Research; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Cecil G. Sheps Center for Health Services Research,False
+"Department of Biostatistics, Yale University School of Public Health, New Haven, CT, USA",n/a,True
+"Division of Gastroenterology and Hepatology, UNC School of Medicine, Chapel Hill, NC, USA",Division of Gastroenterology and Hepatology,False
+"United Therapeutic Corporation, Research Triangle Park, NC, USA",n/a,True
+Department of Family Medicine; University of Connecticut School of Medicine; Farmington; Connecticut,n/a,True
+Department of Pharmacy Practice and Science; University of Iowa College of Pharmacy; Iowa City; Iowa,n/a,True
+Division of Practice Advancement and Clinical Education; University of North Carolina Eshelman School of Pharmacy; Chapel Hill; North Carolina,Eshelman School of Pharmacy,False
+School of Graduate Studies and Research; University of the Incarnate Word; San Antonio; Texas,n/a,True
+Department of Pharmacotherapy and Experimental Therapeutics; Eshelman School of Pharmacy; University of North Carolina; Chapel Hill North Carolina,Division of Pharmacotherapy and Experimental Therapeutics,False
+Department of Pharmacotherapy and Translational Research; College of Pharmacy; University of Florida; Gainesville Florida,n/a,True
+Department of Pharmacy and Therapeutics; School of Pharmacy; Center for Clinical Pharmaceutical Sciences; University of Pittsburgh; Pittsburgh Pennsylvania,n/a,True
+Division of Nephrology and Hypertension; UNC Kidney Center; University of North Carolina; Chapel Hill North Carolina,Division of Nephrology and Hypertension|UNC Kidney Center,False
+Skaggs School of Pharmacy and Pharmaceutical Sciences; University of Colorado; Aurora Colorado,n/a,True
+Department of Cardiology; School of Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Division of Cardiology,False
+Division of Pharmaceutical Outcomes and Policy; UNC Eshelman School of Pharmacy; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Division of Pharmaceutical Outcomes and Policy,False
+Division of Practice Advancement and Clinical Education; UNC Eshelman School of Pharmacy; Chapel Hill North Carolina,Eshelman School of Pharmacy,False
+Curriculum in Toxicology; University of North Carolina at Chapel Hill; Chapel Hill NC,Curriculum in Toxicology,False
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill NC,Department of Biostatistics,False
+The University of Texas MD Anderson Cancer Center; Science Park/Research Division; University of North Carolina at Chapel Hill; Chapel Hill NC,n/a,True
+College of Osteopathic Medicine; William Carey University; Hattiesburg MS,n/a,True
+Division of Biostatistics; School of Public Health; University of Minnesota; Minneapolis MN,n/a,True
+"Department of Biology, University of North Carolina, Charlotte",n/a,True
+"Department of Kinesiology, University of North Carolina, Charlotte",n/a,True
+"Departments of Nutrition and Cell and Molecular Physiology and Carolina Center for Genome Science, University of North Carolina, Chapel Hill",Carolina Center for Genome Sciences|Department of Cell and Molecular Physiology|Department of Nutrition,False
+"Laboratory of Respiratory Biology, National Institute of Environmental Health Sciences, Durham, North Carolina",n/a,True
+"Department of Chemistry and Biochemistry; The University of North Carolina at Greensboro; Patricia A. Sullivan Science Building, PO Box 26170 Greensboro NC 27402 USA",n/a,True
+"UNC Eshelman School of Pharmacy; The University of North Carolina at Chapel Hill; 2320 Kerr Hall, Campus Box 7569 Chapel Hill NC 27599 USA",Eshelman School of Pharmacy,False
+Department of Biostatistics; University of North Carolina; Chapel Hill NC USA,Department of Biostatistics,False
+Department of Dermatology; University of North Carolina; Chapel Hill NC USA,Department of Dermatology,False
+Department of Medicine; Division of Epidemiology; University of New Mexico; Albuquerque NM USA,n/a,True
+British Columbia Cancer Research Center; Vancouver BC Canada,n/a,True
+Cancercare Ontario; Toronto ON Canada,n/a,True
+Center for Clinical Epidemiology and Biostatistics; Department of Biostatistics and Epidemiology; Perelman School of Medicine; University of Pennsylvania; Philadelphia PA USA,n/a,True
+Department of Dermatology; Epidemiology and Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill NC USA,Department of Dermatology|Department of Epidemiology|UNC Lineberger Comprehensive Cancer Center,False
+Department of Epidemiology and Biostatistics; Memorial Sloan-Kettering Cancer Center; New York NY USA,n/a,True
+Department of Epidemiology; University of California; Irvine CA USA,n/a,True
+Departments of Internal Medicine and Dermatology; University of New Mexico; Albuquerque NM USA,n/a,True
+Keck School of Medicine; University of Southern California Norris Comprehensive Cancer Center; University of Southern California; Los Angeles CA USA,n/a,True
+Menzies Centre for Population Health; University of Tasmania; Hobart Tas Australia,n/a,True
+School of Public Health; University of Sydney; Sydney NSW Australia,n/a,True
+Womens College Hospital; Toronto ON Canada,n/a,True
+Department of Dermatology; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Dermatology,False
+Department of Surgery; University of North Carolina School of Medicine; Chapel Hill NC USA,Department of Surgery,False
+The Lineberger Comprehensive Cancer Center; University of North Carolina School of Medicine; Chapel Hill NC USA,UNC Lineberger Comprehensive Cancer Center,False
+Department of Biology; Memorial University of Newfoundland; St John's NL Canada,n/a,True
+Department of Neurobiology and Behavior; Cornell University; Ithaca NY USA,n/a,True
+Lineberger Comprehensive Cancer Center; Department of Microbiology & Immunology; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Microbiology and Immunology|UNC Lineberger Comprehensive Cancer Center,False
+"Division of Geriatrics and Nutritional Science, Washington University School of Medicine, St. Louis, MO, USA",n/a,True
+"Division of Gerontology, Department of Epidemiology and Preventive Medicine, University of Maryland Baltimore, Baltimore, MD, USA",n/a,True
+"Institute for Aging Research, Hebrew SeniorLife, and Harvard Medical School, Boston, MA, USA",n/a,True
+"Maryland Medical Research Institute, Baltimore, MD, USA",n/a,True
+"Maryland Medical Research Institute, Baltimore, MD, USA, ",n/a,True
+"Program on Aging, Disability and Long-Term Care, Cecil G. Sheps Center for Health Services Research, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Cecil G. Sheps Center for Health Services Research,False
+"Biomedical Engineering, SUNY Stony Brook, Stony Brook, NY, USA",n/a,True
+"Cecil G. Sheps Center for Health Services Research, University of North Carolina, Chapel Hill, NC, USA",Cecil G. Sheps Center for Health Services Research,False
+"Center for Advanced Orthopaedic Studies, Beth Israel Deaconess Medical Center, Boston, MA, USA",n/a,True
+"Department of Medicine, Columbia University College of Physicians &amp; Surgeons, New York, NY, USA",n/a,True
+"Epidemiology &amp; Preventive Medicine, University of Maryland, Baltimore, MD, USA",n/a,True
+"Institute for Aging Research, Hebrew SeniorLife, Boston, MA, USA, ",n/a,True
+"Radiology, UCSF, San Francisco, CA, USA",n/a,True
+"Department of Health Policy and Management, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC, USA",Department of Health Policy and Management,False
+"University of North Carolina-Lineberger Comprehensive Cancer Center, Chapel Hill, NC, USA",UNC Lineberger Comprehensive Cancer Center,False
+"Graduate School of Public Health, University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"Human Computer Interaction Institute, Carnegie Mellon University, Pittsburgh, PA, USA",n/a,True
+"School of Journalism and Mass Communication, University of Wisconsin–Madison, Madison, WI, USA",n/a,True
+"School of Medicine, University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"School of Nursing, University of North Carolina, Chapel Hill, NC, USA",School of Nursing,False
+"School of Nursing, University of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"Children’s Hospital Boston, Boston, MA, USA",n/a,True
+"Children’s Hospital of Pittsburgh, Pittsburgh, PA, USA",n/a,True
+"Department of Medicine, Duke University Medical Center, Durham, NC, USA",n/a,True
+"Department of Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Medicine,False
+"Department of Medicine, Virginia Commonwealth University, Richmond, VA, USA",n/a,True
+"Department of Pediatrics, Emory University School of Medicine, Atlanta, GA, USA",n/a,True
+"Department of Pediatrics, University of Illinois at Chicago, Chicago, IL, USA",n/a,True
+"Department of Pediatrics, University of Pennsylvania School of Medicine, Philadelphia, PA, USA",n/a,True
+"Grady Memorial Hospital, Emory University School of Medicine, Atlanta, GA, USA",n/a,True
+"Hematology Branch, National Institutes of Health, Bethesda, MD, USA",n/a,True
+"New England Research Institutes, Watertown, MA, USA",n/a,True
+"Adjunct Senior Fellow, East-West Center, Honolulu.",n/a,True
+"N.B. Ryder Professor of Sociology, University of Wisconsin-Madison.",n/a,True
+"Professor, Faculty of Economics, Keio University, Tokyo.",n/a,True
+"Senior Fellow, East-West Center, Honolulu, and Research Professor, Department of Sociology, University of North Carolina, Chapel Hill.",Department of Sociology,False
+Department of Psychology; Indiana University-Purdue University Indianapolis; Indianapolis IN USA,n/a,True
+Department of Surgery; Indiana University School of Medicine; Indianapolis IN USA,n/a,True
+Indiana University School of Nursing; Indianapolis IN USA,n/a,True
+"Datalys Center for Sports Injury Research and Prevention, Inc, Indianapolis, IN",n/a,True
+"National Collegiate Athletic Association, Sport Science Institute, Indianapolis, IN",n/a,True
+"State Health Registry of Iowa, University of Iowa, Iowa City",n/a,True
+Department of Health Policy and Management; University of North Carolina; Chapel Hill NC,Department of Health Policy and Management,False
+Department of Industrial Engineering; Clemson University; Clemson SC,n/a,True
+Department of Industrial and Systems Engineering; North Carolina State University; Raleigh NC,n/a,True
+"Datalys Center for Sports Injury Research and Prevention, Inc, Indianapolis, IN;",n/a,True
+"Penn State University, University Park, PA;",n/a,True
+"Springfield College, Indianapolis, IN;",n/a,True
+"Department of Industrial Engineering, Clemson University, SC (HTD)",n/a,True
+Division of Gastroenterology and Hepatology; Indiana University School of Medicine; Indianapolis IN USA,n/a,True
+Division of Gastroenterology and Hepatology; University of North Carolina; Chapel Hill NC USA,Division of Gastroenterology and Hepatology,False
+Division of Gastroenterology; California Pacific Medical Center; San Francisco CA USA,n/a,True
+Division of Gastroenterology; University of Michigan; Ann Arbor MI USA,n/a,True
+Division of Gastroenterology; University of Pennsylvania; Philadelphia PA USA,n/a,True
+Division of Gastroenterology; University of Texas Southwestern; Dallas TX USA,n/a,True
+Division of Gastrointestinal and Liver Diseases; University of Southern California; Los Angeles CA USA,n/a,True
+Duke Clinical Research Institute & Department of Biostatistics; Duke University; Durham NC USA,n/a,True
+Liver Disease Research Branch; Division of Digestive Diseases and Nutrition; National Institute of Diabetes and Digestive and Kidney Diseases (NIDDK); NIH; Bethesda MD USA,n/a,True
+"The Datalys Center, Indianapolis, IN",n/a,True
+"Department of Pathology and Laboratory Medicine, School of Medicine, University of North Carolina, Chapel Hill, NC 27599-7035, USA",Department of Pathology and Laboratory Medicine,False
+Department of Biochemistry and Biophysics; University of North Carolina; Chapel Hill; North Carolina; 27599,Department of Biochemistry and Biophysics,False
+Department of Chemistry; University of North Carolina; Chapel Hill; North Carolina; 27599,Department of Chemistry,False
+Department of Chemistry; University of North Carolina; Chapel Hill North Carolina 27599,Department of Chemistry,False
+Department of Biochemistry and Biophysics; University of North Carolina; Chapel Hill North Carolina 27599,Department of Biochemistry and Biophysics,False
+Department of Physics and INFN; Università degli Studi di Milano; Milano 20133 Italy,n/a,True
+Department of Microbiology and Immunology; Lineberger Comprehensive Cancer Center; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Microbiology and Immunology|UNC Lineberger Comprehensive Cancer Center,False
+Department of Molecular Biology; Princeton University; Princeton NJ USA,n/a,True
+Bone Marrow Transplant/Hematology; Mount Sinai Hospital; New York; NY; USA,n/a,True
+Cancer Prevention Fellowship Program; National Cancer Institute; Bethesda; MD; USA,n/a,True
+Department of Medicine; Mount Sinai School of Medicine; New York; NY; USA,n/a,True
+Department of Oncological Sciences; Mount Sinai School of Medicine; New York; NY; USA,n/a,True
+Department of Psychology; William Paterson University; Wayne; NJ; USA,n/a,True
+The John Theurer Cancer Center; Hackensack University Medical Center; Hackensack; NJ; USA,n/a,True
+Cancer Care Research Program; Duke Cancer Institute; Durham; NC; USA,n/a,True
+Cecil G. Sheps Center for Health Services Research; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Cecil G. Sheps Center for Health Services Research,False
+"Department of Biostatistics, School of Public Health; University of California Los Angeles; Los Angeles; CA; USA",n/a,True
+"Cancer Prevention Fellowship Program, Center for Cancer Training; National Cancer Institute; Rockville; MD; USA",n/a,True
+Ferkauf Graduate School of Psychology; Yeshiva University; New York; NY; USA,n/a,True
+Mount Sinai School of Medicine; New York; NY; USA,n/a,True
+College of Nursing; Michigan State University; East Lansing; MI; USA,n/a,True
+Department of Biostatistics; Indiana University School of Medicine; Indianapolis; IN; USA,n/a,True
+Department of Medicine; Indiana University School of Medicine; Indianapolis; IN; USA,n/a,True
+Department of Psychiatry and Behavioral Sciences; Memorial Sloan-Kettering Cancer Center; New York; NY; USA,n/a,True
+Department of Psychology; Indiana University-Purdue University Indianapolis; Indianapolis; IN; USA,n/a,True
+Department of Radiation Oncology; University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,Department of Radiation Oncology,False
+Department of Surgery; Indiana University School of Medicine; Indianapolis; IN; USA,n/a,True
+Indiana University School of Nursing; Indianapolis; IN; USA,n/a,True
+Department of Psychiatry; Columbia University College of Physicians and Surgeons; New York; New York; USA,n/a,True
+Division of Cognitive Neuroscience; New York State Psychiatric Institute; New York; New York; USA,n/a,True
+Department of Psychiatry; University of North Carolina at Chapel Hill; Chapel Hill North Carolina USA,Department of Psychiatry,False
+School of Nursing Carrington Hall; The University of North Carolina at Chapel Hill; Chapel Hill; North Carolina,School of Nursing,False
+School of Nursing; University of North Carolina at Greensboro; Greensboro; North Carolina,n/a,True
+The University of North Carolina at Chapel Hill School of Nursing; Chapel Hill; North Carolina,School of Nursing,False
+"The University of North Carolina at Chapel Hill, School of Exercise and Sport Science; Chapel Hill; North Carolina",Department of Exercise and Sport Science,False
+" Department of Health Policy and Administration, School of Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Health Policy and Management,False
+" Immunization Bureau, Houston Department of Health and Human Services, Houston, TX; at the time of this study, Mr. Setzer was an MSPH student at the University of North Carolina at Chapel Hill",n/a,True
+" Epidemiology Section, North Carolina Division of Public Health, Raleigh, NC",n/a,True
+" North Carolina Center for Public Health Preparedness, North Carolina Institute for Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" Northeastern North Carolina Partnership for Public Health, Elizabeth City, NC",n/a,True
+" Department of Biostatistics, School of Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Biostatistics,False
+" Division of Infectious Diseases, Department of Medicine, University of North Carolina School of Medicine, Chapel Hill, NC",Division of Infectious Diseases,False
+" Behavioral and Clinical Surveillance Branch, Division of HIV/AIDS Prevention, Centers for Disease Control and Prevention, Atlanta [at the time of this study, Dr. Sullivan was with the HIV Vaccine Trials Network, Fred Hutchinson Cancer Research Center, Seattle, WA]",n/a,True
+" Department of Biostatistics, School of Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC [at the time of this study, Dr. Hudgens was with the Statistical Center for HIV and AIDS Research and Prevention, Fred Hutchinson Cancer Research Center, Seattle, WA]",Department of Biostatistics,False
+" HIV Vaccine Trials Network, Fred Hutchinson Cancer Research Center, Seattle, WA",n/a,True
+" New York Blood Center, New York, NY",n/a,True
+" Novartis Pharma AG, Basel, Switzerland [at the time of this study, Mr. diTommaso was with the Statistical Center for HIV and AIDS Research and Prevention, Fred Hutchinson Cancer Research Center, Seattle, WA]",n/a,True
+" Public Health Prevention Service, Epidemiology Program Office, Centers for Disease Control and Prevention, Atlanta, GA [at the time of this study, Ms. Katzman was assigned to the HIV Vaccine Trials Network, Fred Hutchinson Cancer Research Center, Seattle, WA]",n/a,True
+" Department of Epidemiology, North Carolina Center for Public Health Preparedness, North Carolina Institute for Public Health, University of North Carolina at Chapel Hill, School of Public Health, Chapel Hill, NC",North Carolina Institute for Public Health|Department of Epidemiology,False
+" American Cancer Society, Austin, TX",n/a,True
+" Department of Community and Family Medicine, Dartmouth Medical School, Lebanon, NH",n/a,True
+" Division of Reproductive Health, Centers for Disease Control and Prevention, Atlanta, GA",n/a,True
+" Rocky Mountain Health Plans, Grand Junction, CO",n/a,True
+" Rollins School of Public Health, Emory University, Atlanta, GA",n/a,True
+" School of Business, University of Houston Clear Lake, Houston, TX [At the time of this study, Dr. Ayadi was a Health Economist with the Division of Reproductive Health, Centers for Disease Control and Prevention, Atlanta, GA.]",n/a,True
+" Smoke-Free Families National Dissemination Office, Cecil G. Sheps Center for Health Services Research, University of North Carolina, Chapel Hill, NC",Cecil G. Sheps Center for Health Services Research,False
+" Department of Health Behavior and Health Education, School of Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Health Behavior,False
+" Department of Health Education and Behavioral Science, University of Medicine and Dentistry of New Jersey School of Public Health, Newark, NJ",n/a,True
+" Department of Health Behavior and Health Education, School of Public Health, University of North Carolina, Chapel Hill, NC; Institute for Health Research and Policy, University of Illinois, Chicago, IL; and Departmento de Investigacion sobre Tabaco, Instituto Nacional de Salud Pública, Cuernavaca, Morelos, Mexico (current affiliation: Department of Health Promotion, Education, and Behavior, Arnold School of Public Health, University of South Carolina, Columbia, SC)",n/a,True
+" Department of Nutrition, School of Public Health, University of North Carolina, Chapel Hill, NC",Department of Nutrition,False
+" Epidemiology Section, Division of Public Health, North Carolina Department of Health and Human Services, Raleigh, NC",n/a,True
+" North Carolina Center for Public Health Preparedness, North Carolina Institute for Public Health, University of North Carolina School of Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" Cecil G. Sheps Center for Health Services Research and School of Medicine, University of North Carolina, Chapel Hill, NC",Cecil G. Sheps Center for Health Services Research|School of Medicine,False
+" The Institute for Health, Social, and Community Research, Shaw University, Raleigh, NC",n/a,True
+" Department of Epidemiology and North Carolina Center for Public Health Preparedness, North Carolina Institute for Public Health, The University of North Carolina School of Public Health, Chapel Hill, NC",Department of Epidemiology|North Carolina Institute for Public Health,False
+" General Communicable Disease Control Branch, Epidemiology Section, North Carolina Division of Public Health, North Carolina Department of Health and Human Services, Raleigh, NC",n/a,True
+" North Carolina Center for Public Health Preparedness, North Carolina Institute for Public Health, The University of North Carolina School of Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" North Carolina Institute for Public Health, The University of North Carolina School of Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" Bureau of STD Control, New York State Department of Health, Albany, NY",n/a,True
+" Departments of Medicine and Public Health Sciences, Penn State Hershey College of Medicine, Hershey PA",n/a,True
+" Division of Family Health, Office of the Medical Director, New York State Department of Health, Albany, NY",n/a,True
+" University at Albany, State University of New York, Rensselaer, NY",n/a,True
+" University of North Carolina at Chapel Hill, Chapel Hill, NC",University of North Carolina at Chapel Hill,False
+" Department of Epidemiology, Gillings School of Global Public Health, The University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Epidemiology,False
+" North Carolina Center for Public Health Preparedness, North Carolina Institute for Public Health, Gillings School of Global Public Health, The University of North Carolina at Chapel Hill, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" AIDS Care Services, Winston-Salem, NC",n/a,True
+" Department of Counseling/Human Organizational Studies, The George Washington University, Washington, DC",n/a,True
+" Department of Health Behavior and Health Education, University of North Carolina School of Public Health, Chapel Hill, NC",Department of Health Behavior,False
+" Department of Internal Medicine, Wake Forest University School of Medicine, Winston-Salem, NC",n/a,True
+" Department of Social Sciences and Health Policy, Division of Public Health Sciences, Wake Forest University School of Medicine, Winston-Salem, NC",n/a,True
+" Triad Health Project, Greensboro, NC",n/a,True
+" Office of Public Health Preparedness and Response, Centers for Disease Control and Prevention, Atlanta, GA",n/a,True
+" Office of Public Health Preparedness and Response, Epidemiology Section, North Carolina Division of Public Health, North Carolina Department of Health and Human Services, Raleigh, NC",n/a,True
+" University of North Carolina at Chapel Hill, Gillings School of Global Public Health, Chapel Hill, NC",Gillings School of Global Public Health,False
+" University of North Carolina at Chapel Hill, School of Medicine, Chapel Hill, NC",School of Medicine,False
+" Department of Epidemiology, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Epidemiology,False
+" Department of Medicine, Massachusetts General Hospital, Harvard Medical School, Boston, MA",n/a,True
+" University of North Carolina at Chapel Hill, Gillings School of Global Public Health, Department of Maternal and Child Health, Chapel Hill, NC",Department of Maternal and Child Health,False
+" Emory University, Rollins School of Public Health, Department of Behavioral Sciences and Health Education, Atlanta, GA",n/a,True
+" Georgetown University, Department of International Health, Washington, DC",n/a,True
+" The University of Texas Health Science Center at Houston, Houston, TX",n/a,True
+" University of North Carolina, School of Public Health, Chapel Hill, NC",Gillings School of Global Public Health,False
+" Centers for Disease Control and Prevention, Office of Public Health Preparedness and Response, Atlanta, GA",n/a,True
+" The University of North Carolina at Chapel Hill, Department of Emergency Medicine, Chapel Hill, NC",Department of Emergency Medicine,False
+" The University of North Carolina at Chapel Hill, Gillings School of Global Public Health, Institute for Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" The University of North Carolina at Chapel Hill, School for Information and Library Science, Chapel Hill, NC",School of Information and Library Science,False
+" Laurentian University, Centre for Research in Human Development, Sudbury, Ontario",n/a,True
+" The University of North Carolina at Chapel Hill, Injury Prevention Research Center, Chapel Hill, NC",Injury Prevention Research Center,False
+" West Virginia University, Injury Control Research Center and Department of Community Medicine, Morgantown, WV",n/a,True
+" Brandeis University, Heller School for Social Policy and Management, Lurie Institute for Disability Policy, Waltham, MA",n/a,True
+" University of North Carolina at Chapel Hill, FPG Child Development Institute, North Carolina Office on Disability and Health, Chapel Hill, NC",Frank Porter Graham Child Development Institute,False
+" University of North Carolina at Chapel Hill, School of Social Work, Chapel Hill, NC",School of Social Work,False
+" The University of North Carolina at Chapel Hill, Department of Emergency Medicine, Carolina Center for Health Informatics, Chapel Hill, NC",Department of Emergency Medicine,False
+" The University of North Carolina at Chapel Hill, Gillings School of Global Public Health, North Carolina Institute for Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" University of North Carolina at Chapel Hill, Carolina Population Center, Chapel Hill, NC",Carolina Population Center,False
+" North Carolina Department of Health and Human Services, State Center for Health Statistics, Division of Public Health, Chapel Hill, NC",n/a,True
+" The University of North Carolina at Chapel Hill, Department of Pediatrics, Chapel Hill, NC",Department of Pediatrics,False
+" The University of Pennsylvania and The Children's Hospital of Philadelphia, Department of Pediatrics, Philadelphia, PA",n/a,True
+" University of North Carolina, Gillings School of Global Public Health, North Carolina Institute for Public Health, Chapel Hill, NC",Gillings School of Global Public Health,False
+" University of North Carolina at Chapel Hill, Gillings School of Global Public Health, North Carolina Institute for Public Health, Chapel Hill, NC",North Carolina Institute for Public Health,False
+" University of North Carolina, Department of Epidemiology, Chapel Hill, NC",Department of Epidemiology,False
+" Federal University of Bahia, Functional Electrical Stimulation Laboratory, Department of Biomorphology &amp; Study Group in Neuromodulation, Department of Neurosciences, Salvador-Bahia, Brazil",n/a,True
+" University of Iowa, Department of Health Management and Policy, Iowa City, IA",n/a,True
+" University of North Carolina at Chapel Hill, Department of Maternal and Child Health, Chapel Hill, NC",Department of Maternal and Child Health,False
+" Centers for Disease Control and Prevention, Division of Nutrition, Physical Activity, and Obesity, Atlanta, GA",n/a,True
+" University of North Carolina at Chapel Hill, Center for Health Promotion &amp; Disease Prevention, Chapel Hill, NC",UNC Center for Health Promotion and Disease Prevention,False
+" University of North Carolina at Chapel Hill, School of Nursing, Chapel Hill, NC",School of Nursing,False
+"Colorado State University, Fort Collins, Colorado, USA",n/a,True
+"Duke University Medical Center, Durham, North Carolina, USA",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA",University of North Carolina at Chapel Hill,False
+"Virginia Department of Health and Virginia Commonwealth University, Richmond, Virginia, USA",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, North Carolina, USA, ",University of North Carolina at Chapel Hill,False
+"New England Research Institutes, Watertown, Massachusetts, USA",n/a,True
+"University of Illinois at Chicago, Chicago, Illinois, USA",n/a,True
+"University of North Carolina at Chapel Hill, USA, ",University of North Carolina at Chapel Hill,False
+"Health Care Consultant, Evans, Georgia, USA",n/a,True
+"University College London, London, United Kingdom",n/a,True
+"University of New Mexico, Albuquerque, New Mexico, USA",n/a,True
+"University of North Carolina at Chapel Hill, North Carolina, USA",University of North Carolina at Chapel Hill,False
+"Yale University, New Haven, Connecticut, USA",n/a,True
+"Yale University, New Haven, Connecticut, USA, ",n/a,True
+"Cedars-Sinai Medical Center, Los Angeles, California, USA",n/a,True
+"Northwestern University Medical School, Chicago, Illinois, USA",n/a,True
+"Rush University Medical Center, Chicago, Illinois, USA",n/a,True
+"Broadway Housing Communities, New York, New York, USA",n/a,True
+"Columbia University, New York, New York, USA",n/a,True
+"New York State Psychiatric Institute, New York, New York, USA",n/a,True
+"Pathways to Housing, New York, New York, USA",n/a,True
+"Center for AIDS Prevention Studies, San Francisco, California, USA",n/a,True
+"East Carolina University, Greenville, North Carolina, USA",n/a,True
+"Essential Engagement, Inc., Tarboro, North Carolina, USA",n/a,True
+"Gramercy Research Group, Winston-Salem, North Carolina, USA",n/a,True
+"University of Pittsburgh, Pittsburgh, Pennsylvania, USA",n/a,True
+"Northwestern University, Evanston, Illinois, USA",n/a,True
+"RAND Corporation, Pittsburgh, Pennsylvania, USA",n/a,True
+"Kinshasa School of Public Health, Kinshasa, Democratic Republic of the Congo",n/a,True
+"San Diego State University, San Diego, California, USA",n/a,True
+"International Center for Diarrheal Disease Research, Bangladesh, Dhaka, Bangladesh",n/a,True
+" a  3-C Institute for Social Development , Cary, North Carolina,  USA",n/a,True
+" b  University of North Carolina at Chapel Hill , Chapel Hill, North Carolina,  USA",University of North Carolina at Chapel Hill,False
+"Florida State University, Tallahassee, FL, USA",n/a,True
+"Department of Obstetrics &amp; Gynecology, University of Missouri",n/a,True
+"Department of Obstetrics &amp; Gynecology, University of North Carolina at Chapel Hill",Department of Obstetrics and Gynecology,False
+"Department of Obstetrics &amp; Gynecology, University of North Carolina at Chapel Hill, ",Department of Obstetrics and Gynecology,False
+"Department of Pathology, University of North Carolina at Chapel Hill",Department of Pathology and Laboratory Medicine,False
+"School of Medicine, University of Tokyo, Japan",n/a,True
+"Division of Reproductive Endocrinology and Infertility, Department of Obstetrics &amp; Gynecology, University of North Carolina, Chapel Hill, North Carolina",Department of Obstetrics and Gynecology,False
+"Division of Reproductive Endocrinology and Infertility, Department of Obstetrics &amp; Gynecology, University of North Carolina, Chapel Hill, North Carolina, ",Department of Obstetrics and Gynecology,False
+"Reproductive Endocrinology and Infertility, Department of Obstetrics &amp; Gynecology, Greenville Hospital System, Greenville, South Carolina",n/a,True
+"UNC-Duke Michael Hooker Proteomics Center, University of North Carolina, Chapel Hill, North Carolina",School of Medicine,False
+"Erasmus University Medical Center, Department of Obstetrics and Gynecology, Rotterdam, The Netherlands",n/a,True
+"Gynecologic Oncology Associates, Newport Beach, CA",n/a,True
+"University of North Carolina, Division of Gynecologic Oncology, Chapel Hill, NC",Department of Obstetrics and Gynecology,False
+"University of Virginia, Division of Gynecologic Oncology, Charlottesville, VA",n/a,True
+"Department of Gynecology &amp; Obstetrics, Emory University School of Medicine, Atlanta, GA, USA",n/a,True
+"Department of Molecular &amp; Integrative Physiology, University of Illinois at Urbana–Champaign, Urbana, IL, USA",n/a,True
+"Department of Obstetrics and Gynecology, The University of North Carolina School of Medicine, Chapel Hill, NC, USA",Department of Obstetrics and Gynecology,False
+"Greenville Hospital System, University of South Carolina School of Medicine, Greenville, SC, USA",n/a,True
+"Department of Biostatistics &amp; Carolina Population Center, University of North Carolina, Chapel Hill, NC, USA",Department of Biostatistics|Carolina Population Center,False
+"Department of Obstetrics and Gynecology, University of North Carolina, Chapel Hill, NC, USA",Department of Obstetrics and Gynecology,False
+"Division of Applied Research and Technology, National Institute for Occupational Safety and Health, Cincinnati, OH, USA",n/a,True
+"Epidemiology Branch, National Institute of Environmental Health Science/National Institutes of Health, Research Triangle Park, NC, USA",n/a,True
+"Division of Maternal-Fetal Medicine, Department of Obstetrics and Gynecology, Duke University, Durham, NC, USA",n/a,True
+"Department of Obstetrics and Gynecology, Greenville Health System, Greenville, SC, USA",n/a,True
+"Department of Obstetrics and Gynecology, University of North Carolina at Chapel Hill, NC, USA",Department of Obstetrics and Gynecology,False
+"Departmento de Ginecologia e Obstetrícia, Universidade Federal do Rio Grande do Sul, Brazil",n/a,True
+"Departamento de Ginecologia e Obstetrícia, Universidade Federal do Rio Grande do Sul, Porto Alegre, Brazil",n/a,True
+"National Institute of Environmental Health Science, Research Triangle Park, NC, USA",n/a,True
+"Ob/Gyn, Greenville Health System, Greenville, SC, USA",n/a,True
+"Ob/Gyn, UNC School of Medicine, Chapel Hill, NC, USA",School of Medicine,False
+"Obstetrics, Gynecology and Reproductive Sciences, Robert Wood Johnson Medical School, Rutgers University, Basking Ridge, NJ, USA",n/a,True
+"Oregon National Primate Research Center, Oregon Health &amp; Science University, Beaverton, OR, USA",n/a,True
+"Department of Obstetrics and Gynecology, Duke University, Durham, NC, USA",n/a,True
+"Department of Obstetrics and Gynecology, Jefferson Medical College of Thomas Jefferson University, Philadelphia, PA, USA",n/a,True
+"Department of Obstetrics and Gynecology, University of California, San Diego, San Diego, CA, USA",n/a,True
+"Department of Obstetrics and Gynecology, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Obstetrics and Gynecology,False
+"School of Dentistry, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",School of Dentistry,False
+School of Nursing; Indiana University; Indianapolis; IN,n/a,True
+School of Nursing; Oregon Health & Science University; 3455 S.W. U.S. Veterans Hospital Rd.; Portland; OR; 97239-2941,n/a,True
+Nell Hodgson Woodruff School of Nursing; Emory University; 1520 Clifton Road Atlanta GA 30322,n/a,True
+Nell Hodgson Woodruff School of Nursing; Emory University; Atlanta GA,n/a,True
+University of North Carolina at Chapel Hill School of Nursing; Chapel Hill NC,School of Nursing,False
+"Associate Professor and Beerstecher and Blackwell Term Distinguished Scholar, School of Nursing; University of North Carolina at Chapel Hill; 7460 Carrington Hall Chapel Hill NC 27599",School of Nursing,False
+"Helen Denne Schulte Professor Emerita, School of Nursing; University of Wisconsin-Madison; Madison WI",n/a,True
+"Assistant Professor College of Nursing; New York University; 433 First Avenue, #742 New York NY 10010",n/a,True
+Professor School of Nursing; University of North Carolina; Chapel Hill NC,School of Nursing,False
+Professor and Edith Clemmer Steinbright Chair of Gerontology School of Nursing; University of Pennsylvania; Philadelphia PA,n/a,True
+Duke University Medical Center,n/a,True
+La Sierra University,n/a,True
+"Miami University at Oxford, Ohio",n/a,True
+"University of California, Riverside",n/a,True
+"School of Social Work, University of Maryland",n/a,True
+"School of Social Work, University of North Carolinarat Chapel Hill, ",School of Social Work,False
+"Youth Villages, Memphis, Tennessee",n/a,True
+"School of Social Work, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA, ",School of Social Work,False
+State Key Laboratory of Pharmaceutical Biotechnology,n/a,True
+Chongqing Key Laboratory of Oral Diseases and Biomedical Sciences,n/a,True
+Division of Bioprosthodontics,n/a,True
+NC Oral Health Institute,n/a,True
+Department of Sociology; University of North Carolina and East West Center,Department of Sociology,False
+Department of Sociology; University of Oklahoma,n/a,True
+Population Studies Center; University of Michigan,n/a,True
+Department of Biostatistics; University of North Carolina,Department of Biostatistics,False
+Department of Statistics; University of Connecticut,n/a,True
+"Division of Biostatistics, Medical College of Wisconsin",n/a,True
+Instituto de Ciências Matemáticas e de Computação; Universidade de São Paulo,n/a,True
+"Department of Biochemistry and Biophysics, University of North Carolina, Chapel Hill, North Carolina 27599-7260, United States",Department of Biochemistry and Biophysics,False
+"Department of Chemistry, The State University of New York at Buffalo, Buffalo, New York 14260, United States",n/a,True
+"Department of Pharmacology, University of North Carolina, Chapel Hill, North Carolina 27599-7365, United States",Department of Pharmacology,False
+"Center for Structural Biology, University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599",School of Medicine,False
+Department of Biochemistry and Biophysics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599-7260,Department of Biochemistry and Biophysics,False
+Department of Chemistry; State University of New York at Buffalo; Buffalo New York 14260,n/a,True
+Department of Chemistry; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599-3290,Department of Chemistry,False
+"Institute of Chemistry and Biotechnology; Federal University of Alagoas, UFAL; Maceió AL Brazil",n/a,True
+Ralph N. Adams Institute for Bioanalytical Chemistry; University of Kansas; Lawrence KS USA,n/a,True
+"State University of Campinas, UNICAMP; Campinas Brazil",n/a,True
+"Department of Radiology, Hospital for Special Surgery, New York, New York",n/a,True
+"Department of Radiology, the University of North Carolina, Chapel Hill, North Carolina",Department of Radiology,False
+"Division of Vascular and Interventional Radiology, Department of Radiology, University of North Carolina School of Medicine, Chapel Hill, North Carolina",Department of Radiology,False
+"Department of Radiology, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Radiology,False
+"Department of Surgery, University of North Carolina at Chapel Hill",Department of Surgery,False
+"Coastal Radiology Associates, Department of Radiology, Carolina East Medical Center, New Bern, North Carolina",n/a,True
+"Department of Radiology, University of North Carolina, Chapel Hill, North Carolina",Department of Radiology,False
+"Memorial Sloan Kettering Cancer Center, Weill Cornell Medical College, New York, New York",n/a,True
+"n        Barrow Neurological Institute, Phoenix, AZ",n/a,True
+"n        Houston Sleep Center,Houston, TX",n/a,True
+"n        Louisiana State University, Shreveport, LA",n/a,True
+"n        Mayo Clinic, Rochester, MN",n/a,True
+"n        Mount Sinai Medical Center,New York, New York",n/a,True
+"n        Rhode Island Hospital Providence, RI",n/a,True
+"n        St. Joseph Memorial Hospital, Murphysboro, IL",n/a,True
+"n        Stanford University, Stanford, CA",n/a,True
+"n        Toronto, Canada",n/a,True
+"n        University of North Carolina, Chapel Hill, NC",University of North Carolina at Chapel Hill,False
+"n        University of Washington, Seattle, WA",n/a,True
+"n        VA Greater Los Angeles Healthcare System-Sepulveda and University of California, Los Angeles, CA",n/a,True
+Laboratory of Nano- and Translational Medicine; Lineberger Comprehensive Cancer Center; Carolina Center for Cancer Nanotechnology Excellence; Carolina Institute of Nanomedicine; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 USA,UNC Lineberger Comprehensive Cancer Center|School of Medicine|Eshelman School of Pharmacy,False
+"Department of Health Policy and Management, University of North Carolina–Chapel Hill, NC, USA",Department of Health Policy and Management,False
+University of California,n/a,True
+ Agency for Healthcare Research and Quality,n/a,True
+" University of North Carolina, Chapel Hill",University of North Carolina at Chapel Hill,False
+"Agency for Healthcare Research &amp; Quality, Rockville,rMD",n/a,True
+"Ohio State University, Columbus",n/a,True
+"Glen H. Elder, Jr., Ph.D., is University Research Professor, Department of Sociology and the Carolina Population Center, University of North Carolina at Chapel Hill. His main field of interest is life-course studies. Dr. Elder is currently conducting longitudinal studies of the transitions from childhood to the adult years, research on significant others beyond the family, and studies of pathways from disadvantage to greater life opportunity.",n/a,True
+"Lance D. Erickson, Ph.D., is Assistant Professor, Department of Sociology, Brigham Young University. His main fields of interest are the life course, adolescence, and family. His current projects include examinations of mentoring and trajectories of delinquency, whether marriage facilitates or inhibits success among graduate students, and the causal relationship between divorce and well-being.",n/a,True
+"Steve McDonald, Ph.D., is Assistant Professor, Department of Sociology, North Carolina State University. His main fields of interest are social capital, social networks, and inequality across the life course. Dr. McDonald is conducting studies on the influence of informal mentoring relationships on the transition to adulthood and beyond and on informal job-matching processes and their influence on career attainment.",n/a,True
+"University of Pennsylvania, Philadelphia, USA",n/a,True
+"University of Missouri-Kansas City, Kansas City, MO, USA",n/a,True
+Department of Social Medicine and Center for Bioethics; University of North Carolina; North Carolina USA,UNC Center for Bioethics|Department of Social Medicine,False
+The Marsico Lung Institute,Marsico Lung Institute/UNC Cystic Fibrosis Center,False
+Department of Chemical Engineering,n/a,True
+Sandia National Laboratories,n/a,True
+"Division of Physical Therapy at the University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Division of Physical Therapy,False
+"Program in Human Movement Science, Division of Physical Therapy at the University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Curriculum in Human Movement Science,False
+"School of Physical Therapy, University of the Incarnate Word, San Antonio, Texas",n/a,True
+"Department of Exercise and Sport Science, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",Department of Exercise and Sport Science,False
+"Joint Department of Biomedical Engineering, North Carolina State University and University of North Carolina at Chapel Hill, Raleigh, North Carolina",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Keller Army Hospital, West Point, New York",n/a,True
+"United States Military Academy, West Point, New York",n/a,True
+"The University of North Carolina at Chapel Hill Human Movement Science Curriculum, Chapel Hill, North Carolina",Curriculum in Human Movement Science,False
+"10School of Natural Sciences and Mathematics, The University of Dodoma, Dodoma, Tanzania",n/a,True
+"11Département de Sciences Biologiques, Universitéde Montréal, Montréal, Canada",n/a,True
+"12Department of Oceanography, SOEST, University of Hawaii, Honolulu, Hawaii, USA",n/a,True
+"13Australian Rivers Institute, Griffith University, Queensland, Australia",n/a,True
+"14Department of Marine Sciences, University of Georgia, Athens, Georgia, USA",n/a,True
+"15Department of Ocean, Earth and Atmospheric Sciences, Old Dominion University, Norfolk, Virginia, USA",n/a,True
+"16Department of Civil and Environmental Engineering, Massachusetts Institute of Technology, Cambridge, Massachusetts, USA",n/a,True
+"17Center for Comparative Genomics and Bioinformatics, Pennsylvania State University, University Park, Pennsylvania, USA",n/a,True
+"18Department of Energy Joint Genome Institute, Walnut Creek, California, USA",n/a,True
+"1Center for Microbial Oceanography: Research and Education, University of Hawaii, Honolulu, Hawaii, USA",n/a,True
+"2Hawaii Institute of Marine Biology, SOEST, University of Hawaii, Kaneohe, Hawaii, USA",n/a,True
+"3Plymouth Marine Laboratory, University of East Anglia, Norwich, UK",n/a,True
+"4Department of Marine Biology, University of Vienna, Vienna, Austria",n/a,True
+"5Instituto Oceanografico, Universidade de Sao Paulo, Sao Paulo, Brazil",n/a,True
+"6Environmental Sciences Institute, Florida A&M University, Tallahassee, Florida, USA",n/a,True
+"7Department of Marine Sciences, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Marine Sciences,False
+"8Scripps Institution of Oceanography, University of California, San Diego, La Jolla, California, USA",n/a,True
+"9Departament de Biologia Marina i Oceanografia, Institut de Cièncias del Mar, CMIMA, CSIC, Barcelona, Spain",n/a,True
+"Departemt of Mathematics and Statistics, University of Maryland, Baltimore County, Baltimore, USA",n/a,True
+"Department of Biostatistics and Genetics, The Univerity of North Carolina, Chapel Hill, USA.",Department of Biostatistics|Department of Genetics,False
+"Division IV, Office of Biostatistics/OTS/CDER/FDA, Spring, USA",n/a,True
+"Division of Biostatistics, School of Public Health, The Univerity of Minnesota, Minneapolis, USA",n/a,True
+"Division of Biostatistics, School of Public Health, The University of Texas Health Science Center, Houston, USA",n/a,True
+"Clinical and Translational Research Institute, Oregon Health &amp; Science University, Oregon, USA",n/a,True
+"College of Nursing, University of Illinois at Chicago, Chicago, IL, USA",n/a,True
+"School of Nursing, University of North Carolina at Chapel Hill, NC, USA",School of Nursing,False
+"School of Nursing, University of Pennsylvania, Philadelphia, PA, USA",n/a,True
+"School of Nursing, Yale University, New Haven, Connecticut, USA",n/a,True
+"Department of Statistics, North Carolina State University, Raleigh, NC, USA",n/a,True
+"University of Louisville, Louisville, KY 40202, USA",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",University of North Carolina at Chapel Hill,False
+"Department of Biostatistics, University of North Carolina at Chapel Hill, Chapel Hill, N.C., U.S.A.",Department of Biostatistics,False
+"Division of Biostatistics, University of Florida, Gainesville, Fl., U.S.A.",n/a,True
+"Rho Inc., Chapel Hill, N.C., U.S.A.",n/a,True
+"Department of Biostatistics, University of North Carolina at Chapel Hill, U.S.A.",Department of Biostatistics,False
+"Department of Statistics and Department of Entomology, University of Wisconsin at Madison, U.S.A.",n/a,True
+"Department of Biostatistics, Department of Biomedical Informatics, Vanderbilt University, Nashville, Tennessee, U.S.A.",n/a,True
+"Department of Biostatistics, Vanderbilt University, Nashville, Tennessee, U.S.A.",n/a,True
+"Department of Biostatistics, University of Michigan, Ann Arbor, Mich., U.S.A.",n/a,True
+"Department of Biostatistics, University of North Carolina, Chapel Hill, N.C., U.S.A.",Department of Biostatistics,False
+"Department of Genetics and Department of Biostatistics, University of North Carolina, Chapel Hill, N.C., U.S.A.",Department of Biostatistics|Department of Genetics,False
+"Department of Statistics, North Carolina State University, Raleigh, N.C., U.S.A.",n/a,True
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, Washington, U.S.A.",n/a,True
+"Quantitative Sciences, R&D, GlaxoSmithKline, Research Triangle Park, North Carolina, U.S.A.",n/a,True
+Department of Biostatistics CB #7420; University of North Carolina; 3105H McGavran-Greenberg; Chapel Hill; NC; 27599-7420; USA,Department of Biostatistics,False
+Department of Community Medicine; School of Medicine; West Virginia University; PO Box 9190; Morgantown; WV; 26506-9190; USA,n/a,True
+Department of Health Outcomes and Policy; University of Florida College of Medicine; PO Box 100177; Gainesville; FL; 32610-0177; USA,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill; NC; 27599; USA,Department of Biostatistics,False
+"Department of Epidemiology, Biostatistics, and Occupational Health; McGill University; Montreal; Quebec; Canada",n/a,True
+Department of Epidemiology; UNC Gillings School of Global Public Health; Chapel Hill; NC; USA,Department of Epidemiology,False
+Department of Obstetrics and Gynecology and Duke Global Health Institute; Duke University; Durham; NC; USA,n/a,True
+Epidemiology Branch; Eunice Kennedy Shriver National Institute of Child Health and Human Development; Bethesda; MD; USA,n/a,True
+"Department of Biostatistics; University of North Carolina at Chapel Hill; CB #7420, Chapel Hill; NC; 27599-7420; U.S.A.",Department of Biostatistics,False
+Clinical Biostatistics; Merck Research Laboratories; Rahway; NJ; U.S.A.,n/a,True
+Department of Statistics; University of Connecticut; Storrs; CT; U.S.A.,n/a,True
+Department of Biostatistics; University of North Carolina; Chapel Hill; NC 27599-7420; U.S.A.,Department of Biostatistics,False
+Janssen R&D; 1125 Trenton-Harbourton Road; Titusville; NJ 08560; U.S.A.,n/a,True
+Fred Hutchinson Cancer Research Center; Seattle; WA; U.S.A.,n/a,True
+RAND Corporation; Arlington; VA; U.S.A.,n/a,True
+University of North Carolina at Chapel Hill; Chapel Hill; NC; U.S.A.,University of North Carolina at Chapel Hill,False
+Department of Epidemiology; University of North Carolina Gillings School of Global Public Health; Chapel Hill NC 27599 U.S.A.,Department of Epidemiology,False
+Division of Biostatistics; University of Minnesota School of Public Health; Minneapolis MN 55455 U.S.A.,n/a,True
+Department of Biostatistics and Lineberger Comprehensive Cancer Center; University of North Carolina; Chapel Hill NC 27599 U.S.A.,Department of Biostatistics|UNC Lineberger Comprehensive Cancer Center,False
+Oncology Business Unit; Pfizer Inc.; Groton CT 06340 U.S.A.,n/a,True
+"Department of Epidemiology, Biostatistics and Occupational Health; McGill University; Montreal; QC; Canada",n/a,True
+"Department of Epidemiology, Gillings School of Global Public Health; University of North Carolina; Chapel Hill; NC; U.S.A.",Department of Epidemiology,False
+"Division of Epidemiology, Statistics and Prevention Research; NICHD, NIH; Bethesda; MD; U.S.A.",n/a,True
+Department of Nutrition; University of North Carolina at Chapel Hill; Chapel Hill NC U.S.A.,Department of Nutrition,False
+Department of Sociology; University of North Carolina at Chapel Hill; Chapel Hill NC U.S.A.,Department of Sociology,False
+Clinical Biostatistics; Merck Research Laboratories; Rahway NJ U.S.A.,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 U.S.A.,Department of Biostatistics,False
+Department of Statistics; University of Connecticut; Storrs CT 06269 U.S.A.,n/a,True
+"Division of Epidemiology, Statistics and Prevention Research; Eunice Kennedy Shriver National Institute of Child Health and Human Development, NIH; Rockville MD U.S.A.",n/a,True
+Departments of Biostatistics and Biomedical Informatics; Vanderbilt University; Nashville TN 37232 U.S.A.,n/a,True
+Novartis Pharmaceuticals Corporation; East Hanover NJ 07936 U.S.A.,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599 U.S.A.,Department of Biostatistics,False
+"Department of Medicine, Epidemiology, Microbiology and Immunology; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599 U.S.A.",Department of Medicine|Department of Epidemiology|Department of Microbiology and Immunology,False
+"Division of Biostatistics, School of Public Health; University of Minnesota; Minneapolis Minnesota 55455 U.S.A.",n/a,True
+"Division of Infectious Diseases, Department of Medicine; University of North Carolina at Chapel Hill; Chapel Hill North Carolina 27599 U.S.A.",Division of Infectious Diseases,False
+The EMMES Corporation; Rockville Maryland 20850 U.S.A.,n/a,True
+Department of Biostatistics; The University of North Carolina at Chapel Hill; Chapel Hill NC 27599 U.S.A.,Department of Biostatistics,False
+"Department of Medicine, Division of General Medicine and Clinical Epidemiology; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 U.S.A.",Division of General Medicine and Clinical Epidemiology,False
+Vaccine and Infectious Disease Division; Fred Hutchinson Cancer Research Center; Seattle WA 98109 U.S.A.,n/a,True
+Department of Biostatistics and Medical Informatics; University of Wisconsin-Madison; Madison WI 53792 U.S.A.,n/a,True
+Pfizer Oncology; La Jolla CA U.S.A.,n/a,True
+Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill NC U.S.A.,Department of Biostatistics,False
+Department of Biostatistics; West Virginia University; Morgantown WV U.S.A.,n/a,True
+Department of Health Behavior; University of North Carolina at Chapel Hill; Chapel Hill NC U.S.A.,Department of Health Behavior,False
+Biogen Idec; Cambridge MA 02142 U.S.A.,n/a,True
+Department of Statistics; University of Connecticut; Storrs NC 06269 U.S.A.,n/a,True
+"Eli Lilly and Company, Lilly Corporate Center; Indianapolis IN 46285 U.S.A.",n/a,True
+Amgen Inc.; One Amgen Center Drive Thousand Oaks California 91320 U.S.A.,n/a,True
+"Department of Biostatistics; University of North Carolina at Chapel Hill; Chapel Hill, North Carolina 27599 U.S.A.",Department of Biostatistics,False
+"Department of Statistics; University of Connecticut; Storrs, Connecticut 06269 U.S.A.",n/a,True
+Department of Biostatistics; Vanderbilt University; Nashville TN 37232 U.S.A.,n/a,True
+Department of Epidemiology; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 U.S.A.,Department of Epidemiology,False
+"Division of Biostatistics, School of Public Health; University of Minnesota; Minneapolis MN 55455 U.S.A.",n/a,True
+The EMMES Corporation; Rockville MD 20850 U.S.A.,n/a,True
+Department of Biostatistics; MedImmune; Gaithersburg MD U.S.A.,n/a,True
+Department of Biostatistics; University of Florida; Gainesville FL U.S.A.,n/a,True
+Department of Health Outcomes and Policy; University of Florida; Gainesville FL U.S.A.,n/a,True
+Department of Psychiatry; University of North Carolina; Chapel Hill NC U.S.A.,Department of Psychiatry,False
+"Applied Statistics, Department of Mathematical Sciences; The University of Memphis; Memphis TN U.S.A.",n/a,True
+"Department of Biostatistics, School of Public Health; University of North Carolina; Chapel Hill NC U.S.A.",Department of Biostatistics,False
+Amgen Inc.; One Amgen Center Drive; Thousand Oaks CA 91320 U.S.A.,n/a,True
+"Department of Biostatistics, CB7420; University of North Carolina at Chapel Hill; Chapel Hill NC 27516 U.S.A.",Department of Biostatistics,False
+Department of Biostatistics; Boston University; Boston MA U.S.A.,n/a,True
+Department of Biostatistics; University of Washington; Seattle WA U.S.A,n/a,True
+Department of Epidemiology; Erasmus Medical Center; Rotterdam The Netherlands,n/a,True
+Department of Epidemiology; University of North Carolina; Chapel Hill NC U.S.A.,Department of Epidemiology,False
+Department of Internal Medicine; Erasmus Medical Center; Rotterdam NL U.S.A.,n/a,True
+Department of Medicine; University of Washington; Seattle WA U.S.A.,n/a,True
+Department of Statistics; University of Auckland; Auckland New Zealand,n/a,True
+Departments of Epidemiology and Medicine; University of North Carolina; Chapel Hill NC U.S.A.,Department of Epidemiology|Department of Medicine,False
+"Departments of Medicine, Epidemiology, and Health Services; University of Washington; Seattle WA U.S.A.",n/a,True
+Department of Biostatistics; University of North Carolina; Chapel Hill NC 27599 U.S.A.,Department of Biostatistics,False
+Global Biostatistical Science; Amgen Inc.; One Amgen Center Drive Thousand Oaks CA 91320 U.S.A.,n/a,True
+"Department of Health Sciences, University of Leicester; Adrian Building, University Road Leicester LE1 7RH U.K.",n/a,True
+"Department of Statistics and Operations Research, University of North Carolina; 318 Hanes Hall Chapel Hill NC 27599 U.S.A.",Department of Statistics and Operations Research,False
+Eli Lilly; 893 S. Delaware Street Indianapolis IN 46285 U.S.A.,n/a,True
+Genentech; South San Francisco CA U.S.A.,n/a,True
+Merck Research Laboratories; 351 North Sumneytown Pike North Wales PA 19454 U.S.A.,n/a,True
+Sanofi-Aventis; Paris France,n/a,True
+"Université de Technologie de Compiègne, Centre de Recherche de Royallieu; 60205 Compiègne Cedex France",n/a,True
+Department of Biostatistics and Bioinformatics; Duke University School of Medicine; Durham 27710 NC U.S.A.,n/a,True
+"Department of Biostatistics and Bioinformatics; The Rollins School of Public Health of Emory University; 1518 Clifton Rd. N.E., Mailstop 1518-002-3AA Atlanta 30322 GA U.S.A.",n/a,True
+"Department of Biostatistics, Gillings School of Global Public Health; The University of North Carolina at Chapel Hill; Chapel Hill 27599-7420 NC U.S.A.",Department of Biostatistics,False
+"Department of Maternal and Child Health, Gillings School of Global Public Health; The University of North Carolina at Chapel Hill; Chapel Hill 27599-7445 NC U.S.A.",Department of Maternal and Child Health,False
+"Ion Cyclotron Resonance Facility, National High Magnetic Field Laboratory; Florida State University; Tallahassee FL U.S.A.",n/a,True
+School of Dentistry; University of North Carolina at Chapel Hill; Chapel Hill NC U.S.A.,School of Dentistry,False
+Department of Biostatistics; University of North Carolina; Chapel Hill NC U.S.A.,Department of Biostatistics,False
+"Biostatistics and Bioinformatics BranchDivision of Epidemiology Statistics, and Prevention Research; Eunice Kennedy Shriver National Institute of Child Health and Human Development, National Institutes of Health; Rockville MD U.S.A.",n/a,True
+Department of Biostatistics and Informatics; University of Colorado Denver; Aurora CO U.S.A.,n/a,True
+Neptune and Company; Lakewood CO U.S.A.,n/a,True
+Department of Biostatistics; University of North Carolina; Chapel Hill 27599 NC U.S.A.,Department of Biostatistics,False
+SAS Institute Inc.; Cary NC U.S.A.,n/a,True
+"Department of Anatomical, Histological, Forensic Medicine and Orthopedics Sciences; Sapienza University; Rome Italy",n/a,True
+"Department of Cell Biology and Physiology, Program in Molecular Biology and Biotechnology, Lineberger Cancer Center; University of North Carolina School of Medicine; Chapel Hill North Carolina USA",Department of Cell Biology and Physiology|UNC Lineberger Comprehensive Cancer Center,False
+Department of Health Sciences; University of Rome “ForoItalico”; Rome Italy,n/a,True
+Department of Medico-Surgical Sciences and Biotechnologies; Sapienza University; Rome Italy,n/a,True
+Department of Surgery; University of North Carolina School of Medicine; Chapel Hill North Carolina USA,Department of Surgery,False
+"Diabetes Research Institute, Miller School of Medicine; University of Miami; Miami Florida USA",n/a,True
+Innovation Wake Forest Innovations; Wake Forest Baptist Medical Center; Winston Salem North Carolina USA,n/a,True
+Department of Medicine Division of Gastroenterology and Hepatology; The University of North Carolina at Chapel Hill; Chapel Hill North Carolina USA,Division of Gastroenterology and Hepatology,False
+"Department of Pediatrics Division of Gastroenterology; University of California; Los Angeles, California USA",n/a,True
+"Department of Surgery University of California; Los Angeles, California USA",n/a,True
+Department of Surgery; The University of North Carolina at Chapel Hill; Chapel Hill North Carolina USA,Department of Surgery,False
+"Department of Surgery; VA Greater Los Angeles Healthcare System; Los Angeles, California USA",n/a,True
+Stowers Institute for Medical Research; Kansas City Missouri USA,n/a,True
+Cell Biology and Physiology; University of North Carolina School of Medicine; Chapel Hill North Carolina USA,Department of Cell Biology and Physiology,False
+"Department of Scienze e Biotecnologie Medico-Chirurgiche, Fondazione Eleonora Lorillard Spencer Cenci; Sapienza University; Rome Italy",n/a,True
+Diabetes Research Institute Miller School of Medicine; University of Miami; Miami Florida USA,n/a,True
+MGabriel Consulting; 3621 Sweeten Creek Road Chapel Hill North Carolina USA,n/a,True
+Wake Forest Innovations; Wake Forest University School of Medicine; Winston-Salem North Carolina USA,n/a,True
+Department of Cell Biology and Physiology; University of North Carolina; Chapel Hill North Carolina USA,Department of Cell Biology and Physiology,False
+Department of Medicine; University of North Carolina; Chapel Hill North Carolina USA,Department of Medicine,False
+Department of Genetics and Genome Sciences; University of North Carolina; Chapel Hill North Carolina USA,Department of Genetics,False
+Department of Orthopaedics; University of North Carolina; Chapel Hill North Carolina USA,Department of Orthopaedics,False
+Department of Biomedical Engineering; State University of New York; Stony Brook New York USA,n/a,True
+School of Physical Therapy; Indiana University; Indianapolis Indiana USA,n/a,True
+Department of Physical Therapy; University of Indiana-Purdue; Indianapolis Indiana,n/a,True
+"Department of Surgery, University of North Carolina School of Medicine, Chapel Hill, NC 27599-7211, USA",Department of Surgery,False
+"Division of Cardiothoracic Surgery, University of North Carolina at Chapel Hill, Chapel Hill, NC 27599, USA",Division of Cardiothoracic Surgery,False
+"Molecular Biomedical Sciences, College of Veterinary Medicine, North Carolina State University, Raleigh, NC 27695, USA",n/a,True
+"Assistant Professor, Department of Health Policy and Management, Gillings School of Global Public Health; University of North Carolina at Chapel Hill",Department of Health Policy and Management,False
+"Associate Professor, Department of Health Policy and Management, Gillings School of Global Public Health; University of North Carolina at Chapel Hill",Department of Health Policy and Management,False
+"Clinical Professor, Department of Health Policy and Management, Gillings School of Global Public Health; University of North Carolina at Chapel Hill",Department of Health Policy and Management,False
+"Fogarty Global Health Fellow, School of Medicine; University of North Carolina at Chapel Hill; 130 Mason Farm Road, Campus Box 7030 Chapel Hill NC 27599",School of Medicine,False
+"Norb F. Schaefer Professor of International Studies, Department of Economics; Duke University",n/a,True
+"Professor of Public Policy and Sociology, Sanford School of Public Policy; Duke University",n/a,True
+An independent consultant,n/a,True
+"Assistant Professor, Program in Public Health, Department of Preventive Medicine; Stony Brook University",n/a,True
+"Research Assistant Professor, Department of Nutrition, Gillings School of Global Health; University of North Carolina at Chapel Hill",Department of Nutrition,False
+"Research Assistant Professor, Department of Public Policy; University of North Carolina at Chapel Hill; Abernathy Hall, CB #3435 Chapel Hill NC 27599",Department of Public Policy,False
+"Assistant Professor, Maternal and Child Health, Epidemiology, University of North Carolina at Chapel Hill.",Department of Maternal and Child Health|Department of Epidemiology,False
+"Postdoctoral Research Fellow, Office of Population Research, Princeton University, Wallace Hall, Princeton, NJ 08544.",n/a,True
+"Research Associate Professor, Maternal and Child Health, Epidemiology, University of North Carolina at Chapel Hill.",Department of Maternal and Child Health|Department of Epidemiology,False
+"Research Professor, Maternal and Child Health, Epidemiology, University of North Carolina at Chapel Hill.",Department of Maternal and Child Health|Department of Epidemiology,False
+"Deputy Project Director, Evidence to Action (E2A) Project; Management Sciences for Health; 1201 Connecticut Avenue, NW, Suite 700 Washington DC 20036",n/a,True
+"Research Professor, Maternal and Child Health, Gillings School of Global Public Health; University of North Carolina; Chapel Hill",Department of Maternal and Child Health,False
+Senior Program Officer; PATH; Washington DC,n/a,True
+Department of Psychiatry and Human Behavior; Center for Alcohol and Addiction Studies; Alpert Medical School of Brown University; Providence RI USA,n/a,True
+Merrill Palmer Institute; Wayne State University; Detroit MI USA,n/a,True
+"Pathfinder Technologies Inc, Nashville, TN, USA",n/a,True
+"Providence Portland Medical Center, Portland, OR, USA",n/a,True
+"Vanderbilt University, Nashville, TN, USA",n/a,True
+"Beth Israel Deaconess Medical Center, Harvard Medical School, Boston, MA, USA",n/a,True
+"Cambridge Health Alliance, Harvard Medical School, Cambridge, MA, USA",n/a,True
+"Kitware, Carrboro, NC, USA",n/a,True
+"Mount Auburn Hospital, Harvard Medical School, Cambridge, MA, USA",n/a,True
+"Rensselaer Polytechnic Institute, Troy, NY, USA",n/a,True
+"Tufts University School of Medicine, Springfield, MA, USA",n/a,True
+"University of Maryland Medical Center, Baltimore, MD, USA",n/a,True
+"University of Pennsylvania Medical School, Philadelphia, PA, USA",n/a,True
+"Washington University School of Medicine, St Louis, MO, USA",n/a,True
+"Wright State University, Dayton, OH, USA",n/a,True
+Bowles Center for Alcohol Studies; University of North Carolina; Chapel Hill North Carolina,Bowles Center for Alcohol Studies,False
+"n        Department of Biology, University of South Dakota, Vermillion, SD 57069, USA",n/a,True
+"n        Department of Ecology and Evolutionary Biology, University of Kansas, Lawrence, KS 66045, USA",n/a,True
+"n        Department of Ichthyology, Academy of Natural Sciences, Philadelphia, PA 19103, USA",n/a,True
+"n        National Evolutionary Synthesis Center, 2024 West Main Street, A200, Durham, NC 27705, USA",n/a,True
+"n        Zebrafish Information Network, University of Oregon, Eugene, OR 97403, USA",n/a,True
+"n        n          Department of Biology, University of Florida, Gainesville, FL 32609, USAn        ",n/a,True
+"n        n          Department of Biology, University of North Carolina, Chapel Hill, NC 27599n        ",Department of Biology,False
+"n        n          Department of Computer Science, Iowa State University, Ames, IA 50011, USAn        ",n/a,True
+"n        n          NESCent, Durham, NC 27705, USAn        ",n/a,True
+"n        Biochemical Science Division, National Institute of Standards and Technology, Gaithersburg, MD, USA",n/a,True
+"n        Department of Biological Sciences, Wayne State University, USA",n/a,True
+"n        Department of Biology, University of Ottawa, Canada",n/a,True
+"n        Department of Ecology and Evolutionary Biology, University of Kansas, USA",n/a,True
+"n        Department of Mechanical Engineering, Indian Institute of Technology Kharagpur, India",n/a,True
+"n        Departments of Zoology and Botany, and Beaty Biodiversity Museum, University of British Columbia, Canada",n/a,True
+"n        NCB Naturalis, Leiden, the Netherlands",n/a,True
+"n        National Evolutionary Synthesis Center, Durham, NC, USA",n/a,True
+" Department of Biostatistics University of North Carolina 349 Wing C, CB #7062 Chapel Hill, NC, 27599",Department of Biostatistics,False
+ Department of Computer Science,n/a,True
+ Department of Radiation Oncology,n/a,True
+ Department of Radiology,n/a,True
+ Department of Surgery,n/a,True
+" Department of Surgery University of North Carolina School of Medicine 3327 Old Infirmary CB 7510 Chapel Hill, NC 27599-7510 USA",Department of Surgery,False
+ School of Medicine,n/a,True
+" Joint Department of Biomedical Engineering, University of North Carolina, North Carolina State University, Chapel Hill, NC, USA",UNC/NCSU Joint Department of Biomedical Engineering,False
+" Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC, USA",UNC Lineberger Comprehensive Cancer Center,False
+" Uniformed Services University of the Health Sciences, Bethesda, Maryland",n/a,True
+" United States Naval Academy, Annapolis, Maryland",n/a,True
+" University of North Carolina at Chapel Hill, Chapel Hill, North Carolina",University of North Carolina at Chapel Hill,False
+"n        Center for Global Health Research, KEMRI, Kisumu, Kenya",n/a,True
+n        Curriculum in Genetics and Molecular Biology,n/a,True
+"n        Department of Clinical Sciences, Liverpool School of Tropical Medicine",n/a,True
+"n        Department of Community Health, School of Medical Sciences, Kwame Nkrumah University of Science and Technology, Kumasi",n/a,True
+"n        Department of Epidemiology of Parasitic Diseases, Malaria Research and Training Center, Faculty of Medicine, Pharmacy, and Odontostomatology, University of Science, Techniques, and Technologies of Bamako, Mali",n/a,True
+"n        Department of Epidemiology, Gillings School of Global Public Health",Department of Epidemiology,False
+"n        Department of Medicine, University of California, San Francisco",n/a,True
+"n        Department of Parasitology, Muhumbili University of Health and Allied Sciences, Dar es Salaam, Tanzania",n/a,True
+n        Department of Pediatrics,n/a,True
+"n        Division of Infectious Diseases, Department of Medicine",n/a,True
+n        Division of Transfusion Medicine,n/a,True
+"n        Ecole de Sante Publique, Faculte de Medicine, University of Kinshasa, Democratic Republic of the Congo",n/a,True
+"n        Faculty of Health Sciences, University of Ouagadougou, Burkina Faso",n/a,True
+"n        Faculty of Infectious and Tropical Diseases, London School of Hygiene and Tropical Medicine, United Kingdom",n/a,True
+n        Graduate School of Biomedical Sciences,n/a,True
+n        KEMRI-CDC,n/a,True
+"n        Malaria Alert Center, University of Malawi College of Medicine, Blantyre",n/a,True
+"n        Malaria Branch, Division of Parasitic Diseases and Malaria, Center for Global Health, Centers for Disease Control and Prevention (CDC), Atlanta, Georgia",n/a,True
+"n        Malaria Research, Department of Medicine Solna",n/a,True
+"n        Medical Research Council Laboratories, Banjul, Gambia",n/a,True
+"n        Navrongo Health Research Centre, Ghana Health Service, Navrongo",n/a,True
+"n        Centre for Global Public Health, University of Manitoba, Winnipeg, Canada",n/a,True
+"n        Department of Biostatistics, Gillings School of Global Public Health",Department of Biostatistics,False
+n        Department of Epidemiology,n/a,True
+"n        Department of Epidemiology and Population Health, Albert Einstein College of Medicine, New York, New York",n/a,True
+"n        Department of Pathology, VU University Medical Center, Amsterdam, The Netherlands",n/a,True
+"n        Division of Epidemiology and Biostatistics, School of Public Health, University of Illinois, Chicago",n/a,True
+"n        Impact Research and Development Organization, Kisumu, Kenya",n/a,True
+"n        Department of Microbiology and Immunology, University of North Carolina School of Medicine, Chapel Hill",Department of Microbiology and Immunology,False
+"n        Epidemiology Unit, Ministry of Health",n/a,True
+"n        Genetech Research Institute, Colombo, Sri Lanka",n/a,True
+"n        ACTG Operations Center, Social and Scientific Systems, Silver Spring, Maryland",n/a,True
+"n        Center for Biostatistics in AIDS Research, Harvard School of Public Health, Boston, Massachusetts",n/a,True
+"n        Department of Immunology and Microbiology, Rush University Medical Center",n/a,True
+n        Department of Medicine,n/a,True
+"n        Department of Medicine, University of Colorado at Denver, Aurora",n/a,True
+"n        Department of Medicine, University of North Carolina, Chapel Hill",Department of Medicine,False
+"n        Division of Infectious Diseases and HIV, Drexel University, Philadelphia, Pennsylvania",n/a,True
+"n        Division of Infectious Diseases, University of Pittsburgh School of Medicine",n/a,True
+"n        Feinberg School of Medicine, Northwestern University, Chicago, Illinois",n/a,True
+"n        HIV Research Branch, TRP, Division of AIDS, National Institute of Allergy and Infectious Diseases, National Institute of Health, Bethesda",n/a,True
+" Department of Surgery, Kamuzu Central Hospital, Lilongwe, Malawi",n/a,True
+" University of North Carolina Project, Lilongwe, Malawi",UNC Project-Malawi,False
+"n        Department of Nutrition, School of Public Health and School of Medicine, University of North Carolina, Chapel Hill, NC 27599-7400",Department of Nutrition|School of Medicine,False
+"n        Carolina Population Center and Department of Nutrition, University of North Carolina, Chapel Hill, NC 27516",Carolina Population Center|Department of Nutrition,False
+"n        Department of Anthropology, Northwestern University, Evanston, IL 60208",n/a,True
+"n        Department of Epidemiology, Biostatistics, and Occupational Health, McGill University, Montreal, Quebec H3A 1A2, Canada",n/a,True
+"n        Department of Nutrition, Carolina Population Center, University of North Carolina, Chapel Hill, NC 27516-2524",Department of Nutrition|Carolina Population Center,False
+"n        University of Leeds, Centre for Epidemiology and Biostatistics, University of Leeds, Leeds, LS2 9JT UK",n/a,True
+"n        Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC 27599-7461",Department of Nutrition,False
+"n        Carolina Population Center, University of North Carolina, Chapel Hill, NC 27599",Carolina Population Center,False
+"n        Department of Biostatistics, University of North Carolina, Chapel Hill, NC 27599",Department of Biostatistics,False
+"n        Department of Nutrition, University of North Carolina, Chapel Hill, NC 27516",Department of Nutrition,False
+"n        Department of Psychiatry, University of North Carolina, Chapel Hill, NC 27516",Department of Psychiatry,False
+"n        Department of Nutrition, University of North Carolina, Chapel Hill, NC 27599",Department of Nutrition,False
+"n        Department of Statistics, Iowa State University, Ames, IA 50011",n/a,True
+"n        Division of Human Nutrition, Wageningen University, 6700 EV Wageningen, The Netherlands",n/a,True
+"n        FANTA-2, AED, FANTA-2, Washington, DC 20009",n/a,True
+"n        Fafo Institute for Applied International Studies, NO-0608 Oslo, Norway",n/a,True
+"n        Independent consultant, 23744 Schoenwalde, Germany",n/a,True
+"n        Institute of Research for Development, UMR 204 `Nutripass', Montpellier, France F34394",n/a,True
+"n        Program in International and Community Nutrition, University of California, Davis, CA 95616",n/a,True
+"n        Birth to Twenty Research Programme, University of the Witwatersrand and the Human Sciences Research Council, Durban 4014, South Africa",n/a,True
+"n        Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC 27516-2524",Department of Nutrition,False
+"n        Hubert Department of Global Health, Rollins School of Public Health, Emory University, Atlanta, GA 30322",n/a,True
+"n        Indian Council of Medical Research, New Delhi 138648, India",n/a,True
+"n        MRC Epidemiology Resource Centre, University of Southampton, Southampton S016 6YD, UK",n/a,True
+"n        Office of Population Studies Foundation, University of San Carlos, Cebu 6000, Philippines",n/a,True
+"n        S.L. Jain Hospital, Delhi 464551, India",n/a,True
+"n        Universidade Federal de Pelotas, Pelotas 96090-790, Brazil",n/a,True
+"n        Department of Medicine, George Washington University School of Medicine, Washington, DC 20037",n/a,True
+"n        Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC, 27599",Department of Nutrition,False
+"n        Department of Nutritional Sciences, Faculty of Medicine, University of Toronto, Toronto, ON, Canada M5S 3E2",n/a,True
+"n        Physicians Committee for Responsible Medicine, Washington, DC 20016",n/a,True
+"n        Private Practice, Arlington, VA 22207",n/a,True
+"n        Department of Food, Bioprocessing and Nutrition Sciences, North Carolina State University, Raleigh, NC 27695",n/a,True
+"n        Fomon Infant Nutrition Unit, Department of Pediatrics, University of Iowa, Iowa City, IA 52242",n/a,True
+"n        Department of Nutrition, University of North Carolina, Chapel Hill, NC",Department of Nutrition,False
+"n        Nutrition and Health Research Center, National Institute of Public Health, Cuernavaca, Mexico",n/a,True
+"n        Department of Nutrition, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC 27516",Department of Nutrition,False
+"n        Department of Nutrition, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Nutrition,False
+"n        Department of Preventive Medicine, Feinberg School of Medicine, Northwestern University, Chicago, IL",n/a,True
+"n        Department of Nutrition and Carolina Population Center, University of North Carolina, Chapel Hill, NC",Department of Nutrition|Carolina Population Center,False
+"n        National Institute of Nutrition and Food Safety, Chinese Center for Disease Control and Prevention, Beijing, China",n/a,True
+"n        Nutrition Research Institute, School of Public Health and School of Medicine, The University of North Carolina at Chapel Hill, Kannapolis, NC 28081",Nutrition Research Institute|School of Medicine|Gillings School of Global Public Health,False
+"n        Instituto de Investigacion Nutricional, La Molina Lima 12, Perú",n/a,True
+"n        Nutrition Department, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC, 27516",Department of Nutrition,False
+"n        Department of Nutrition, Gillings Schools of Global Public Health",Department of Nutrition,False
+"n        Department of Pediatrics, Georgia Health Sciences University, Augusta, GA",n/a,True
+"n        Department of Nutrition, School of Public Health, University of North Carolina, Chapel Hill, NC",Department of Nutrition,False
+"n        Clinical and Translational Research Center, University of North Carolina, Chapel Hill, NC",North Carolina Translational and Clinical Sciences Institute,False
+"n        Department of Medicine, University of North Carolina, Chapel Hill, NC",Department of Medicine,False
+"n        Department of Psychiatry, University of North Carolina, Chapel Hill, NC",Department of Psychiatry,False
+"n        Clinical Trials Research Unit, University of Leeds, Leeds, UK",n/a,True
+"n        Department of Biostatistics, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, NC",Department of Biostatistics,False
+"n        Carolina Population Center, University of North Carolina, Chapel Hill, NC",Carolina Population Center,False
+"n        Department of Biostatistics, University of North Carolina, Chapel Hill, NC",Department of Biostatistics,False
+"n        Division of Infectious Diseases, School of Medicine, University of North Carolina, Chapel Hill, NC",Division of Infectious Diseases,False
+"n        Principia, Chapel Hill, NC",n/a,True
+"n        U.S. Centers for Disease Control and Prevention, Atlanta, GA",n/a,True
+"n        University of North Carolina Project, Lilongwe, Malawi",UNC Project-Malawi,False
+"n        Cardiovascular Health Research Unit, Department of Medicine, University of Washington, Seattle, WA",n/a,True
+"n        Center for Public Health Genomics, and Division of Biostatistics and Epidemiology, Department of Public Health Sciences, University of Virginia, Charlottesville, VA",n/a,True
+"n        Clinical Research Branch, National Institute on Aging, Baltimore, MD",n/a,True
+"n        Department of Biostatistics, Boston University School of Public Health, Boston, MA",n/a,True
+"n        Department of Clinical Physiology and Nuclear Medicine, Turku University Hospital, and Research Centre of Applied and Preventive Cardiovascular Medicine, University of Turku, Turku, Finland",n/a,True
+"n        Department of Clinical Sciences, Lund University, Malmö, Sweden",n/a,True
+"n        Department of Epidemiology and Carolina Center for Genome Sciences, University of North Carolina, Chapel Hill, NC",Carolina Center for Genome Sciences|Department of Epidemiology,False
+"n        Department of Epidemiology and Nutrition, Harvard School of Public Health, Boston, MA; Division of Cardiovascular Medicine, Brigham and Women's Hospital, Harvard Medical School, Boston, MA",n/a,True
+"n        Department of Epidemiology, Erasmus Medical Center, Rotterdam, The Netherlands",n/a,True
+"n        Department of Genetics, Washington University School of Medicine, St. Louis, MO",n/a,True
+"n        Department of Internal Medicine, Wake Forest School of Medicine, Winston-Salem, NC",n/a,True
+"n        Department of Medical Epidemiology and Biostatistics, Karolinska Institutet, Stockholm, Sweden",n/a,True
+"n        Department of Medical Sciences, Molecular Medicine and Science for Life Laboratory, Uppsala University, Uppsala, Sweden",n/a,True
+"n        Department of Medicine, Brigham and Women's Hospital and Harvard Medical School, Boston, MA; Massachusetts Veterans Epidemiology and Research Information Center and Geriatric Research, Education, and Clinical Center, Boston Veterans Affairs Healthcare System, Boston, MA",n/a,True
+"n        Department of Nutrition and Dietetics, Harokopio University of Athens, Athens, Greece",n/a,True
+"n        Department of Nutrition, Harvard School of Public Health, Boston, MA",n/a,True
+"n        Department of Odontology, Umeå University, Umeå, Sweden",n/a,True
+"n        Department of Public Health and Caring Sciences, Clinical Nutrition and Metabolism, Uppsala University, Uppsala, Sweden",n/a,True
+"n        Department of Public Health and Clinical Medicine, Nutritional Research, Umeå University, Umeå, Sweden",n/a,True
+"n        Division of Epidemiology and Community Health, University of Minnesota, Minneapolis, MN",n/a,True
+"n        Division of Public Health Sciences, Department of Biostatistical Sciences, Wake Forest School of Medicine, Winston-Salem, NC",n/a,True
+"n        Division of Public Health Sciences, Department of Epidemiology and Prevention, Wake Forest School of Medicine, Winston-Salem, NC",n/a,True
+"n        Fimlab Laboratories and University of Tampere, School of Medicine, and Tampere University Hospital, Tampere, Finland",n/a,True
+"n        Geriatric Unit, Azienda Sanitaria Firenze, Florence, Italy",n/a,True
+"n        Oxford Centre for Diabetes, Endocrinology and Metabolism, University of Oxford, Oxford, UK",n/a,True
+"n        Tufts University Friedman School of Nutrition Science and Policy, Jean Mayer USDA Human Nutrition Research Center on Aging at Tufts University, Boston, MA",n/a,True
+"n        Wellcome Trust Sanger Institute, Wellcome Trust Genome Campus, Hinxton, UK",n/a,True
+"n        UNC Project, Lilongwe, Malawi",UNC Project-Malawi,False
+"n        Carolina Population Center, School of Medicine, University of North Carolina, Chapel Hill, NC",Carolina Population Center|School of Medicine,False
+"n        Division of Epidemiology and Biostatistics, School of Public Health, University of Witwatersrand, Parktown, South Africa",n/a,True
+"n        Institute of Human Nutrition and Department of Epidemiology, Columbia University, New York, NY",n/a,True
+"n        Department of Nutrition, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Nutrition,False
+"n        Nutrition and Health Research Center, National Institute of Public Health, Cuernavaca, Morelos, Mexico",n/a,True
+"n        CDC, Atlanta, GA",n/a,True
+"n        USDA, ARS, Western Human Nutrition Research Center, Davis, CA",n/a,True
+"n        Department of Biostatistics, Gillings School of Global Public Health, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Biostatistics,False
+"n        Department of Psychiatry and Behavioral Sciences, Duke University Medical Center, Durham, NC",n/a,True
+"n        Department of Health Policy and Management, University of North Carolina, Chapel Hill, NC",Department of Health Policy and Management,False
+"n        Partners for Development, Abuja, Nigeria",n/a,True
+"n        Carolina Population Center, University of North Carolina at Chapel Hill, Chapel Hill, NC",Carolina Population Center,False
+"n        Department of Biostatistics, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Biostatistics,False
+"n        Furman University, Greenville, SC",n/a,True
+"n        Oregon Research Institute, Eugene, OR",n/a,True
+"n        Department of Anthropology, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Anthropology,False
+"n        Institute of Nutrition and Foods Safety, Chinese Centers for Disease Control, Beijing, China",n/a,True
+"n        Department of Biostatistics, University of North Carolina Chapel Hill, Chapel Hill, NC",Department of Biostatistics,False
+"n        Department of Epidemiology, University of North Carolina Chapel Hill, Chapel Hill, NC",Department of Epidemiology,False
+"n        Department of Kinesiology and Health Sciences, College of William and Mary, Williamsburg, VA",n/a,True
+"n        Department of Epidemiology and Prevention, Wake Forest School of Medicine, Winston-Salem, NC",n/a,True
+"n        Department of Epidemiology, Colorado School of Public Health, University of Colorado Denver, Aurora, CO",n/a,True
+"n        Department of Internal Medicine, University of New Mexico, Albuquerque, NM",n/a,True
+"n        Department of Nutrition and Food Hygiene, School of Public Health, Zhejiang University, Hangzhou, China",n/a,True
+"n        Department of Nutritional Sciences, University of Cincinnati Medical Center, Cincinnati, OH",n/a,True
+"n        Department of Research and Evaluation, Kaiser Permanente Southern California, Pasadena, CA",n/a,True
+"n        Departments of Nutrition and Medicine, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Nutrition|Department of Medicine,False
+"n        School of Nursing and Department of Biostatistics, University of North Carolina at Chapel Hill, Chapel Hill, NC",School of Nursing|Department of Biostatistics,False
+"n        Seattle Children's Hospital, Seattle, WA",n/a,True
+"n        Department of Nutrition, Carolina Population Center, University of North Carolina at Chapel Hill, Chapel Hill, NC",Department of Nutrition|Carolina Population Center,False
+"Broad Institute of Harvard and MIT, Cambridge, Massachusetts 02142, UnitedrStates",n/a,True
+"Department of Chemistry andrChemical Biology, Center for Biotechnology and Interdisciplinary Studies, Rensselaer Polytechnic Institute, Troy, New York 12180,rUnited States",n/a,True
+"Departmentrof Biochemistry andrMolecular Biology, University of Oklahoma Health Sciences Center, Oklahoma Center for Medical Glycobiology, 940 StantonrL. Young Blvd., Oklahoma City, Oklahoma 73126, United States",n/a,True
+"Division of Medicinal Chemistryrand Natural Products, Eshelman School of Pharmacy, University of North Carolina, Chapel Hill, North Carolina 27599,rUnited States",Division of Chemical Biology and Medicinal Chemistry,False
+"Department of Biochemistry and Biophysics, University of North Carolina, Chapel Hill, North Carolinar27599, United States",Department of Biochemistry and Biophysics,False
+"Departmentrof Chemistry, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599-3290, UnitedrStates",Department of Chemistry,False
+"Department of Chemistry, University of California—Davis, Davis, Californiar95616, United States",n/a,True
+"Department of Chemistry, University of North Carolina at Chapel Hill, ChapelrHill, North Carolina 27599-3290, United States",Department of Chemistry,False
+"Departmentrof Chemistry, Michigan State University, 578 S. Shaw Lane, East Lansing, Michigan 48824, United States",n/a,True
+"Divisionrof Medicinal Chemistry and Natural Products, UNC Eshelman School ofrPharmacy, University of North Carolina, Chapel Hill, North Carolina 27599, United States",Division of Chemical Biology and Medicinal Chemistry,False
+"Departmentrof Biochemistry and Biophysics, University of North Carolina School of Medicine, 120 Mason Farm Road, Chapel Hill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Departmentrof Physics, Department of Chemistry and Biochemistry, and Programsrof Biophysics, Chemical Physics, and Biochemistry, The Ohio State University, 191 West Woodruff Avenue, Columbus, Ohio 43210, United States",n/a,True
+"TheoreticalrChemistry, School of Biotechnology, Royal Institute of Technology, Roslagstullsbacken 15, SE-10691 Stockholm, Sweden",n/a,True
+"Departmentrof Biochemistry and Biophysics, University of North Carolina, School of Medicine, ChapelrHill, North Carolina 27599, United States",Department of Biochemistry and Biophysics,False
+"Departmentrof Physics and Astronomy, University of North Carolina, Chapel Hill, North Carolina 27599-3255, United States",Department of Physics and Astronomy,False
+"Institute for Cell & Molecular Biosciences, The Medical School; Newcastle University; Framlington Place Newcastle upon Tyne NE2 4HH UK",n/a,True
+"Institute for Cellular Medicine, The Medical School; Newcastle University; Framlington Place Newcastle upon Tyne NE2 4HH UK",n/a,True
+Marsico Lung Institute; University of North Carolina; Chapel Hill NC 27599 USA,Marsico Lung Institute/UNC Cystic Fibrosis Center,False
+School of Biological and Biomedical Sciences; Durham University; South Road Durham DH1 3LE UK,n/a,True
+"Department of Biostatistics, Fay W. Boozman College of Public Health; University of Arkansas for Medical Sciences; Little Rock Arkansas",n/a,True
+"Department of Health Behavior and Health Education, Fay W. Boozman College of Public Health; University of Arkansas for Medical Sciences; Little Rock Arkansas",n/a,True
+General Administration; University of North Carolina; Chapel Hill North Carolina,University of North Carolina at Chapel Hill,False
+Psychology Department; University of Arkansas at Little Rock; Little Rock Arkansas,n/a,True
+Department of Medical Oncology; Dana-Farber Cancer Institute; Boston Massachusetts,n/a,True
+Department of Medicine; Brigham and Women's Hospital; Boston Massachusetts,n/a,True
+Department of Medicine; Harvard Medical School; Boston Massachusetts,n/a,True
+"Division of Otolaryngology, Department of Surgery; Brigham and Women's Hospital; Boston Massachusetts",n/a,True
+BellBrook Labs; Madison Wisconsin U.S.A,n/a,True
+Department of Cell and Molecular Physiology; University of North Carolina at Chapel Hill; North Carolina U.S.A,Department of Cell and Molecular Physiology,False
+Department of Otolaryngology-Head and Neck Surgery; University of North Carolina at Chapel Hill; North Carolina U.S.A,Department of Otolaryngology/Head and Neck Surgery,False
+Department of Pharmacology; University of North Carolina at Chapel Hill; North Carolina U.S.A,Department of Pharmacology,False
+Department of Psychology University of North Carolinarat Chapel Hill,Department of Psychology and Neuroscience,False
+"Department of Psychology University of North Carolinarat Chapel Hill, NC, ",Department of Psychology and Neuroscience,False
+"Curriculum in Neurobiology, Neuroscience Center, andrDepartment of Cell and Molecular Physiology, University of North Carolina,rChapel Hill",UNC Neuroscience Center|Department of Cell and Molecular Physiology,False
+"Department of Molecular and Cell Biology and Helen WillsrNeuroscience Institute, University of California, Berkeley, ",n/a,True
+"Systems Neurobiology Laboratory, The Salk Instituterfor Biological Studies, La Jolla, CA",n/a,True
+Biology Department; University of North Carolina; Chapel Hill NC 27599 USA,Department of Biology,False
+Department of Biological Sciences; Graduate School of Science; Osaka University; Machikaneyama Toyonaka Osaka 560-0043 Japan,n/a,True
+Department of Biology; University of York; Heslington York YO10 5DD UK,n/a,True
+Sainsbury Laboratory; University of Cambridge; Bateman Street Cambridge CB2 1LR UK,n/a,True
+Biology Department; 208 Mueller Laboratory; Pennsylvania State University; University Park PA 16802 USA,n/a,True
+Department of Biology; University of North Carolina; Chapel Hill NC 27599 USA,Department of Biology,False
+Plant Genetic Engineering Laboratory; School of Agriculture and Food Sciences; University of Queensland; Brisbane Qld 4072 Australia,n/a,True
+School of Environmental and Life Sciences; University of Newcastle; Callaghan NSW 2308 Australia,n/a,True
+Department of Urology; Roswell Park Cancer Institute; Buffalo New York,n/a,True
+Lineberger Comprehensive Cancer Center; University of North Carolina School of Medicine; Chapel Hill North Carolina,UNC Lineberger Comprehensive Cancer Center,False
+Center for Population Health Sciences; University of Edinburgh Medical School; Tevoit Place; Edinburgh United Kingdom,n/a,True
+Department of Epidemiology; Division of Urology; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,Department of Epidemiology|Department of Urology,False
+Epidemiology Branch; National Institute of Environmental Health Sciences; Research Triangle Park; North Carolina,n/a,True
+Lineberger Comprehensive Cancer Center; Division of Urology; University of North Carolina at Chapel Hill; Chapel Hill North Carolina,UNC Lineberger Comprehensive Cancer Center,False
+School of Public Health; Louisiana State University Health Science Center; New Orleans Louisiana,n/a,True
+Department of Molecular Biomedical Sciences; North Carolina State University; Raleigh North Carolina,n/a,True
+Department of Veterinary Biosciences; The Ohio State University; Columbus Ohio,n/a,True
+Department of Veterinary Clinical Sciences; The Ohio State University; Columbus Ohio,n/a,True
+Department of Genetics; University of North Carolina School of Medicine; Chapel Hill North Carolina,Department of Genetics,False
+Department of Internal Medicine; University of Michigan Medical School; Ann Arbor Michigan,n/a,True
+Department of Urology; The Johns Hopkins University School of Medicine; Baltimore Maryland,n/a,True
+Michigan Center for Translational Pathology; University of Michigan Medical School; Ann Arbor Michigan,n/a,True
+Translational Genomics Research Institute; Phoenix Arizona,n/a,True
+"Department of Computer Science, University of North Carolina at Chapel Hill, Sitterson Hall, CB #3175, Chapel Hill, North Carolina 27599, USA",Department of Computer Science,False
+"Department of Physics and Astronomy, University of North Carolina at Chapel Hill, 345 Chapman Hall, CB #3255, Chapel Hill, North Carolina 27599, USA",Department of Physics and Astronomy,False
+"Rheomics Inc., B40 Chapman Hall CB #3255, Chapel Hill, North Carolina 27599, USA",n/a,True
+"Department of Biomedical Engineering, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, USA",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Department of Pathology and Laboratory Medicine, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, USA",Department of Pathology and Laboratory Medicine,False
+"Division of Gastroenterology, Department of Internal Medicine, Carolinas Medical Center, Charlotte, NC 28203, USA",n/a,True
+"Department of Probability and Statistics, School of Mathematics, Beijing Institute of Technology, Beijing 100081, China",n/a,True
+"Lineberger Comprehensive Cancer Center, University of North Carolina, Chapel Hill, NC 27514, USA",UNC Lineberger Comprehensive Cancer Center,False
+"Public Health Sciences Division, Fred Hutchinson Cancer Research Center, Seattle, WA 98109, USA",n/a,True
+"Hôpital Sacré Cœur, Beirut B.P.116, Lebanon",n/a,True
+"Medical Audiology Services, Perth, WA 6005, Australia",n/a,True
+"NYU Langone Medical Center, New York, NY 10016, USA",n/a,True
+"PD Hinduja Hospital National and MRC, Mumbai 400016, India",n/a,True
+"Royal National Throat, Nose and Ear Hospital, London WC1X 8EE, UK",n/a,True
+"South of England CI Centre, Southampton SO17 1BJ, UK",n/a,True
+"Sunnybrook, Toronto, ON, Canada M4N 3M5",n/a,True
+"The Eargroup, Herentalsebaan 75, 2100 Antwerp-Deurne, Belgium",n/a,True
+"University Medical Center Freiburg, 79106 Freiburg, Germany",n/a,True
+"University Sapienza, 185 Rome, Italy",n/a,True
+"University of Kansas Medical Center, Kansas City, MO 66160, USA",n/a,True
+"University of North Carolina at Chapel Hill, Chapel Hill, NC 27514, USA",University of North Carolina at Chapel Hill,False
+"VU University Medical Center, 1081 HZ Amsterdam, The Netherlands",n/a,True
+"World Hearing Center, 02-042 Warsaw, Poland",n/a,True
+"Yorkshire CI Service, Bradford BD9 5HU, UK",n/a,True
+"Department of Physics and Astronomy, University of North Carolina, Chapel Hill, NC 27599, USA",Department of Physics and Astronomy,False
+"The Key Laboratory of Nonferrous Metal Materials and New Processing Technology of Ministry of Education, Guangxi University, Nanning 530004, China",n/a,True
+ University of North Carolina at Chapel Hill,University of North Carolina at Chapel Hill,False
+ University of Texas at Austin,n/a,True
+"Endocrine Section, Applied Physiology Laboratory, Department of Exercise &amp; Sport Science, University of North Carolina, Chapel Hill, NC, USA",Department of Exercise and Sport Science,False
+"Endocrine Section, Applied Physiology Laboratory, Department of Exercise &amp; Sport Science, University of North Carolina, Department of Nutrition, School of Public Health, University of North Carolina, CB # 8700 - UNC-CH, Chapel Hill, NC 27599, USA",Department of Exercise and Sport Science|Department of Nutrition,False
+"University of North Carolina at Chapel Hill, 170 Manning Drive, POB 3rd Floor, Chapel Hill, NC 27599-7305, USA",University of North Carolina at Chapel Hill,False
+"Baird MS Center, Department of Neurology, State University of New York at Buffalo, Buffalo, NY, USA",n/a,True
+"Buffalo Neuroimaging Analysis Center, Department of Neurology, School of Medicine and Biomedical Sciences, MRI Imaging Clinical Translational Research Center, University at Buffalo, State University of New York, 100 High Street, Buffalo, NY 14203, USA",n/a,True
+"Buffalo Neuroimaging Analysis Center, Department of Neurology, School of Medicine and Biomedical Sciences, University at Buffalo, State University of New York, Buffalo, NY, USA",n/a,True
+"Department of Neurology, Microbiology and Immunology, University of North Carolina at Chapel Hill, Chapel Hill, NC, USA",Department of Microbiology and Immunology|Department of Neurology,False
+"US Medical Affairs, EMD Serono, Inc., Rockland, MA, USA",n/a,True
+"Center for Environmental Medicine, Asthma, and Lung Biology, University of North Carolina, Chapel Hill, NC 27599, USA","Center for Environmental Medicine, Asthma and Lung Biology",False
+"Children’s Hospital of Oakland Research Institute, Oakland, CA 94609, USA",n/a,True
+"Department of Foods and Nutrition, Purdue University, West Lafayette, IN 47907, USA",n/a,True
+"Department of Pathobiology and Diagnostic Investigation, Michigan State University, East Lansing, MI 48824, USA",n/a,True
+"BASF, Ludwigshafen, Germany",n/a,True
+"Charles River Laboratories Inc., Durham, North Carolina",n/a,True
+"Consultants in Veterinary Pathology, Murrysville, Pennsylvania",n/a,True
+"Duke University, Durham, North Carolina",n/a,True
+"Frenkendorf CH-4402, Switzerland",n/a,True
+"GEMpath Inc., Longmont, Colorado",n/a,True
+"U.S. Environmental Protection Agency (EPA), Washington, DC",n/a,True
+"U.S. Environmental Protection Agency, Research Triangle Park, North Carolina",n/a,True
+"U.S. Food and Drug Administration (FDA), Silver Spring, Maryland",n/a,True
+"University of Aarhus, DK-8000 Aarhus, Denmark",n/a,True
+"University of North Carolina, Chapel Hill, North Carolina",University of North Carolina at Chapel Hill,False
+"Department of Nutrition, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Nutrition,False
+"National Toxicology Program, National Institute of Environmental Health and Sciences, Cellular and Molecular Pathology Branch, Research Triangle Park, North Carolina, USA",n/a,True
+"Department of Environmental Sciences and Engineering, Gillings School of Global Public Health, University of North Carolina, Chapel Hill, North Carolina, USA",Department of Environmental Sciences and Engineering,False
+"Biostatistics Branch, Division of Intramural Research, National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA",n/a,True
+"Cellular and Molecular Pathology Branch, Division of the National Toxicology Program, National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA",n/a,True
+"NTP Laboratory, Division of the National Toxicology Program, National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA",n/a,True
+"UltraPath Imaging, Durham, North Carolina, USA",n/a,True
+"Curriculum in Toxicology, University of North Carolina, School of Medicine, Chapel Hill, North Carolina, USA",Curriculum in Toxicology,False
+"Experimental Pathology Laboratories, Inc., Research Triangle Park, North Carolina, USA",n/a,True
+Intracellular Membrane Trafficking Unit; Oral and Pharyngeal Cancer Branch; National Institute of Dental and Craniofacial Research; National Institutes of Health; 30 Convent Dr. 303A; Bethesda; MD; 20892-4340; USA,n/a,True
+Department of Cell Biology and Physiology; University of North Carolina at Chapel Hill; Chapel Hill NC 27599-7090 USA,Department of Cell Biology and Physiology,False
+Department of Chemistry; University of North Carolina at Chapel Hill; Chapel Hill NC 27599-3290 USA,Department of Chemistry,False
+Department of Microbiology and Immunology; University of North Carolina at Chapel Hill; Chapel Hill NC 27599-7290 USA,Department of Microbiology and Immunology,False
+Department of Pathology and Spatiotemporal Modeling Center; University of New Mexico; Albuquerque NM 87131 USA,n/a,True
+Department of Cell Biology & Physiology; University of North Carolina at Chapel Hill; Chapel Hill NC 27599 USA,Department of Cell Biology and Physiology,False
+Department of Medicine; Division of Hematology & Oncology; University of North Carolina; Chapel Hill North Carolina,Division of Hematology/Oncology,False
+Department of Medicine; Division of Hematology; Duke University Medical Center; Durham North Carolina,n/a,True
+Department of Pathology & Laboratory Medicine; University of North Carolina; Chapel Hill North Carolina,Department of Pathology and Laboratory Medicine,False
+Division of Medical Genetics; Duke University Medical Center; Durham North Carolina,n/a,True
+Transfusion Service; Duke Hospital; Durham North Carolina,n/a,True
+"Department of Biomedical Engineering University of Texas at San Antonio, San Antonio, TX, USA",n/a,True
+"Department of Biomedical Engineering University of Texas at San Antonio, San Antonio, TX, USA 2Biodynamic Research Corporation, San Antonio, TX, USA",n/a,True
+"Department of Biomedical Engineering University of Texas at San Antonio, San Antonio, TX, USA 4WESMD Professional Associates, San Antonio, TX, USA 5Rosenberg School of Optometry, University of the Incarnate Word, San Antonio, TX, USA",n/a,True
+"Department of Geological Sciences, University of Texas at San Antonio, San Antonio, TX, USA",n/a,True
+"Department of Ophthalmology, University of North Carolina School of Medicine, Chapel Hill, NC, USA",Department of Ophthalmology,False
+"Department of Ophthalmology, University of Texas Health Science Center, San Antonio, TX, USA",n/a,True
+"U.S. Army Institute of Surgical Research, JBSA Fort Sam Houston, San Antonio, TX, USA",n/a,True
+Department of General Surgery; University of Ulm; Ulm Germany,n/a,True
+Department of Medicine; Division of Gastroenterology and Hepatology; University of North Carolina; Chapel Hill NC USA,Division of Gastroenterology and Hepatology,False
+Department of Nutrition Science; East Carolina University; Greenville NC USA,n/a,True
+"University of North Carolina, Chapel Hill, North Carolina (EPD, MDS, KIN, TLN, LCH), Children's Hospital Boston and Dana Farber Cancer Institute, Boston, Massachusetts (JW)",n/a,True
+"Johns Hopkins University School of Nursing, Baltimore (JX), Howard University Hospital, Washington, DC (OA), University of Pittsburgh, Pittsburgh, Pennsylvania (EW, JA, LT, ADD), University of North Carolina, Chapel Hill (MKS)",n/a,True
+"Department of Surgery, Kamuzu Central Hospital, Lilongwe, Malawi",n/a,True
+Departments of Surgeryand,n/a,True
+"Epidemiology, University of North Carolina, Chapel Hill, North Carolina",Department of Epidemiology,False
+"University of North Carolina School of Medicine, Chapel Hill, North Carolina, USA",School of Medicine,False
+"Department of Surgery, University of North Carolina, Chapel Hill, NCUSA",Department of Surgery,False
+"Department of Obstetrics and Gynecology, Duke University, Durham, USA",n/a,True
+"Department of Surgery, Division of Trauma and Critical Care, University of North Carolina at Chapel Hill, USA;",Department of Surgery,False
+"Department of Surgery, University of Rochester, USA;",n/a,True
+"Kamuzu Central Hospital, Lilongwe, Malawi;",n/a,True
+"Director, Kamuzu Central Hospital",n/a,True
+"Fellow, Infectious Diseases, Weill Cornell Medical College, New York-Presbyterian Hospital",n/a,True
+"MD/PhD student, University of North Carolina – Chapel Hill",University of North Carolina at Chapel Hill,False
+"Physician Investigator, UNC Project-Malawi &amp; Kamuzu Central Hospital",UNC Project-Malawi,False
+"Professor, UNC School of Medicine; International Director, UNC Project-Malawi",UNC Project-Malawi,False
+"Professor, UNC School of Medicine; Scientific Director, UNC Project-Malawi",UNC Project-Malawi,False
+Kinshasa School of Public Health; Kinshasa; Democratic Republic of Congo,n/a,True
+University of Kinshasa; Kinshasa; Democratic Republic of Congo,n/a,True
+University of North Carolina at Chapel Hill; Chapel Hill; NC; USA,University of North Carolina at Chapel Hill,False
+Baylor College of Medicine and Department of Pediatrics; Texas Children's Hospital; Houston; TX; USA,n/a,True
+Department of Pediatrics; Kamuzu Central Hospital; Lilongwe; Malawi,n/a,True
+Malawi Ministry of Health; Lilongwe; Malawi,n/a,True
+School of Public Health; University of North Carolina; Chapel Hill; NC; USA,Gillings School of Global Public Health,False
+"Department of Epidemiology, Gillings School of Public Health; University of North Carolina; Chapel Hill; NC; USA",Department of Epidemiology,False
+Department of International Health; University of Tampere School of Medicine; Tampere; Finland,n/a,True
+Division of Community Medicine; University of Malawi College of Medicine; Blantyre; Malawi,n/a,True
+Division of Infectious Diseases; University of North Carolina School of Medicine; Chapel Hill; NC; USA,Division of Infectious Diseases,False
+Department of Epidemiology; University of North Carolina at Chapel Hill Gillings School of Global Public Health; Chapel Hill; NC; USA,Department of Epidemiology,False
+"Health Economics and Epidemiology Research Office, Department of Internal Medicine; School of Clinical Medicine; Faculty of Health Sciences; University of the Witwatersrand; Johannesburg; South Africa",n/a,True
+Witkoppen Health and Welfare Centre; Johannesburg; South Africa,n/a,True
+Baylor College of Medicine and Department of Pathology & Immunology; Texas Children's Hospital; Houston; TX; USA,n/a,True
+Centre for Infectious Disease Epidemiology and Research; School of Public Health and Family Medicine; University of Cape Town; Cape Town; South Africa,n/a,True
+Centre for Infectious Disease Research in Zambia (CIDRZ); Lusaka; Zambia,n/a,True
+Division of Infectious Diseases; Department of Medicine; University of Stellenbosch and Tygerberg Hospital; Cape Town; South Africa,n/a,True
+Institute of Social and Preventive Medicine (ISPM); University of Bern; Bern; Switzerland,n/a,True
+Khayelitsha ART Programme; Médecins Sans Frontières; Cape Town; South Africa,n/a,True
+Newlands Clinic; Harare; Zimbabwe,n/a,True
+The Desmond Tutu HIV Centre; Institute for Infectious Disease and Molecular Medicine; University of Cape Town; Cape Town; South Africa,n/a,True
+Centre for Research into Environment and Health; Aberystwyth University; Aberystwyth UK,n/a,True
+Department of Health Statistics and Information Systems; World Health Organization; Geneva Switzerland,n/a,True
+Department of Public Health and Environment; World Health Organization; Geneva Switzerland,n/a,True
+Gillings School of Global Public Health; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Gillings School of Global Public Health,False
+London School of Hygiene and Tropical Medicine; London UK,n/a,True
+Norwich Medical School; University of East Anglia; Norwich UK,n/a,True
+Rollins School of Public Health; Emory University; Atlanta GA USA,n/a,True
+"School of Public Health; University of California, Berkeley; Berkeley CA USA",n/a,True
+Swiss Tropical and Public Health Institute; Basel Switzerland,n/a,True
+Baylor College of Medicine Abbott Fund Children's Clinical Centre of Excellence-Malawi; Lilongwe Malawi,n/a,True
+Department of Medicine; Division of Infectious Diseases; University of North Carolina at Chapel Hill School of Medicine; Chapel Hill NC USA,Division of Infectious Diseases,False
+University of North Carolina Project Lilongwe; Lilongwe Malawi,UNC Project-Malawi,False
+Division of HIV/AIDS; San Francisco General Hospital; University of California San Francisco; San Francisco CA USA,n/a,True
+Gillings School of Global Public Health; University of North Carolina; Chapel Hill NC USA,Gillings School of Global Public Health,False
+Makerere University Joint AIDS Program; Kampala Mbarara Uganda,n/a,True
+Makerere University-University of California San Francisco Research Collaboration; Mbarara Kampala Uganda,n/a,True
+School of Public Health; University of California; Berkeley CA USA,n/a,True
+Department of Geography and Environment; University of Southampton; Southampton UK,n/a,True
+The Water Institute; University of North Carolina; Chapel Hill NC USA,The Water Institute,False
+WaterAid UK; London UK,n/a,True
+World Health Organization; Geneva Switzerland,n/a,True
+" Department of Pathology and Laboratory Medicine The University of North Carolina at Chapel Hill Chapel Hill, NC 27599",Department of Pathology and Laboratory Medicine,False
+" Division of Cardiology The University of North Carolina at Chapel Hill Chapel Hill, NC 27599",Division of Cardiology,False
+" Joint Department of Biomedical Engineering The University of North Carolina at Chapel Hill Chapel Hill, NC 27599",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Joint Department of Biomedical Engineering, University of North Carolina and North Carolina State University, Chapel Hill, NC, USA",UNC/NCSU Joint Department of Biomedical Engineering,False
+"Department of Biomedical Engineering, Duke University, Durham, NC, USA",n/a,True
+Department of Clinical Sciences; Tufts Cummings School of Veterinary Medicine; Grafton; MA; USA,n/a,True
+Department of Molecular Biomedical Sciences; College of Veterinary Medicine; North Carolina State University; Raleigh; NC; USA,n/a,True
+Department of Population Health and Pathobiology; College of Veterinary Medicine; North Carolina State University; Raleigh; NC; USA,n/a,True
+"Department of Clinical Sciences, Tufts Cummings School of Veterinary Medicine, North Grafton, Massachusetts",n/a,True
+"Department of Medicine, School of Medicine, University of Colorado, Denver, Aurora, Colorado",n/a,True
+"Department of Molecular Biomedical Sciences, College of Veterinary Medicine, North Carolina State University, Raleigh, North Carolina",n/a,True
+"Department of Veterinary Clinical Sciences, College of Veterinary Medicine, The Ohio State University, Columbus, Ohio",n/a,True
+"Department of Veterinary Clinical Sciences, College of Veterinary Medicine, University of Minnesota, St Paul, Minnesota",n/a,True
+"Masonic Cancer Center, University of Minnesota, Minneapolis, Minnesota",n/a,True
+"The Broad Institute, Cambridge, Massachusetts",n/a,True
+"University of Colorado Cancer Center, Aurora, Colorado",n/a,True
+"VDx Veterinary Diagnostics, Davis, California",n/a,True
+"Centro de Investigación en Demografía y Salud, Universidad Nacional Autónoma de Nicaragua, León",n/a,True
+"Duke University Medical Center, Durham, North Carolina",n/a,True
+"Duke University School of Nursing, Durham, North Carolina",n/a,True
+University of North Carolina at Chapel Hill School of Nursing,School of Nursing,False
+University of North Carolina-Chapel Hill School of Nursing,School of Nursing,False
+"University of North Carolina-Chapel Hill School of Nursing, ",School of Nursing,False
+Durham Veterans Affairs Medical Center Duke University Medical Center,n/a,True
+"University of North Carolina at Chapel Hill School of Nursing, ",School of Nursing,False
+"Durham Veterans Affairs Medical Center &amp; Duke University Medical Center, Durham, NC",n/a,True
+"Massachusetts General Hospital Center for Global Health, Boston, USA",n/a,True
+"University of California Los Angeles School of Dentistry, USA",n/a,True
+"University of Miami, Coral Gables, FL, USA",n/a,True
+"University of Missouri–Kansas City School of Medicine, USA",n/a,True
+"University of Pittsburgh, PA, USA",n/a,True
+"Yale University, New Haven, CT, USA",n/a,True
+Division of Molecular Pharmaceutics; University of North Carolina; Chapel Hill NC USA,Division of Molecular Pharmaceutics,False
+Joint Department of Biomedical Engineering; University of North Carolina at Chapel Hill and North Carolina State University; Raleigh NC USA,UNC/NCSU Joint Department of Biomedical Engineering,False
+"Washington State University, Pullman, WA, USA",n/a,True
+Department of General Psychiatry; Institute of Mental Health; Singapore Singapore,n/a,True
+Department of Psychiatry and Psychotherapy; University of Cologne; Cologne Germany,n/a,True
+Department of Psychiatry; University of North Carolina; Chapel Hill NC USA,Department of Psychiatry,False
+Department of Psychiatry; Yale University; New Haven CT USA,n/a,True
+"Hotchkiss Brain Institute, Department of Psychiatry, University of Calgary; Calgary Alberta Canada",n/a,True
+"Institute of Brain, Behaviour and Mental Health, University of Manchester; Manchester UK",n/a,True
+"King's College London, Institute of Psychiatry; London UK",n/a,True
+"University Hospital of Child and Adolescent Psychiatry and Psychotherapy, University of Bern; Bern Switzerland",n/a,True
+University of Basel Psychiatric Clinics; Basel Switzerland,n/a,True
+"Department of Clinical Neuroscience, Centre for Psychiatric Research and Education; Karolinska Institutet and Stockholm County Council; Stockholm Sweden",n/a,True
+Department of Psychiatry; University of North Carolina at Chapel Hill; Chapel Hill NC USA,Department of Psychiatry,False
+Department of Dermatology & Cutaneous Surgery; University of Miami Miller School of Medicine; Miami Florida,n/a,True
+"Department of Surgery, Division of Vascular Surgery; University of North Carolina Medical School; Chapel Hill North Carolina",Department of Surgery,False
+Organogenesis Inc.; Canton Massachusetts,n/a,True
+Sabolinski LLC; Franklin Massachusetts,n/a,True
+Department of Biochemistry and Biophysics; University of North Carolina; Chapel Hill; NC; USA,Department of Biochemistry and Biophysics,False
+Department of Pharmacology; University of North Carolina; Chapel Hill; NC; USA,Department of Pharmacology,False
+Department of Physics; University of North Carolina; Chapel Hill; NC; USA,Department of Physics and Astronomy,False
+"College of Pharmacy, Sookmyung Women's University, Seoul, Korea.",n/a,True
+"Department of Family Medicine, University of North Carolina School of Medicine, Chapel Hill, NC, USA.",Department of Family Medicine,False
+"McWhorter School of Pharmacy, Samford University, Birmingham, AL, USA.",n/a,True
+ Curriculum in Toxicology,n/a,True
+"Center for Environmental Medicine, Asthma, and Lung Biology",n/a,True
+Hussman School of Media and Journalism,Hussman School of Journalism and Media,False
+Department of Pedatrics,n/a,True
+"Department of Maternal and Child Health,",n/a,True
+Eshleman School of Pharmacy,Eshelman School of Pharmacy,False
+Hussman School of Journalism,Hussman School of Journalism and Media,False
+Department of of Epidemiology,n/a,True
+Center for Women&apos;s Health Research,n/a,True
+"Department of Chemistry,",n/a,True
+"Department of Psychiatry,",n/a,True
+Cecil G. Sheps Center for Health Research,Cecil G. Sheps Center for Health Services Research,False
+"Department of Medicine,",Department of Medicine,False
+Department of Physiology,n/a,True
+University of North Carolina Chapel Hill,University of North Carolina at Chapel Hill,False
+Deparment of Pharmacology,n/a,True
+Department ofPharmacology,n/a,True
+Department of Cell Biology and Molecular Physiology,n/a,True
+Cystic Fibrosis and Pulmonary Dieases Research and Treatment Center,n/a,True
+ Department of Family Medicine,n/a,True
+Institute for Global Health and Infectious Diseases,n/a,True
+"Department of Genetics,",n/a,True
+UNC Lineberger Comprehensive Center,UNC Lineberger Comprehensive Cancer Center,False
+Department of Biostatics,n/a,True
+Department of Pschiatry,n/a,True
+Department of Obsetrics and Gynaecology,n/a,True
+Department of Obstetrics and Gynaecology,n/a,True
+Departments of Pediatrics,n/a,True
+UNC Department of Epidemiology,Department of Epidemiology,False
+Department ofGeography,n/a,True
+"Department of Mathematics,",n/a,True
+"Department of Electrical and Computer Engineering, Colorado State University, Fort Collins, CO 80523-1373, USA",n/a,True
+"Department of Statistics, Colorado State University, Fort Collins, CO 80523-1373, USA",n/a,True
+"CFHT Corporation, 65-1238 Mamalahoa Highway, Kamuela, HI 96743, USA",n/a,True
+"Center for Astrophysics and Space Science, University of California at San Diego, 9500 Gilman Drive, La Jolla, CA 92093, USA",n/a,True
+"Departimento de Físika, Escuela Superior de Física y Matematicas del Instituto Politecnico Nacional, Edif. 9, U. P. Zacatenco, 07738 Cuidad de Mexico, DF, Mexico",n/a,True
+"Department of Physics and Astronomy, University of North Carolina at Greensboro, Greensboro, NC 27402, USA",n/a,True
+"Geneva Observatory, Geneva University, Chemin des Maillettes 51, 1290 Sauverny, Switzerland",n/a,True
+"Instituto de Astronomía, Universidad Nacional Autónoma de México, Apartado Postal 877, 22830 Ensenada, BC, Mexico",n/a,True
+"Instituto de Ciencias Astronómicas de la Tierra y del Espacio, CONICET, Casilla de Correo 49, 5400 San Juan, Argentina",n/a,True
+"The Aerospace Corporation, M2/266, P.O. Box 92957, Los Angeles, CA 90009, USA",n/a,True
+"Center for Experimental Nuclear Physics and Astrophysics and Department of Physics, University of Washington, Seattle, WA 98195, USA",n/a,True
+"Centre for Particle Physics, University of Alberta, Edmonton, AB, Canada T6G 2G7",n/a,True
+"Department of Physics and Astronomy, University of South Carolina, Columbia, SC 29208, USA",n/a,True
+"Department of Physics and Astronomy, University of Tennessee, Knoxville, TN 37996, USA",n/a,True
+"Department of Physics, University of South Dakota, Vermillion, SD 57069, USA",n/a,True
+"Institute for Theoretical and Experimental Physics, Moscow 117218, Russia",n/a,True
+"Joint Institute for Nuclear Research, Dubna 141980, Russia",n/a,True
+"Los Alamos National Laboratory, Los Alamos, NM 87545, USA",n/a,True
+"Nuclear Science Division, Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA",n/a,True
+"Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA",n/a,True
+"Pacific Northwest National Laboratory, Richland, WA 99352, USA",n/a,True
+"Research Center for Nuclear Physics and Department of Physics, Osaka University, Ibaraki, Osaka 567-0047, Japan",n/a,True
+"South Dakota School of Mines and Technology, Rapid City, SD 57701, USA",n/a,True
+"Triangle Universities Nuclear Laboratory, Durham, NC 27708, USA",n/a,True
+"Center for Gastrointestinal Biology and Disease, University of North Carolina, Chapel Hill, North Carolina, USA",Center for Gastrointestinal Biology and Disease,False
+"Molecular Staging, Inc, Suite 701, 300 George Street, New Haven 06511, CT, USA",n/a,True
+"Thurston Arthritis Research Center, Department of Medicine, University of North Carolina at Chapel Hill, CB# 7280, 3330 Thurston Building, Chapel Hill 27599-7280, NC, USA",Thurston Arthritis Research Center,False
+"Division of Molecular Pharmaceutics, School of Pharmacy, University of North Carolina, Chapel Hill, NC 27599, USA",Division of Molecular Pharmaceutics,False
+"Dept. of Chemistry, Duke University, Box 90346, Durham 27708-0346, NC, USA",n/a,True
+"Dept. of Chemistry, University of North Carolina, Chapel Hill 27599-3290, NC, USA",Department of Chemistry,False
+"Pedestrian and Bicycle Information Center, University of North Carolina at Chapel Hill, Chapel Hill, NC 27514, USA",Highway Safety Research Center,False
+"School of Transportation and Logistics, Dalian University of Technology, Dalian 116024, China",n/a,True
+"Department of Gastroenterology and Hepatology, University of North Carolina, Chapel Hill, North Carolina, USA",Division of Gastroenterology and Hepatology,False
+"School of Social Work, University of Washington, Seattle, Washington, USA",n/a,True
+"Division of Urologic Surgery, The University of North Carolina at Chapel Hill, NC, USA",Department of Surgery,False
+Department Physics and Astronomy,n/a,True
+"Department of Mathematics, Purdue University, West Lafayette, Indiana 47907, USA and School of Mechanical Engineering, Purdue University, West Lafayette, Indiana 47907, USA",n/a,True
+"Department of Mathematics, University of North Carolina at Chapel Hill, Chapel Hill, North Carolina 27599, USA",Department of Mathematics,False
+"Mathematics Department, Duke University, Durham, North Carolina 27708, USA",n/a,True
+Institute of Global Health and Infectious Disease,n/a,True
+University of Georgia,n/a,True
+"University of North Carolina at Chapel Hill,",University of North Carolina at Chapel Hill,False
+Deptartment of Physics and Astronomy,n/a,True
+University of North California at Chapel Hill,University of North Carolina at Chapel Hill,False
+UNC Lineberger Comprehensive Care Center,UNC Lineberger Comprehensive Cancer Center,False
+Department of Pulmonary Diseases and Critical Care Medicine,n/a,True
+"Department of Biostatistics,",n/a,True
+UNC Lineberger Cancer Center,UNC Lineberger Comprehensive Cancer Center,False
+Department of Phamacology,n/a,True
+"Department of Computer Science,",n/a,True
+2Department of Physics and Astronomy,n/a,True
+Institute for the Environment,n/a,True
+Institute of Marine Science,n/a,True
+Department of Opthamology,n/a,True
+Curriculum in Applied Science and Engineering,n/a,True
+"Division of Pulmonary Diseases and Critical Care Medicine,",n/a,True
+Department of Exercise and Sports Science,n/a,True
+"Department of Nutrition,",n/a,True
+Gillings School of Global Pubic Heath,Gillings School of Global Public Health,False
+Department of Statistics and Operation Research,n/a,True
+University of Toronto,n/a,True
+Division of Hemtology/Oncology,n/a,True
+Gillings School of Public Health,Gillings School of Global Public Health,False
+Departments of Epidemiology,n/a,True
+Departments of Genetics,n/a,True
+Curriculum of Genetics and Molecular Biology,n/a,True
+Gillings School Global Public Health,Gillings School of Global Public Health,False
+Department of Environmental Science and Engineering,n/a,True
+Department of Gastroenterology,n/a,True
+Department of Biochemistry,n/a,True
+"Environment, Ecology and Energy Program - Environmental Science",n/a,True
+Division of Pharmacotherapy Experimental Therapeutics,n/a,True
+Division of Speech Hearing Sciences,n/a,True
+Department of Pharmacy,n/a,True
+University of Pittsburgh School of Medicine,n/a,True
+Carolina-Duke Joint Program in German Studies,Carolina-Duke Graduate Program in German Studies,False
+Cell Biology and Physiology,Department of Cell Biology and Physiology,False
+Health Informatics,n/a,True
+Journalism (Technology and Communication),Hussman School of Journalism and Media,False

--- a/spec/jobs/remediate_affiliations_job_spec.rb
+++ b/spec/jobs/remediate_affiliations_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require 'active_fedora/cleaner'
+
+RSpec.describe RemediateAffiliationsJob, type: :job do
+  let(:unmappable_affiliations_path) { File.join(fixture_path, 'files', 'short_unmappable_affiliations.csv') }
+  before do
+    allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { false }
+  end
+
+  it 'enqueues jobs' do
+    ActiveJob::Base.queue_adapter = :test
+    expect { described_class.perform_later }.to have_enqueued_job(described_class).on_queue('long_running_jobs')
+  end
+
+  it 'creates a new AffiliationRemediationService' do
+    ActiveJob::Base.queue_adapter = :test
+    allow(AffiliationRemediationService).to receive(:new).and_return(AffiliationRemediationService.new(unmappable_affiliations_path))
+    described_class.perform_now
+    expect(AffiliationRemediationService).to have_received(:new).with(Rails.root.join(ENV['DATA_STORAGE'], 'reports', 'unmappable_affiliations.csv').to_s)
+  end
+end

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -119,6 +119,19 @@ RSpec.describe AffiliationRemediationService do
       original_second_creator_hash = second_creator.attributes
       expect(service.map_person_attributes(original_second_creator_hash)).to eq(updated_second_creator_hash)
     end
+
+    it 'keeps both creators associated with the object' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq([unmappable_affiliation_one])
+      second_creator = obj.creators.find { |person| person['index'] == [2] }
+      expect(second_creator.attributes['affiliation']).to eq([])
+      service.update_affiliations(obj)
+      obj.reload
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq([mapped_affiliation_one])
+      second_creator = obj.creators.find { |person| person['index'] == [2] }
+      expect(second_creator.attributes['affiliation']).to eq([])
+    end
   end
 
   context 'with an article and general work' do

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -33,18 +33,18 @@ RSpec.describe AffiliationRemediationService do
   end
   let(:work_with_people) do
     General.create(title: ['New General Work with people'],
-                   'translators_attributes'.to_sym => { '0' => { name: 'translator_1',
-                                                                 affiliation: 'Carolina Center for Genome Sciences',
-                                                                 index: 1 },
-                                                        '1' => { name: 'translator_2',
-                                                                 affiliation: 'Department of Chemistry',
-                                                                 index: 2 },
-                                                        '2' => { name: 'translator_3',
-                                                                 affiliation: 'Unmappable affiliation 1',
-                                                                 index: 3 },
-                                                        '3' => { name: 'translator_4',
-                                                                 affiliation: 'Unmappable affiliation 2',
-                                                                 index: 4 } })
+                   translators_attributes: { '0' => { name: 'translator_1',
+                                                      affiliation: 'Carolina Center for Genome Sciences',
+                                                      index: 1 },
+                                             '1' => { name: 'translator_2',
+                                                      affiliation: 'Department of Chemistry',
+                                                      index: 2 },
+                                             '2' => { name: 'translator_3',
+                                                      affiliation: 'Unmappable affiliation 1',
+                                                      index: 3 },
+                                             '3' => { name: 'translator_4',
+                                                      affiliation: 'Unmappable affiliation 2',
+                                                      index: 4 } })
   end
 
   before do
@@ -70,32 +70,6 @@ RSpec.describe AffiliationRemediationService do
     expect(service.mappable_affiliation?(mapped_affiliation_one)).to eq true
   end
 
-  context 'with multiple affiliations' do
-    let(:unmappable_affiliation_one) { 'Departmentrof Chemistry and Neuroscience Center University of North Carolina at Chapel Hill Chapel Hill, NC 27599-3290' }
-    let(:mapped_affiliation_one) { ['UNC Neuroscience Center', 'Department of Chemistry'] }
-
-    before do
-      ActiveFedora::Cleaner.clean!
-      Blacklight.default_index.connection.delete_by_query('*:*')
-      Blacklight.default_index.connection.commit
-      article
-    end
-
-    it 'can map from an unmappable affiliation to a mappable affiliation' do
-      expect(service.map_to_new_affiliation(unmappable_affiliation_one)).to eq(mapped_affiliation_one)
-      # expect(service.map_to_new_affiliation(unmappable_affiliation_two)).to eq(mapped_affiliation_two)
-    end
-
-    it 'can update the creator affiliations' do
-      first_creator = obj.creators.find { |person| person['index'] == [1] }
-      expect(first_creator.attributes['affiliation']).to eq([unmappable_affiliation_one])
-      service.update_affiliations(obj)
-      obj.reload
-      first_creator = obj.creators.find { |person| person['index'] == [1] }
-      expect(first_creator.attributes['affiliation']).to eq(mapped_affiliation_one)
-    end
-  end
-
   context 'with an article and general work' do
     before do
       ActiveFedora::Cleaner.clean!
@@ -110,6 +84,72 @@ RSpec.describe AffiliationRemediationService do
         service.remediate_all_affiliations
         obj.reload
       end.to(change { obj.creators })
+    end
+  end
+
+  context 'with an affiliation that needs to be moved to "other_affiliation"' do
+    let(:unmappable_affiliation_one) { 'Colorado School of Public Health' }
+    let(:mapped_affiliation_one) { [] }
+    let(:expected_other_affiliation) { 'Colorado School of Public Health' }
+    let(:updated_person_hash) do
+      {
+        'index' => [1],
+        'name' => ['creator_1'],
+        'orcid' => [],
+        'affiliation' => [],
+        'other_affiliation' => [expected_other_affiliation]
+      }
+    end
+
+    before do
+      ActiveFedora::Cleaner.clean!
+      Blacklight.default_index.connection.delete_by_query('*:*')
+      Blacklight.default_index.connection.commit
+      article
+    end
+
+    it 'moves non-UNC affiliations to "other_affiliation"' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      original_person_hash = first_creator.attributes
+      expect(service.map_person_attributes(original_person_hash)).to eq(updated_person_hash)
+    end
+
+    it 'can update the creator affiliations' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq([unmappable_affiliation_one])
+      expect(first_creator.attributes['other_affiliation']).to eq([])
+      service.update_affiliations(obj)
+      obj.reload
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq(mapped_affiliation_one)
+      expect(first_creator.attributes['other_affiliation']).to eq([unmappable_affiliation_one])
+    end
+  end
+
+  context 'with multiple affiliations' do
+    let(:unmappable_affiliation_one) { 'Departmentrof Chemistry and Neuroscience Center University of North Carolina at Chapel Hill Chapel Hill, NC 27599-3290' }
+    let(:mapped_affiliation_one) { ['UNC Neuroscience Center', 'Department of Chemistry'] }
+
+    it 'can map from an unmappable affiliation to a mappable affiliation' do
+      expect(service.map_to_new_affiliation(unmappable_affiliation_one)).to eq(mapped_affiliation_one)
+    end
+
+    context 'with an article' do
+      before do
+        ActiveFedora::Cleaner.clean!
+        Blacklight.default_index.connection.delete_by_query('*:*')
+        Blacklight.default_index.connection.commit
+        article
+      end
+
+      it 'can update the creator affiliations' do
+        first_creator = obj.creators.find { |person| person['index'] == [1] }
+        expect(first_creator.attributes['affiliation']).to eq([unmappable_affiliation_one])
+        service.update_affiliations(obj)
+        obj.reload
+        first_creator = obj.creators.find { |person| person['index'] == [1] }
+        expect(first_creator.attributes['affiliation']).to eq(mapped_affiliation_one)
+      end
     end
   end
 
@@ -158,7 +198,7 @@ RSpec.describe AffiliationRemediationService do
     end
   end
 
-  context 'with a general work with a mix of people objects' do
+  context 'with a general work with a different type of people object' do
     let(:obj) { service.object_by_id(work_with_people.id) }
     let(:updated_translator_1_hash) do
       {

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -156,7 +156,6 @@ RSpec.describe AffiliationRemediationService do
 
   context 'with an affiliation that needs to be moved to "other_affiliation"' do
     let(:uncontrolled_affiliation_one) { 'Colorado School of Public Health' }
-    let(:mapped_affiliation_one) { [] }
     let(:updated_person_hash) do
       {
         'index' => [1],

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -1,0 +1,186 @@
+require 'rails_helper'
+require 'active_fedora/cleaner'
+
+RSpec.describe AffiliationRemediationService do
+  let(:service) { described_class.new(unmappable_affiliations_path) }
+  let(:unmappable_affiliations_path) { File.join(fixture_path, 'files', 'short_unmappable_affiliations.csv') }
+  let(:unmappable_affiliation_one) { 'University of North Carolina at Chapel Hill. Library' }
+  let(:mapped_affiliation_one) { 'University of North Carolina at Chapel Hill. University Libraries' }
+  let(:unmappable_affiliation_two) { 'Department of Economics and Curriculum for the Environment and Ecology; University of North Carolina at Chapel Hill' }
+  let(:mapped_affiliation_two) { 'Department of Economics' }
+  let(:updated_person_hash) do
+    {
+      'index' => [1],
+      'name' => ['creator_1'],
+      'orcid' => [],
+      'affiliation' => ['University of North Carolina at Chapel Hill. University Libraries'],
+      'other_affiliation' => []
+    }
+  end
+  let(:obj) { service.object_by_id(article.id) }
+  let(:article_identifier) { '76537342x' }
+  let(:article) do
+    FactoryBot.create(
+      :article,
+      id: article_identifier,
+      creators_attributes: { '0' => { name: 'creator_1',
+                                      affiliation: unmappable_affiliation_one,
+                                      index: 1 },
+                             '1' => { name: 'creator_2',
+                                      affiliation: unmappable_affiliation_two,
+                                      index: 2 } }
+    )
+  end
+  let(:work_with_people) do
+    General.create(title: ['New General Work with people'],
+                   'translators_attributes'.to_sym => { '0' => { name: 'translator_1',
+                                                                 affiliation: 'Carolina Center for Genome Sciences',
+                                                                 index: 1 },
+                                                        '1' => { name: 'translator_2',
+                                                                 affiliation: 'Department of Chemistry',
+                                                                 index: 2 },
+                                                        '2' => { name: 'translator_3',
+                                                                 affiliation: 'Unmappable affiliation 1',
+                                                                 index: 3 },
+                                                        '3' => { name: 'translator_4',
+                                                                 affiliation: 'Unmappable affiliation 2',
+                                                                 index: 4 } })
+  end
+
+  before do
+    allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { false }
+  end
+
+  it 'can be instantiated' do
+    expect(described_class.new(unmappable_affiliations_path)).to be
+  end
+
+  it 'has a list of target ids' do
+    expect(service.id_list).to be_a_kind_of(Array)
+    expect(service.id_list.first).to be_a_kind_of(String)
+  end
+
+  it 'can map from an unmappable affiliation to a mappable affiliation' do
+    expect(service.map_to_new_affiliation(unmappable_affiliation_one)).to eq(mapped_affiliation_one)
+    expect(service.map_to_new_affiliation(unmappable_affiliation_two)).to eq(mapped_affiliation_two)
+  end
+
+  it 'can determine if an affiliation is unmappable' do
+    expect(service.mappable_affiliation?(unmappable_affiliation_one)).to eq false
+    expect(service.mappable_affiliation?(mapped_affiliation_one)).to eq true
+  end
+
+  context 'with an article and general work' do
+    before do
+      ActiveFedora::Cleaner.clean!
+      Blacklight.default_index.connection.delete_by_query('*:*')
+      Blacklight.default_index.connection.commit
+      article
+      work_with_people
+    end
+
+    it 'has a wrapper method' do
+      expect do
+        service.remediate_all_affiliations
+        obj.reload
+      end.to(change { obj.creators })
+    end
+  end
+
+  context 'with an example Article' do
+    let(:obj) { service.object_by_id(article.id) }
+
+    before do
+      ActiveFedora::Cleaner.clean!
+      Blacklight.default_index.connection.delete_by_query('*:*')
+      Blacklight.default_index.connection.commit
+      article
+    end
+
+    it 'can find the object associated with an id on the list' do
+      expect(obj).to be_a_kind_of(Article)
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq([unmappable_affiliation_one])
+    end
+
+    it 'limits calls to the DepartmentService' do
+      allow(DepartmentsService).to receive(:label)
+      service.update_affiliations(obj)
+      expect(DepartmentsService).to have_received(:label).with(unmappable_affiliation_one).once
+    end
+
+    it 'can update the creator affiliations' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq([unmappable_affiliation_one])
+      service.update_affiliations(obj)
+      obj.reload
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      expect(first_creator.attributes['affiliation']).to eq([mapped_affiliation_one])
+    end
+
+    it 'can create a new person hash based on original person attributes' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      original_person_hash = first_creator.attributes
+      expect(service.map_person_attributes(original_person_hash)).to eq(updated_person_hash)
+    end
+
+    it 'keeps the original number of creators' do
+      expect(obj.creators.count).to eq 2
+      service.update_affiliations(obj)
+      obj.reload
+      expect(obj.creators.count).to eq 2
+    end
+  end
+
+  context 'with a general work with a mix of people objects' do
+    let(:obj) { service.object_by_id(work_with_people.id) }
+    let(:updated_translator_1_hash) do
+      {
+        'index' => [1],
+        'name' => ['translator_1'],
+        'orcid' => [],
+        'affiliation' => ['Carolina Center for Genome Sciences'],
+        'other_affiliation' => []
+      }
+    end
+    let(:updated_translator_3_hash) do
+      {
+        'index' => [3],
+        'name' => ['translator_3'],
+        'orcid' => [],
+        'affiliation' => [],
+        'other_affiliation' => []
+      }
+    end
+
+    before do
+      ActiveFedora::Cleaner.clean!
+      Blacklight.default_index.connection.delete_by_query('*:*')
+      Blacklight.default_index.connection.commit
+      work_with_people
+    end
+
+    it 'can update the translator affiliations' do
+      first_translator = obj.translators.find { |person| person['index'] == [1] }
+      expect(obj.translators.count).to eq 4
+      expect(first_translator.attributes['affiliation']).to eq(['Carolina Center for Genome Sciences'])
+      service.update_affiliations(obj)
+      obj.reload
+      first_translator = obj.translators.find { |person| person['index'] == [1] }
+      expect(obj.translators.count).to eq 4
+      expect(first_translator.attributes['affiliation']).to eq(['Carolina Center for Genome Sciences'])
+    end
+
+    it 'does not map affiliations that are still unmappable' do
+      third_translator = obj.translators.find { |person| person['index'] == [3] }
+      original_person_hash = third_translator.attributes
+      expect(service.map_person_attributes(original_person_hash)).to eq(updated_translator_3_hash)
+    end
+
+    it 'keeps the original affiliation if it is mappable' do
+      first_translator = obj.translators.find { |person| person['index'] == [1] }
+      original_person_hash = first_translator.attributes
+      expect(service.map_person_attributes(original_person_hash)).to eq(updated_translator_1_hash)
+    end
+  end
+end

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe AffiliationRemediationService do
   end
 
   context 'with an affiliation that needs to be moved to "other_affiliation"' do
-    let(:unmappable_affiliation_one) { 'Colorado School of Public Health' }
+    let(:uncontrolled_affiliation_one) { 'Colorado School of Public Health' }
     let(:mapped_affiliation_one) { [] }
     let(:updated_person_hash) do
       {
@@ -163,7 +163,7 @@ RSpec.describe AffiliationRemediationService do
         'name' => ['creator_1'],
         'orcid' => [],
         'affiliation' => [],
-        'other_affiliation' => [unmappable_affiliation_one]
+        'other_affiliation' => [uncontrolled_affiliation_one]
       }
     end
 

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -70,6 +70,25 @@ RSpec.describe AffiliationRemediationService do
     expect(service.mappable_affiliation?(mapped_affiliation_one)).to eq true
   end
 
+  context 'with an empty string as the old affiliation' do
+    let(:unmappable_affiliation_one) { '' }
+    let(:updated_person_hash) do
+      {
+        'index' => [1],
+        'name' => ['creator_1'],
+        'orcid' => [],
+        'affiliation' => [],
+        'other_affiliation' => []
+      }
+    end
+
+    it 'maps the empty string to an empty array' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      original_person_hash = first_creator.attributes
+      expect(service.map_person_attributes(original_person_hash)).to eq(updated_person_hash)
+    end
+  end
+
   context 'with an article and general work' do
     before do
       ActiveFedora::Cleaner.clean!
@@ -90,14 +109,13 @@ RSpec.describe AffiliationRemediationService do
   context 'with an affiliation that needs to be moved to "other_affiliation"' do
     let(:unmappable_affiliation_one) { 'Colorado School of Public Health' }
     let(:mapped_affiliation_one) { [] }
-    let(:expected_other_affiliation) { 'Colorado School of Public Health' }
     let(:updated_person_hash) do
       {
         'index' => [1],
         'name' => ['creator_1'],
         'orcid' => [],
         'affiliation' => [],
-        'other_affiliation' => [expected_other_affiliation]
+        'other_affiliation' => [unmappable_affiliation_one]
       }
     end
 

--- a/spec/services/affiliation_remediation_service_spec.rb
+++ b/spec/services/affiliation_remediation_service_spec.rb
@@ -89,6 +89,38 @@ RSpec.describe AffiliationRemediationService do
     end
   end
 
+  context 'with one affiliation that needs to be mapped and one empty one' do
+    let(:article) do
+      FactoryBot.create(
+        :article,
+        id: article_identifier,
+        creators_attributes: { '0' => { name: 'creator_1',
+                                        affiliation: unmappable_affiliation_one,
+                                        index: 1 },
+                               '1' => { name: 'creator_2',
+                                        index: 2 } }
+      )
+    end
+    let(:updated_second_creator_hash) do
+      {
+        'index' => [2],
+        'name' => ['creator_2'],
+        'orcid' => [],
+        'affiliation' => [],
+        'other_affiliation' => []
+      }
+    end
+
+    it 'maps the attributes for both creators' do
+      first_creator = obj.creators.find { |person| person['index'] == [1] }
+      original_first_creator_hash = first_creator.attributes
+      expect(service.map_person_attributes(original_first_creator_hash)).to eq(updated_person_hash)
+      second_creator = obj.creators.find { |person| person['index'] == [2] }
+      original_second_creator_hash = second_creator.attributes
+      expect(service.map_person_attributes(original_second_creator_hash)).to eq(updated_second_creator_hash)
+    end
+  end
+
   context 'with an article and general work' do
     before do
       ActiveFedora::Cleaner.clean!


### PR DESCRIPTION
Each environment should have a list of affiliations. The mapping list is not unique to each environment (we only did it for production), but I think testing the job on the other environments will be enough to see if it's working.