### PR TITLE
HYC-1441 - Increase timeout for video derivative generation

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -300,7 +300,7 @@ Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 
 # Set timeout for creating video derivatives. Otherwise the process sometimes silently fails.
-Hydra::Derivatives::Processors::Video::Processor.timeout = 20.minutes
+Hydra::Derivatives::Processors::Video::Processor.timeout = 30.minutes
 Hydra::Derivatives::Processors::Document.timeout = 5.minutes
 Hydra::Derivatives::Processors::Audio.timeout = 10.minutes
 Hydra::Derivatives::Processors::Image.timeout = 5.minutes

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -300,7 +300,7 @@ Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 
 # Set timeout for creating video derivatives. Otherwise the process sometimes silently fails.
-Hydra::Derivatives::Processors::Video::Processor.timeout = 10.minutes
+Hydra::Derivatives::Processors::Video::Processor.timeout = 20.minutes
 Hydra::Derivatives::Processors::Document.timeout = 5.minutes
 Hydra::Derivatives::Processors::Audio.timeout = 10.minutes
 Hydra::Derivatives::Processors::Image.timeout = 5.minutes


### PR DESCRIPTION
Relates to https://jira.lib.unc.edu/browse/HYC-1441
When uploading a large video file was timing out during derivative generation, which is not the cause of the original issue, but impacts the same object when the mp4 file is uploaded instead of the m4a file.