### PR TITLE
HYC-1404 - Fix advanced search returning everything or nothing

### DIFF
--- a/app/search_builders/range_limit_catalog_search_builder.rb
+++ b/app/search_builders/range_limit_catalog_search_builder.rb
@@ -11,7 +11,7 @@ class RangeLimitCatalogSearchBuilder < Hyrax::CatalogSearchBuilder
   # This should always be the last processor in this processor chain.
   # Adds full text searching for :all_fields
   def join_works_from_files(solr_parameters)
-    return unless blacklight_params[:all_fields]
+    return if blacklight_params[:all_fields].nil? || blacklight_params[:all_fields].empty?
 
     if solr_parameters[:q].present?
       solr_parameters[:q] += all_fields_query

--- a/app/search_builders/range_limit_catalog_search_builder.rb
+++ b/app/search_builders/range_limit_catalog_search_builder.rb
@@ -11,7 +11,7 @@ class RangeLimitCatalogSearchBuilder < Hyrax::CatalogSearchBuilder
   # This should always be the last processor in this processor chain.
   # Adds full text searching for :all_fields
   def join_works_from_files(solr_parameters)
-    return if blacklight_params[:all_fields].nil? || blacklight_params[:all_fields].empty?
+    return if blacklight_params[:all_fields].blank?
 
     if solr_parameters[:q].present?
       solr_parameters[:q] += all_fields_query


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1404

Fix bug that was adding an empty search to advanced searches whenever all_fields was unpopulated, which was causing searches for specific fields to match everything, and causing filters by facets to return no results when no search terms were provided