### PR TITLE
HYC-1262 - Additional error handling for reindex

### DIFF
--- a/spec/services/tasks/solr_migration_service_spec.rb
+++ b/spec/services/tasks/solr_migration_service_spec.rb
@@ -138,13 +138,12 @@ RSpec.describe Tasks::SolrMigrationService do
     end
 
     it 'Index with invalid id is skipped' do
-      # Sort by created time in order to delete a consistent object across runs
       initial_records = ActiveFedora::SolrService.get('*:*', rows: 100, sort: 'id ASC')
       expect(initial_records['response']['numFound']).to eq 7
 
       list_path = service.list_object_ids(output_dir, nil)
 
-      # Delete an object from fedora
+      # Selecting the HonorsThesis work to ensure a consistent object gets deleted across runs
       target_records = ActiveFedora::SolrService.get('has_model_ssim:HonorsThesis', rows: 1, sort: 'id ASC')
       ActiveFedora::Base.find(target_records['response']['docs'][0]['id']).delete
 

--- a/spec/services/tasks/solr_migration_service_spec.rb
+++ b/spec/services/tasks/solr_migration_service_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'active_fedora/base'
+require 'fileutils'
 
 RSpec.describe Tasks::SolrMigrationService do
   let(:service) { described_class.new }
@@ -149,6 +150,17 @@ RSpec.describe Tasks::SolrMigrationService do
       service.reindex(list_path, true)
       reindexed_records = ActiveFedora::SolrService.get('*:*', rows: 100, sort: 'id ASC')
       expect(reindexed_records['response']['numFound']).to eq 6
+    end
+
+    it 'Index with invalid input file' do
+      list_path = service.list_object_ids(output_dir, nil)
+      # Delete the list file so that it won't be found when running reindexng
+      FileUtils.rm(list_path)
+
+      allow(Rails.logger).to receive(:error)
+      service.reindex(list_path, false)
+
+      expect(Rails.logger).to have_received(:error).with('Execution interrupted by unexpected error')
     end
 
     def expect_results_match(results1, results2)

--- a/spec/services/tasks/solr_migration_service_spec.rb
+++ b/spec/services/tasks/solr_migration_service_spec.rb
@@ -138,13 +138,15 @@ RSpec.describe Tasks::SolrMigrationService do
     end
 
     it 'Index with invalid id is skipped' do
+      # Sort by created time in order to delete a consistent object across runs
       initial_records = ActiveFedora::SolrService.get('*:*', rows: 100, sort: 'id ASC')
       expect(initial_records['response']['numFound']).to eq 7
 
       list_path = service.list_object_ids(output_dir, nil)
 
       # Delete an object from fedora
-      ActiveFedora::Base.find(initial_records['response']['docs'][4]['id']).delete
+      target_records = ActiveFedora::SolrService.get('has_model_ssim:HonorsThesis', rows: 1, sort: 'id ASC')
+      ActiveFedora::Base.find(target_records['response']['docs'][0]['id']).delete
 
       # Using a clean reindex to reset the index before repopulation
       service.reindex(list_path, true)


### PR DESCRIPTION
Part of https://jira.lib.unc.edu/browse/HYC-1262
Handle uncaught errors so they show up in the logs, and handle object not found