### PR TITLE
Change sync mode for mount-code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ volumes:
 x-mutagen:
   sync:
     defaults:
+      mode: "two-way-resolved"
       ignore:
         vcs: true
         paths:
@@ -115,7 +116,6 @@ x-mutagen:
     mount-code:
       alpha: '.'
       beta: "volume://mount-code"
-      mode: "two-way-resolved"
       configurationBeta:
         permissions:
           defaultFileMode: 0644

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,9 +110,12 @@ x-mutagen:
     defaults:
       ignore:
         vcs: true
+        paths:
+          - ".DS_Store"
     mount-code:
       alpha: '.'
       beta: "volume://mount-code"
+      mode: "two-way-resolved"
       configurationBeta:
         permissions:
           defaultFileMode: 0644


### PR DESCRIPTION
* Switch mount-code to using two-way-resolved sync mode, to prevent conflicts from stopping syncs of updated files in git from reaching the container