### PR TITLE
HYC-1490 - Test coverage/refactor for attach_files_to_work_job overrides

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -71,7 +71,10 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     return if scan_results.instance_of? ClamAV::SuccessResponse
 
     if scan_results.instance_of? ClamAV::VirusResponse
-      FileUtils.rm_rf(File.dirname(file_path))
+      File.delete(file_path)
+      # Delete the parent directory if it is empty
+      parent_dir = File.dirname(file_path)
+      Dir.rmdir(parent_dir) if Dir.empty?(parent_dir)
       raise VirusDetectedError.new(scan_results, file_path)
     end
   end

--- a/app/overrides/jobs/attach_files_to_work_job_override.rb
+++ b/app/overrides/jobs/attach_files_to_work_job_override.rb
@@ -30,7 +30,7 @@ Hyrax::AttachFilesToWorkJob.class_eval do
 
   # [hyc-override] add virus checking method
   def virus_check!(uploaded_file)
-    file_path = URI.unescape(uploaded_file.file.to_s)
+    file_path = URI::Parser.new.unescape(uploaded_file.file.to_s)
     scan_results = Hyc::VirusScanner.hyc_infected?(file_path)
     return if scan_results.instance_of? ClamAV::SuccessResponse
 

--- a/app/overrides/jobs/attach_files_to_work_job_override.rb
+++ b/app/overrides/jobs/attach_files_to_work_job_override.rb
@@ -1,9 +1,6 @@
-# [hyc-override] add virus checking to job
-# Converts UploadedFiles into FileSets and attaches them to works.
-class AttachFilesToWorkJob < Hyrax::ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
-
-  # @param [ActiveFedora::Base] work - the work object
+# https://github.com/samvera/hyrax/blob/v2.9.6/app/jobs/attach_files_to_work_job.rb
+Hyrax::AttachFilesToWorkJob.class_eval do
+   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
   def perform(work, uploaded_files, **work_attributes)
     validate_files!(uploaded_files)
@@ -40,29 +37,6 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
   end
 
   private
-
-  # The attributes used for visibility - sent as initial params to created FileSets.
-  def visibility_attributes(attributes)
-    attributes.slice(:visibility, :visibility_during_lease,
-                     :visibility_after_lease, :lease_expiration_date,
-                     :embargo_release_date, :visibility_during_embargo,
-                     :visibility_after_embargo)
-  end
-
-  def validate_files!(uploaded_files)
-    uploaded_files.each do |uploaded_file|
-      next if uploaded_file.is_a? Hyrax::UploadedFile
-
-      raise ArgumentError, "Hyrax::UploadedFile required, but #{uploaded_file.class} received: #{uploaded_file.inspect}"
-    end
-  end
-
-  ##
-  # A work with files attached by a proxy user will set the depositor as the intended user
-  # that the proxy was depositing on behalf of. See tickets #2764, #2902.
-  def proxy_or_depositor(work)
-    work.on_behalf_of.blank? ? work.depositor : work.on_behalf_of
-  end
 
   # [hyc-override] add virus checking method
   def virus_check!(uploaded_file)

--- a/app/overrides/jobs/attach_files_to_work_job_override.rb
+++ b/app/overrides/jobs/attach_files_to_work_job_override.rb
@@ -35,10 +35,14 @@ Hyrax::AttachFilesToWorkJob.class_eval do
     return if scan_results.instance_of? ClamAV::SuccessResponse
 
     if scan_results.instance_of? ClamAV::VirusResponse
-      File.delete(file_path)
-      # Delete the parent directory if it is empty
-      parent_dir = File.dirname(file_path)
-      Dir.rmdir(parent_dir) if Dir.empty?(parent_dir)
+      begin
+        File.delete(file_path)
+        # Delete the parent directory if it is empty
+        parent_dir = File.dirname(file_path)
+        Dir.rmdir(parent_dir) if Dir.empty?(parent_dir)
+      rescue StandardError => e
+        Rails.logger.warn("Failed to delete infected file #{file_path}: #{e.message}")
+      end
       raise VirusDetectedError.new(scan_results, file_path)
     end
   end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe AttachFilesToWorkJob, type: :job do
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:role) { Role.new(name: 'admin') }
+  let(:work) { 
+    Article.create(title: ['New Article'],
+      depositor: user.user_key) 
+  }
+  let(:file_set) { FactoryBot.create(:file_set, title: ['test file set']) }
+  let(:file_set_actor) { Hyrax::Actors::FileSetActor.new(file_set, user) }
+  let(:admin_set) { AdminSet.create(title: ['an admin set']) }
+  let(:permission_template) { Hyrax::PermissionTemplate.create(source_id: admin_set.id) }
+  let(:workflow) { Sipity::Workflow.create(name: 'a workflow', permission_template_id: permission_template.id, active: true) }
+  let(:entity) { Sipity::Entity.create(workflow_id: workflow.id, proxy_for_global_id: work.to_global_id.to_s) }
+  let(:target_dir) { Dir.mktmpdir }
+  let(:target_file) { Tempfile.new('file.txt', target_dir).path }
+  let(:uploaded_file) { Hyrax::UploadedFile.new(user: user, file: File.new(target_file)) }
+
+  before do
+    file_set_actor.attach_to_work(work)
+    role.users << admin
+    role.save
+  end
+
+  after do
+    FileUtils.rm_rf(target_dir)
+  end
+
+  context 'with file containing virus' do
+    before do
+      expect(Hyc::VirusScanner).to receive(:hyc_infected?).and_return(ClamAV::VirusResponse.new(target_file, 'avirus'))
+      expect(Hyrax::Workflow::VirusFoundNotification).to receive(:send_notification)
+          .with(entity: entity, recipients: anything, comment: anything, user: user)
+    end
+
+    it 'sends virus email message' do
+      subject.perform(work, [uploaded_file])
+    end
+  end
+
+  context 'with safe file' do
+    before do
+      expect(Hyc::VirusScanner).to receive(:hyc_infected?).and_return(ClamAV::SuccessResponse.new(target_file))
+    end
+
+    it 'succeeds without any reporting' do
+      subject.perform(work, [uploaded_file])
+    end
+  end
+end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe AttachFilesToWorkJob, type: :job do
   let(:user) { FactoryBot.create(:user) }
   let(:admin) { FactoryBot.create(:admin) }
   let(:role) { Role.new(name: 'admin') }
-  let(:work) { 
+  let(:work) {
     Article.create(title: ['New Article'],
-      depositor: user.user_key) 
+      depositor: user.user_key)
   }
   let(:file_set) { FactoryBot.create(:file_set, title: ['test file set']) }
   let(:file_set_actor) { Hyrax::Actors::FileSetActor.new(file_set, user) }
@@ -39,6 +39,16 @@ RSpec.describe AttachFilesToWorkJob, type: :job do
     it 'sends virus email message' do
       subject.perform(work, [uploaded_file])
       expect(File).not_to exist(target_file)
+    end
+
+    context 'that cannot be deleted' do
+      before do
+        allow(File).to receive(:delete).and_raise(Errno::EACCES)
+      end
+
+      it 'still sends virus email message' do
+        subject.perform(work, [uploaded_file])
+      end
     end
   end
 

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe AttachFilesToWorkJob, type: :job do
       # Original method should not be called
       allow(subject).to receive(:original_perform).and_raise('nope')
       allow(Hyc::VirusScanner).to receive(:hyc_infected?).and_return(ClamAV::VirusResponse.new(target_file, 'avirus'))
+      # Establish expectation for the following tests that a virus detection notification gets sent
       expect(Hyrax::Workflow::VirusFoundNotification).to receive(:send_notification)
           .with(entity: entity, recipients: anything, comment: anything, user: user)
     end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require Rails.root.join('app/overrides/jobs/attach_files_to_work_job_override.rb')
 
 RSpec.describe AttachFilesToWorkJob, type: :job do
   let(:user) { FactoryBot.create(:user) }

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe AttachFilesToWorkJob, type: :job do
 
     it 'sends virus email message' do
       subject.perform(work, [uploaded_file])
+      expect(File).not_to exist(target_file)
     end
   end
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1490

* Add tests for overrides
* Change approach to override, removing non-overridden code, and wrapping the original method
* Change infected file behavior, so it now will only delete the pattern dir containing the file if its empty. Also, catch any errors that occur during deletion so email always gets sent.