### PR TITLE
HYC-1558 - Update SolrMigartionService to work with hyrax 3

### DIFF
--- a/app/services/tasks/solr_migration_service.rb
+++ b/app/services/tasks/solr_migration_service.rb
@@ -8,10 +8,11 @@ module Tasks
   # Service for reindexing objects from one solr instance to another
   class SolrMigrationService
     PAGE_SIZE = 1000
+    ADMIN_TYPES = 'has_model_ssim:AdminSet'.freeze
     AF_TYPES = 'has_model_ssim:ActiveFedora*'.freeze
     HYDRA_TYPES = 'has_model_ssim:Hydra*'.freeze
-    ALL_OTHER_TYPES = '-has_model_ssim:ActiveFedora* AND -has_model_ssim:Hydra*'.freeze
-    BASE_QUERIES = [AF_TYPES, HYDRA_TYPES, ALL_OTHER_TYPES].freeze
+    ALL_OTHER_TYPES = '-has_model_ssim:AdminSet AND -has_model_ssim:ActiveFedora* AND -has_model_ssim:Hydra*'.freeze
+    BASE_QUERIES = [AF_TYPES, HYDRA_TYPES, ADMIN_TYPES, ALL_OTHER_TYPES].freeze
 
     # List all object ids in the repository, ordered by object type.
     # Returns the path to the file containing the list of ids. Its name contains the timestamp when the command was issued.

--- a/spec/services/tasks/solr_migration_service_spec.rb
+++ b/spec/services/tasks/solr_migration_service_spec.rb
@@ -177,12 +177,6 @@ RSpec.describe Tasks::SolrMigrationService do
         record2 = docs2[index]
         record1.each do |key, value|
           next if ['timestamp', '_version_'].include?(key)
-
-          if value != record2[key]
-            puts "Mismatch"
-            puts "Rec1:\n#{record1}"
-            puts "Rec2:\n#{record2}"
-          end
           expect(value).to eq(record2[key]), "Expected #{key} to have value #{value} but was #{record2[key]}"
         end
         expect(record1.length).to eq record2.length


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1558

* Update counts in solrmigration spec to take into account new embargo and lease objects
* Adjust indexing order to place adminsets before works/filesets, without doing so tests were flapping with regards to the admin_set_tesim field
* Some rubocop fixes