### PR TITLE
HYC-1565 - Update Google Scholar for hyrax 3

### DIFF
--- a/app/overrides/presenters/hyrax/google_scholar_presenter_override.rb
+++ b/app/overrides/presenters/hyrax/google_scholar_presenter_override.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/blob/v3.4.2/app/presenters/hyrax/google_scholar_presenter.rb
+Hyrax::GoogleScholarPresenter.class_eval do
+  # [hyc-override] include helper for sorting creators
+  include HycHelper
+
+  # [hyc-override] use person objects for authors
+  def authors
+    return if object.creator_display.blank?
+
+    sort_people_by_index(object.creator_display)
+        .map { |creator| creator.split('||').second }
+  end
+
+  # [hyc-override] use date issued instead of created
+  def publication_date
+    Array(object.try(:date_issued)).first || ''
+  end
+
+  # [hyc-override] Additional journal fields not currently populated by hyrax
+  ##
+  # @return [String] a string representing the journal title
+  def journal_title
+    Array(object.try(:journal_title)).first || ''
+  end
+
+  ##
+  # @return [String] a string representing the journal volume
+  def volume
+    Array(object.try(:journal_volume)).first || ''
+  end
+
+  ##
+  # @return [String] a string representing the journal issue
+  def issue
+    Array(object.try(:journal_issue)).first || ''
+  end
+
+  ##
+  # @return [String] a string representing the first page
+  def firstpage
+    Array(object.try(:page_start)).first || ''
+  end
+
+  ##
+  # @return [String] a string representing the last page
+  def lastpage
+    Array(object.try(:page_end)).first || ''
+  end
+end

--- a/app/overrides/presenters/hyrax/work_show_presenter_override.rb
+++ b/app/overrides/presenters/hyrax/work_show_presenter_override.rb
@@ -7,4 +7,10 @@ Hyrax::WorkShowPresenter.class_eval do
            :creator_display, :contributor, :subject, :publisher, :language, :embargo_release_date,
            :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
            :rendering_ids, :member_of_collection_ids, :alternative_title, to: :solr_document
+
+  # Indicates if the work is considered scholarly according to google scholar
+  # This method is not defined in hyrax, but it is referenced by GoogleScholarPresenter
+  def scholarly?
+    false
+  end
 end

--- a/app/presenters/hyrax/article_presenter.rb
+++ b/app/presenters/hyrax/article_presenter.rb
@@ -8,5 +8,10 @@ module Hyrax
              :issn, :journal_issue, :journal_title, :journal_volume, :language_label,
              :license_label, :note, :page_end, :page_start, :peer_review_status, :place_of_publication, :rights_holder,
              :rights_statement_label, :translator_display, :use, to: :solr_document
+
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/data_set_presenter.rb
+++ b/app/presenters/hyrax/data_set_presenter.rb
@@ -7,5 +7,10 @@ module Hyrax
              :extent, :funder, :kind_of_data, :last_modified_date, :language_label,
              :license_label, :methodology, :note, :orcid_label, :other_affiliation_label, :project_director_display, :researcher_display,
              :rights_holder, :rights_statement_label, :sponsor, to: :solr_document
+
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/dissertation_presenter.rb
+++ b/app/presenters/hyrax/dissertation_presenter.rb
@@ -7,5 +7,10 @@ module Hyrax
              :creator_display, :date_issued, :dcmi_type, :degree, :degree_granting_institution, :deposit_record, :doi,
              :graduation_year, :language_label, :license_label, :note, :place_of_publication,
              :resource_type, :reviewer_display, :rights_statement_label, :use, to: :solr_document
+
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/general_presenter.rb
+++ b/app/presenters/hyrax/general_presenter.rb
@@ -12,5 +12,10 @@ module Hyrax
              :note, :page_start, :page_end, :peer_review_status, :place_of_publication,
              :project_director_display, :researcher_display, :reviewer_display, :rights_holder, :rights_statement_label,
              :series, :sponsor, :table_of_contents, :translator_display, :url, :use, to: :solr_document
+    
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/honors_thesis_presenter.rb
+++ b/app/presenters/hyrax/honors_thesis_presenter.rb
@@ -7,5 +7,10 @@ module Hyrax
              :creator_display, :date_issued, :dcmi_type, :degree, :degree_granting_institution, :deposit_record, :doi,
              :extent, :graduation_year, :language_label, :license_label, :note,
              :rights_statement_label, :url, :use, to: :solr_document
+    
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/journal_presenter.rb
+++ b/app/presenters/hyrax/journal_presenter.rb
@@ -6,5 +6,10 @@ module Hyrax
     delegate :abstract, :admin_note, :alternative_title, :creator_display, :date_issued, :dcmi_type, :deposit_record, :digital_collection,
              :doi, :edition, :extent, :isbn, :issn, :language_label, :license_label, :note, :place_of_publication,
              :rights_statement_label, :series, to: :solr_document
+    
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/masters_paper_presenter.rb
+++ b/app/presenters/hyrax/masters_paper_presenter.rb
@@ -7,5 +7,10 @@ module Hyrax
              :degree, :degree_granting_institution, :deposit_record, :doi, :extent,
              :graduation_year, :language_label, :license_label, :note, :reviewer_display, :rights_statement_label, :use,
              to: :solr_document
+    
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/scholarly_work_presenter.rb
+++ b/app/presenters/hyrax/scholarly_work_presenter.rb
@@ -5,5 +5,10 @@ module Hyrax
   class ScholarlyWorkPresenter < Hyrax::WorkShowPresenter
     delegate :abstract, :admin_note, :advisor_display, :conference_name, :creator_display, :date_issued, :dcmi_type, :deposit_record,
              :digital_collection, :doi, :language_label, :license_label, :note, :rights_statement_label, to: :solr_document
+    
+    # See: WorkShowPresenter.scholarly?
+    def scholarly?
+      true
+    end
   end
 end

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -1,4 +1,4 @@
-<!--[hyc-override] Updating meta tags for google scholar-->
+<%# [hyc-override] Updating meta tags for google scholar %>
 <% content_for(:twitter_meta) do %>
   <meta name="twitter:card" content="product" />
   <meta name="twitter:site" content="<%= t('hyrax.product_twitter_handle') %>" />
@@ -15,35 +15,53 @@
   <meta name="twitter:label2" content="Rights Statement" />
 <% end %>
 
+<% gscholar = Hyrax::GoogleScholarPresenter.new(@presenter) %>
+
+<% if gscholar.scholarly? %>
 <% content_for(:gscholar_meta) do %>
-  <meta name="citation_title" content="<%= Array.wrap(@presenter.title).first %>" />
-  <% if !@presenter.creator_display.blank? %>
-    <%# conditional can be removed once all people objects have indexes %>
-    <% if @presenter.creator_display.first.match('index:') %>
-      <% sort_people_by_index(@presenter.creator_display).each do |creator| %>
-        <meta name="citation_author" content="<%= creator.split('||').second %>" />
-      <% end %>
-    <% else %>
-      <% Array.wrap(@presenter.creator_display).each do |creator| %>
-        <meta name="citation_author" content="<%= creator.split('||').first %>" />
-      <% end %>
-    <% end %>
+  <meta name="description" content="<%= gscholar.description %>" />
+  <meta name="citation_title" content="<%= gscholar.title %>" />
+
+  <% gscholar.authors.each do |author| %>
+  <meta name="citation_author" content="<%= author %>" />
   <% end %>
-  <meta name="citation_publication_date" content="<%= Array.wrap(@presenter.date_issued).first %>" />
-  <meta name="citation_pdf_url" content="<%= @presenter.download_url %>" />
-  <% if @presenter.respond_to?(:journal_title) %>
-  <meta name="citation_journal_title" content="<%= Array.wrap(@presenter.journal_title).first %>"/>
+
+  <% if gscholar.publication_date.present? %>
+  <meta name="citation_publication_date" content="<%= gscholar.publication_date %>" />
   <% end %>
-  <% if @presenter.respond_to?(:journal_volume) %>
-  <meta name="citation_volume" content="<%= Array.wrap(@presenter.journal_volume).first %>"/>
+
+  <% if gscholar.pdf_url.present? %>
+  <meta name="citation_pdf_url" content="<%= gscholar.pdf_url %>" />
   <% end %>
-  <% if @presenter.respond_to?(:journal_issue) %>
-  <meta name="citation_issue" content="<%= Array.wrap(@presenter.journal_issue).first %>"/>
+
+  <% if gscholar.keywords.present? %>
+  <meta name="citation_keywords" content="<%= gscholar.keywords %>" />
   <% end %>
-  <% if @presenter.respond_to?(:page_start) %>
-  <meta name="citation_firstpage" content="<%= Array.wrap(@presenter.page_start).first %>"/>
+
+  <% if gscholar.publisher.present? %>
+  <meta name="citation_publisher" content="<%= gscholar.publisher %>" />
   <% end %>
-  <% if @presenter.respond_to?(:page_end) %>
-  <meta name="citation_lastpage" content="<%= Array.wrap(@presenter.page_end).first %>"/>
+
+  <%# [hyc-override] Additional metadata fields %>
+  <% if gscholar.journal_title.present? %>
+  <meta name="citation_journal_title" content="<%= gscholar.journal_title %>" />
   <% end %>
+
+  <% if gscholar.volume.present? %>
+  <meta name="citation_volume" content="<%= gscholar.volume %>" />
+  <% end %>
+
+  <% if gscholar.issue.present? %>
+  <meta name="citation_issue" content="<%= gscholar.issue %>" />
+  <% end %>
+
+  <% if gscholar.firstpage.present? %>
+  <meta name="citation_firstpage" content="<%= gscholar.firstpage %>" />
+  <% end %>
+
+  <% if gscholar.lastpage.present? %>
+  <meta name="citation_lastpage" content="<%= gscholar.lastpage %>" />
+  <% end %>
+  <%# [hyc-override] End additional metadata fields %>
+<% end %>
 <% end %>

--- a/spec/presenters/hyrax/article_presenter_spec.rb
+++ b/spec/presenters/hyrax/article_presenter_spec.rb
@@ -458,4 +458,10 @@ RSpec.describe Hyrax::ArticlePresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/artwork_presenter_spec.rb
+++ b/spec/presenters/hyrax/artwork_presenter_spec.rb
@@ -193,4 +193,10 @@ RSpec.describe Hyrax::ArtworkPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns false' do
+      expect(presenter.scholarly?).to be_falsey
+    end
+  end
 end

--- a/spec/presenters/hyrax/data_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/data_set_presenter_spec.rb
@@ -318,4 +318,10 @@ RSpec.describe Hyrax::DataSetPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/dissertation_presenter_spec.rb
+++ b/spec/presenters/hyrax/dissertation_presenter_spec.rb
@@ -353,4 +353,10 @@ RSpec.describe Hyrax::DissertationPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/general_presenter_spec.rb
+++ b/spec/presenters/hyrax/general_presenter_spec.rb
@@ -717,4 +717,10 @@ RSpec.describe Hyrax::GeneralPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/honors_thesis_presenter_spec.rb
+++ b/spec/presenters/hyrax/honors_thesis_presenter_spec.rb
@@ -313,4 +313,10 @@ RSpec.describe Hyrax::HonorsThesisPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/journal_presenter_spec.rb
+++ b/spec/presenters/hyrax/journal_presenter_spec.rb
@@ -291,4 +291,10 @@ RSpec.describe Hyrax::JournalPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/masters_paper_presenter_spec.rb
+++ b/spec/presenters/hyrax/masters_paper_presenter_spec.rb
@@ -326,4 +326,10 @@ RSpec.describe Hyrax::MastersPaperPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/presenters/hyrax/multimed_presenter_spec.rb
+++ b/spec/presenters/hyrax/multimed_presenter_spec.rb
@@ -233,4 +233,10 @@ RSpec.describe Hyrax::MultimedPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_falsey
+    end
+  end
 end

--- a/spec/presenters/hyrax/scholarly_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/scholarly_work_presenter_spec.rb
@@ -236,4 +236,10 @@ RSpec.describe Hyrax::ScholarlyWorkPresenter do
       end
     end
   end
+
+  describe '#scholar?' do
+    it 'returns true' do
+      expect(presenter.scholarly?).to be_truthy
+    end
+  end
 end

--- a/spec/views/shared/_citations.html.erb_spec.rb
+++ b/spec/views/shared/_citations.html.erb_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe 'shared/_citations.html.erb', type: :view do
+  let(:depositor) { FactoryBot.create(:user) }
+  let(:creator_display) { ['index:2||Bilbo Baggins', 'index:1||Baggins, Frodo'] }
+
+  let(:ability) { double }
+
+  describe 'google scholar' do
+    context 'with journal article' do
+      let(:work_solr_document) do
+        SolrDocument.new(
+          id: '999',
+          has_model_ssim: ['Article'],
+          human_readable_type_tesim: ['Article'],
+          creator_display_tesim: creator_display,
+          license_tesim: ['http://creativecommons.org/licenses/by/3.0/us/'],
+          title_tesim: ['Sail the Seven Hycs'],
+          date_issued_tesim: ['1970'],
+          doi_tesim: ['http://dx.doi.org/10.1186/1753-6561-3-S7-S87'],
+          journal_volume_tesim: ['55'],
+          journal_issue_tesim: ['10'],
+          page_start_tesim: ['99'],
+          page_end_tesim: ['106'],
+          keyword_tesim: ['bacon', 'sausage', 'eggs'],
+          publisher_tesim: ['French Press'],
+          description_tesim: ['Abstraction layer']
+        )
+      end
+
+      let(:presenter) do
+        Hyrax::ArticlePresenter.new(work_solr_document, ability)
+      end
+
+      before do
+        allow(view).to receive(:polymorphic_url)
+        assign(:presenter, presenter)
+        render
+      end
+
+      let(:gs_rendered) { Nokogiri::HTML(view.content_for(:gscholar_meta)) }
+
+      it 'appears in meta tags' do
+        gscholar_meta_tags = gs_rendered.xpath("//meta[contains(@name, 'citation_')]")
+        expect(gscholar_meta_tags.count).to eq(10)
+      end
+
+      it 'displays regular and journal meta data tags' do
+        tag = gs_rendered.xpath("//meta[@name='description']")
+        expect(tag.attribute('content').value).to eq('Abstraction layer')
+
+        tag = gs_rendered.xpath("//meta[@name='citation_title']")
+        expect(tag.attribute('content').value).to eq('Sail the Seven Hycs')
+
+        tags = gs_rendered.xpath("//meta[@name='citation_author']")
+        expect(tags.first.attribute('content').value).to eq('Baggins, Frodo')
+        expect(tags.last.attribute('content').value).to eq('Bilbo Baggins')
+
+        tag = gs_rendered.xpath("//meta[@name='citation_publication_date']")
+        expect(tag.attribute('content').value).to eq('1970')
+
+        tag = gs_rendered.xpath("//meta[@name='citation_pdf_url']")
+        expect(tag).to be_blank
+
+        tag = gs_rendered.xpath("//meta[@name='citation_keywords']")
+        expect(tag.attribute('content').value).to eq('bacon; sausage; eggs')
+
+        tag = gs_rendered.xpath("//meta[@name='citation_publisher']")
+        expect(tag.attribute('content').value).to eq('French Press')
+      end
+    end
+
+    context 'with multimedia (non-scholarly)' do
+      let(:work_solr_document) do
+        SolrDocument.new(
+          id: '999',
+          has_model_ssim: ['Multimed'],
+          human_readable_type_tesim: ['Multimed'],
+          creator_display_tesim: creator_display,
+          title_tesim: ['Sail the Seven Hycs'],
+          date_issued_tesim: ['1970'],
+          keyword_tesim: ['bacon', 'sausage', 'eggs'],
+          publisher_tesim: ['French Press'],
+          description_tesim: ['Abstraction layer']
+        )
+      end
+
+      let(:presenter) do
+        Hyrax::MultimedPresenter.new(work_solr_document, ability)
+      end
+
+      before do
+        allow(view).to receive(:polymorphic_url)
+        assign(:presenter, presenter)
+        render
+      end
+
+      let(:gs_rendered) { Nokogiri::HTML(view.content_for(:gscholar_meta)) }
+
+      it 'has no citation meta tags' do
+        gscholar_meta_tags = gs_rendered.xpath("//meta[contains(@name, 'citation_')]")
+        expect(gscholar_meta_tags.count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3808

* Update google scholar metadata population to use GoogleScholarPresenter, which is the current approach in hyrax
* Add `scholarly?` method for work presenters, which is referenced by `GoogleScholarPresenter.scholarly?`. 
    * Presenters default to scholarly=false, but all work types except Artwork and Multimedia override it to true