### PR TITLE
HYC-1556 - Update geonames response

### DIFF
--- a/spec/features/create_masters_paper_spec.rb
+++ b/spec/features/create_masters_paper_spec.rb
@@ -85,15 +85,11 @@ RDFXML
       stub_request(:get, 'http://sws.geonames.org/4460162/').
         to_return(status: 200, body: chapel_hill, headers: { 'Content-Type' => 'application/rdf+xml;charset=UTF-8' })
 
-      stub_request(:any, "http://api.geonames.org/getJSON?geonameId=4460162&username=#{ENV['GEONAMES_USER']}").
-        with(headers: {
-               'Accept' => '*/*',
-               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-               'User-Agent' => 'Ruby'
-             }).to_return(status: 200, body: { asciiName: 'Chapel Hill',
-                                               countryName: 'United States',
-                                               adminName1: 'North Carolina' }.to_json,
-                          headers: { 'Content-Type' => 'application/json' })
+      stub_request(:any, "http://www.geonames.org/getJSON?geonameId=4460162&username=#{ENV['GEONAMES_USER']}").
+        to_return(status: 200, body: { name: 'Chapel Hill',
+                                        countryName: 'United States',
+                                        adminName1: 'North Carolina' }.to_json,
+                  headers: { 'Content-Type' => 'application/json' })
     end
 
     scenario 'as a non-admin' do


### PR DESCRIPTION
* Update geonames response based on what new version of Questioning Authority is expecting. Also determined that caching mechanism prevents the URLs from being requested again across test runs, so have to be careful with that.