### PR TITLE
Add a role mapping for production to prevent failure on forms pages

### DIFF
--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -20,4 +20,5 @@ test:
     - leland_himself@example.com
 
 production:
-  # Add roles for users here.
+  patron:
+    - patron1@example.com


### PR DESCRIPTION
To resolve the following error on forms pages:
```
ActionView::Template::Error (No roles were found for the p
roduction environment in /net/deploy/ir/test/releases/20221129124310/config/role_map.yml)
```