### PR TITLE
Workflow restriction download permissions

### DIFF
--- a/app/overrides/controllers/hyrax/downloads_controller_override.rb
+++ b/app/overrides/controllers/hyrax/downloads_controller_override.rb
@@ -3,6 +3,7 @@
 Hyrax::DownloadsController.class_eval do
   # [hyc-override] adding downloads controller and merging hyc:downloadscontroller
   include Hyc::DownloadAnalyticsBehavior
+  include Hyrax::WorkflowsHelper # Provides #workflow_restriction?
 
   # [hyc-override] Loading the admin set for record
   before_action :set_record_admin_set
@@ -24,7 +25,11 @@ Hyrax::DownloadsController.class_eval do
   # that files are in a LDP basic container, and thus, included in the asset's uri.
   def authorize_download!
     authorize! :download, params[asset_param_key]
-  rescue CanCan::AccessDenied
+    # Deny access if the work containing this file is restricted by a workflow
+    file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: params[asset_param_key], use_valkyrie: Hyrax.config.use_valkyrie?)
+    return unless workflow_restriction?(file_set.parent, ability: current_ability)
+    raise Hyrax::WorkflowAuthorizationException
+  rescue CanCan::AccessDenied, Hyrax::WorkflowAuthorizationException
     # [hyc-override] Send permission failures to
     render_401
   end

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -146,6 +146,18 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
           expect(response).to be_not_found
         end
       end
+
+      context 'when restricted by workflow' do
+
+        before do
+          allow(subject).to receive(:workflow_restriction?).and_return(true)
+        end
+
+        it 'gets 401 response' do
+          get :show, params: { id: file_set}
+          expect(response).to be_unauthorized
+        end
+      end
     end
   end
 end

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -158,6 +158,11 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
           expect(response).to be_unauthorized
         end
       end
+
+      it 'retrieves the thumbnail without contacting Fedora' do
+        expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
+        get :show, params: { id: file_set, file: 'thumbnail' }
+      end
     end
   end
 end


### PR DESCRIPTION
Relates to:
https://github.com/samvera/hyrax/issues/5913
https://github.com/samvera/hyrax/pull/5921

* Users will git a forbidden response if they attempt to download a workflow restricted file that they do not have access to.