### PR TITLE
HYC-1583 - Fix analytics and solr config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       DOI_PREFIX: '10.17615'
       EMAIL_FROM_ADDRESS: 'hyraxapp@example.com'
       EMAIL_GEONAMES_ERRORS_ADDRESS: 'hyraxapp@example.com'
-      FEDORA_TEST_URL: http://127.0.0.1:8080/rest
+      FEDORA_TEST_URL: http://localhost:8080/fcrepo/rest
       HYRAX_DATABASE_PASSWORD: 'password'
       HYRAX_HOST: 'https://example.com'
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
@@ -43,11 +43,11 @@ jobs:
       IMAGE_PROCESSOR: 'graphicsmagick'
     services:
       fedora:
-        image: samvera/fcrepo4:4.7.5-cgroup1
+        image: cazzerson/fcrepo4:4.7.5
         ports:
           - 8080:8080
         env:
-          CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
+          CATALINA_OPTS: "-Djava.awt.headless=true -server -Xms1G -Xmx2G -XX:MaxNewSize=1G -XX:+HeapDumpOnOutOfMemoryError -Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json"
       redis:
         image: redis
         options: >-

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,6 +63,10 @@ class CatalogController < ApplicationController
     config.view.masonry.partials = [:index]
     config.view.slideshow.partials = [:index]
 
+    # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
+    # Often, it's because they inadvertantly exceeded the character limit of a GET request.
+    config.http_method = :post
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: 'search',

--- a/app/overrides/services/hyrax/solr_query_service_override.rb
+++ b/app/overrides/services/hyrax/solr_query_service_override.rb
@@ -1,0 +1,8 @@
+# [hyc-override] Hyrax 3.4.1 changes GET request to POST to allow for larger query size
+# https://github.com/samvera/hyrax/blob/v3.4.2/app/services/hyrax/solr_query_service.rb
+# frozen_string_literal: true
+Hyrax::SolrQueryService.module_eval do
+  def get
+    solr_service.post(build)
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -2,9 +2,10 @@
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
 analytics:
-  analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-  app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
-  app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
-  privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-  privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-  client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+  google:
+    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
+    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+    privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>


### PR DESCRIPTION
Part of https://jira.lib.unc.edu/browse/HYC-1583

* Fix for analytics config that was causing the dashboard to fail to load
* Switch solr queries to using POST since the review submissions page was producing solr URLs that were too long (this change is in the catalog_controller template in hyrax)
* Switch to using different fedora container for gh actions, since previous one stopped working. Now it is consistent with the dev vm