### PR TITLE
HYC-1602 - Convert source identifier to a single value

### DIFF
--- a/app/overrides/models/bulkrax/csv_entry_override.rb
+++ b/app/overrides/models/bulkrax/csv_entry_override.rb
@@ -3,6 +3,15 @@
 Bulkrax::CsvEntry.class_eval do
   UPDATABLE_TYPES ||= %w[Article Artwork DataSet Dissertation General HonorsThesis Journal MastersPaper Multimed ScholarlyWork FileSet Collection]
 
+  def build_system_metadata
+    self.parsed_metadata['id'] = hyrax_record.id
+    # [hyc-override] convert source_identifier to a single value if its an array
+    source_id = hyrax_record.send(work_identifier)
+    source_id = source_id.to_a.first if source_id.is_a?(ActiveTriples::Relation)
+    self.parsed_metadata[source_identifier] = source_id
+    self.parsed_metadata[key_for_export('model')] = hyrax_record.has_model.first
+  end
+
   # [hyc-override] check model name before building entry
   alias_method :original_build_metadata, :build_metadata
   def build_metadata

--- a/app/overrides/parsers/bulkrax/csv_parser_override.rb
+++ b/app/overrides/parsers/bulkrax/csv_parser_override.rb
@@ -2,7 +2,7 @@
 
 require 'csv'
 
-Bulkrax:: CsvParser.class_eval do
+Bulkrax::CsvParser.class_eval do
   # [hyc-override] file permissions update from 0600 to 0644
   # This method comes from application_parser.rb
   alias_method :original_write_import_file, :write_import_file


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1602

* Override to convert source identifier to a single value, so that the source field doesn't get mangled when round tripping
