### PR TITLE
HYC-1603 - Cleanup people objects in bulkrax

### DIFF
--- a/app/overrides/factories/bulkrax/object_factory_override.rb
+++ b/app/overrides/factories/bulkrax/object_factory_override.rb
@@ -59,6 +59,7 @@ Bulkrax::ObjectFactory.class_eval do
 
   # List the ids of person objects by the provided field type on the object being updated
   def existing_person_ids(field_name)
+    return [] if @object.nil?
     people = @object.send(field_name)
     people.to_a.map { |p| p.id }
   end

--- a/app/overrides/factories/bulkrax/object_factory_override.rb
+++ b/app/overrides/factories/bulkrax/object_factory_override.rb
@@ -40,6 +40,7 @@ Bulkrax::ObjectFactory.class_eval do
     people_attributes = {}
     @transform_attributes.each do |k, v|
       if !v.blank? && PersonHelper.person_field?(k)
+        unaccounted_for_ids = existing_person_ids(k)
         @transform_attributes.delete(k)
         unprefixed = {}
         v.each_with_index do |person, index|
@@ -47,11 +48,26 @@ Bulkrax::ObjectFactory.class_eval do
           # Remove blank id fields
           unprefixed_person.delete_if { |k, v| k == 'id' && v.blank? }
           unprefixed[index.to_s] = unprefixed_person
+          unaccounted_for_ids.delete(unprefixed_person['id'])
         end
+        destroy_unaccounted_for(unprefixed, unaccounted_for_ids)
         people_attributes["#{k}_attributes"] = unprefixed
       end
     end
     @transform_attributes.merge!(people_attributes)
+  end
+
+  # List the ids of person objects by the provided field type on the object being updated
+  def existing_person_ids(field_name)
+    people = @object.send(field_name)
+    people.to_a.map { |p| p.id }
+  end
+
+  # Add entries to people hash to mark unaccounted for ids as destroyed
+  def destroy_unaccounted_for(people_hash, unaccounted_for_ids)
+    unaccounted_for_ids.each do |id|
+      people_hash[people_hash.size.to_s] = { 'id' => id, '_destroy' => true }
+    end
   end
 
   def unprefix_keys(prefix, original)

--- a/spec/models/bulkrax/object_factory_spec.rb
+++ b/spec/models/bulkrax/object_factory_spec.rb
@@ -9,81 +9,193 @@ module Bulkrax
                                     klass: General)
       }
 
-      context 'with record containing people objects' do
-        let(:attributes) {
-          {
-            'title'=>['Test Work 1'],
-            'creators'=>[{
-               'creators_affiliation'=>'Department of Biology',
-               'creators_id'=>'#nested_persong635480',
-               'creators_index'=>'2',
-               'creators_name'=>'Biology Creator',
-               'creators_orcid'=>'',
-               'creators_other_affiliation'=>''
-             }, {
-               'creators_affiliation'=>'Department of Medicine',
-               'creators_id'=>'#nested_persong635481',
-               'creators_index'=>'1',
-               'creators_name'=>'Medicine Creator',
-               'creators_orcid'=>'',
-               'creators_other_affiliation'=>'School of Testing'
-             }],
-             'id'=>'9p2909328'
-           }
-        }
+      context 'work without people objects' do
+        before do
+          work_obj = General.create(title: ['Test General Work'])
+          subject.instance_eval do
+            @object = work_obj
+          end
+        end
 
-        it 'moves creators to creators_attributes and changes to hash with numeric indexes' do
-          transformed = subject.send(:transform_attributes)
-          expect(transformed['title']).to eq ['Test Work 1']
-          expect(transformed).to_not have_key('creators')
-          expect(transformed['creators_attributes']['0']).to include({
-            'affiliation'=>'Department of Biology',
-            'id'=>'#nested_persong635480',
-            'index'=>'2',
-            'name'=>'Biology Creator',
-            'orcid'=>'',
-            'other_affiliation'=>''
-          })
-          expect(transformed['creators_attributes']['1']).to include({
-            'affiliation'=>'Department of Medicine',
-            'id'=>'#nested_persong635481',
-            'index'=>'1',
-            'name'=>'Medicine Creator',
-            'orcid'=>'',
-            'other_affiliation'=>'School of Testing'
-          })
-          expect(transformed['creators_attributes'].length).to eq 2
+        context 'with record containing people objects' do
+          let(:attributes) {
+            {
+              'title'=>['Test Work 1'],
+              'creators'=>[{
+                 'creators_affiliation'=>'Department of Biology',
+                 'creators_id'=>'#nested_persong635480',
+                 'creators_index'=>'2',
+                 'creators_name'=>'Biology Creator',
+                 'creators_orcid'=>'',
+                 'creators_other_affiliation'=>''
+               }, {
+                 'creators_affiliation'=>'Department of Medicine',
+                 'creators_id'=>'#nested_persong635481',
+                 'creators_index'=>'1',
+                 'creators_name'=>'Medicine Creator',
+                 'creators_orcid'=>'',
+                 'creators_other_affiliation'=>'School of Testing'
+               }],
+               'id'=>'9p2909328'
+             }
+          }
+
+          it 'moves creators to creators_attributes and changes to hash with numeric indexes' do
+            transformed = subject.send(:transform_attributes)
+            expect(transformed['title']).to eq ['Test Work 1']
+            expect(transformed).to_not have_key('creators')
+            expect(transformed['creators_attributes']['0']).to include({
+              'affiliation'=>'Department of Biology',
+              'id'=>'#nested_persong635480',
+              'index'=>'2',
+              'name'=>'Biology Creator',
+              'orcid'=>'',
+              'other_affiliation'=>''
+            })
+            expect(transformed['creators_attributes']['1']).to include({
+              'affiliation'=>'Department of Medicine',
+              'id'=>'#nested_persong635481',
+              'index'=>'1',
+              'name'=>'Medicine Creator',
+              'orcid'=>'',
+              'other_affiliation'=>'School of Testing'
+            })
+            expect(transformed['creators_attributes'].length).to eq 2
+          end
+        end
+
+        context 'with record single value field that should be multi valued' do
+          let(:attributes) {
+            {
+              'title'=>['Test Work 2'],
+              'abstract'=>['Testing factory'],
+              'date_issued'=>'12/20/22',
+               'id'=>'9p2909328',
+             }
+          }
+
+          it 'wraps field value in array' do
+            transformed = subject.send(:transform_attributes)
+            expect(transformed['date_issued']).to eq ['12/20/22']
+          end
+        end
+
+        context 'with record multi value field that should be single valued' do
+          let(:attributes) {
+            {
+              'title'=>['Test Work 3'],
+              'admin_note'=>['Note 1', 'Note 2'],
+               'id'=>'9p2909328',
+             }
+          }
+
+          it 'replaces array with first value' do
+            transformed = subject.send(:transform_attributes)
+            expect(transformed['admin_note']).to eq 'Note 1'
+          end
         end
       end
 
-      context 'with record single value field that should be multi valued' do
-        let(:attributes) {
-          {
-            'title'=>['Test Work 2'],
-            'abstract'=>['Testing factory'],
-            'date_issued'=>'12/20/22',
-             'id'=>'9p2909328',
-           }
+      context 'with work containing people objects' do
+        let(:work_obj) {
+          General.create(title: ['Test General Work'],
+              creators_attributes: {
+                '0' => { name: 'creator_1',
+                        affiliation: 'Carolina Center for Genome Sciences',
+                        index: 1 },
+                '1' => { name: 'creator_2',
+                        affiliation: 'Department of Biology',
+                        index: 2 }
+                })
         }
 
-        it 'wraps field value in array' do
-          transformed = subject.send(:transform_attributes)
-          expect(transformed['date_issued']).to eq ['12/20/22']
+        let(:creator_1) { work_obj.creators.to_a.find { |p| p.index.to_a.first == 1 } }
+        let(:creator_2) { work_obj.creators.to_a.find { |p| p.index.to_a.first == 2 } }
+
+        before(:each) do
+          work = work_obj
+          subject.instance_eval do
+            @object = work
+          end
         end
-      end
 
-      context 'with record multi value field that should be single valued' do
-        let(:attributes) {
-          {
-            'title'=>['Test Work 3'],
-            'admin_note'=>['Note 1', 'Note 2'],
-             'id'=>'9p2909328',
-           }
-        }
+        context 'with updates to creator fields' do
+          let(:attributes) {
+            {
+              'title'=>['Test Work 1'],
+              'creators'=>[{
+                 'creators_affiliation'=>'Department of Medicine',
+                 'creators_id'=>creator_1.id,
+                 'creators_index'=>'1',
+                 'creators_name'=>'creator_1',
+                 'creators_orcid'=>'',
+                 'creators_other_affiliation'=>'School of Testing'
+                }, {
+                 'creators_affiliation'=>'Department of Biology',
+                 'creators_id'=>creator_2.id,
+                 'creators_index'=>'2',
+                 'creators_name'=>'Biology Creator',
+                 'creators_orcid'=>'',
+                 'creators_other_affiliation'=>''
+                }],
+                'id'=>'9p2909328'
+             }
+          }
 
-        it 'replaces array with first value' do
-          transformed = subject.send(:transform_attributes)
-          expect(transformed['admin_note']).to eq 'Note 1'
+          it 'updates existing people objects' do
+            transformed = subject.send(:transform_attributes)
+            expect(transformed['creators_attributes']['0']).to include({
+                'affiliation'=>'Department of Medicine',
+                'id'=>creator_1.id,
+                'index'=>'1',
+                'name'=>'creator_1',
+                'orcid'=>'',
+                'other_affiliation'=>'School of Testing'
+              })
+            expect(transformed['creators_attributes']['1']).to include({
+                'affiliation'=>'Department of Biology',
+                'id'=>creator_2.id,
+                'index'=>'2',
+                'name'=>'Biology Creator',
+                'orcid'=>'',
+                'other_affiliation'=>''
+              })
+            expect(transformed['creators_attributes'].length).to eq 2
+          end
+        end
+
+        context 'with deleted creator' do
+          let(:attributes) {
+            {
+              'title'=>['Test Work 1'],
+              'creators'=>[{
+                 'creators_affiliation'=>'Carolina Center for Genome Sciences',
+                 'creators_id'=>creator_1.id,
+                 'creators_index'=>'1',
+                 'creators_name'=>'creator_1',
+                 'creators_orcid'=>'',
+                 'creators_other_affiliation'=>'School of Testing'
+                }],
+                'id'=>'9p2909328'
+             }
+          }
+
+          it 'updates existing people objects' do
+            transformed = subject.send(:transform_attributes)
+            expect(transformed['creators_attributes']['0']).to include({
+                'affiliation'=>'Carolina Center for Genome Sciences',
+                'id'=>creator_1.id,
+                'index'=>'1',
+                'name'=>'creator_1',
+                'orcid'=>'',
+                'other_affiliation'=>'School of Testing'
+              })
+            expect(transformed['creators_attributes']['1']).to include({
+                'id'=>creator_2.id,
+                '_destroy'=>true
+              })
+            expect(transformed['creators_attributes'].length).to eq 2
+          end
         end
       end
     end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1603

* Register ids of people objects which are not listed in a CSV import as needing to be destroyed (will not destroy them if there are no fields related to a particular person type in the import)