### PR TITLE
HYC-1605 - Update from bulkrax upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'blacklight_advanced_search', '~> 6.4.1'
 gem 'blacklight_oai_provider', '6.1.1'
 gem 'blacklight_range_limit', '6.5.0'
 gem 'bootstrap-sass', '~> 3.4.1'
-gem 'bulkrax', '~> 4.4.0'
+gem 'bulkrax', github: 'samvera-labs/bulkrax', ref: 'f74e350a01ca4fe82271f51ea46697fc725943a9'
 gem 'clamav-client', require: 'clamav/client'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'blacklight_advanced_search', '~> 6.4.1'
 gem 'blacklight_oai_provider', '6.1.1'
 gem 'blacklight_range_limit', '6.5.0'
 gem 'bootstrap-sass', '~> 3.4.1'
-gem 'bulkrax', github: 'samvera-labs/bulkrax', ref: 'f74e350a01ca4fe82271f51ea46697fc725943a9'
+gem 'bulkrax', '~> 5.0.0'
 gem 'clamav-client', require: 'clamav/client'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,23 @@
+GIT
+  remote: https://github.com/samvera-labs/bulkrax.git
+  revision: f74e350a01ca4fe82271f51ea46697fc725943a9
+  ref: f74e350a01ca4fe82271f51ea46697fc725943a9
+  specs:
+    bulkrax (4.4.0)
+      bagit (~> 0.4)
+      coderay
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.1.0)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -151,20 +171,6 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (4.4.0)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.1.0)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.37.1)
@@ -1019,7 +1025,7 @@ DEPENDENCIES
   blacklight_oai_provider (= 6.1.1)
   blacklight_range_limit (= 6.5.0)
   bootstrap-sass (~> 3.4.1)
-  bulkrax (~> 4.4.0)
+  bulkrax!
   byebug (~> 11.1.3)
   capybara (~> 3.36)
   clamav-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,3 @@
-GIT
-  remote: https://github.com/samvera-labs/bulkrax.git
-  revision: f74e350a01ca4fe82271f51ea46697fc725943a9
-  ref: f74e350a01ca4fe82271f51ea46697fc725943a9
-  specs:
-    bulkrax (4.4.0)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.1.0)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -171,6 +151,20 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
+    bulkrax (5.0.0)
+      bagit (~> 0.4)
+      coderay
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.2.4)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.37.1)
@@ -549,7 +543,7 @@ GEM
     legato (0.7.0)
       multi_json
     libv8 (7.3.492.27.1-x86_64-linux)
-    libxml-ruby (3.1.0)
+    libxml-ruby (3.2.4)
     link_header (0.0.8)
     linkeddata (3.1.5)
       equivalent-xml (~> 0.6)
@@ -1025,7 +1019,7 @@ DEPENDENCIES
   blacklight_oai_provider (= 6.1.1)
   blacklight_range_limit (= 6.5.0)
   bootstrap-sass (~> 3.4.1)
-  bulkrax!
+  bulkrax (~> 5.0.0)
   byebug (~> 11.1.3)
   capybara (~> 3.36)
   clamav-client

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,6 +25,16 @@ class Ability
     # end
   end
 
+  # Added by bulkrax
+  def can_import_works?
+    can_create_any_work?
+  end
+
+  # Added by bulkrax
+  def can_export_works?
+    can_create_any_work?
+  end
+
   private
 
   # [hyc-override] Overriding review ability to include entity-specific permissions

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,14 +25,14 @@ class Ability
     # end
   end
 
-  # Added by bulkrax
+  # [hyc-override] Added by bulkrax, changed to only permit admins
   def can_import_works?
-    can_create_any_work?
+    current_user.admin?
   end
 
-  # Added by bulkrax
+  # [hyc-override] Added by bulkrax, changed to only permit admins
   def can_export_works?
-    can_create_any_work?
+    current_user.admin?
   end
 
   private

--- a/app/overrides/models/concerns/bulkrax/import_behavior_override.rb
+++ b/app/overrides/models/concerns/bulkrax/import_behavior_override.rb
@@ -1,36 +1,6 @@
 # frozen_string_literal: true
 # https://github.com/samvera-labs/bulkrax/blob/v4.4.0/app/models/concerns/bulkrax/import_behavior.rb
 Bulkrax::ImportBehavior.module_eval do
-  # [hyc-override] Permitting controlled vocabs on single value fields
-  # Upstream PR: https://github.com/samvera-labs/bulkrax/pull/696
-  def sanitize_controlled_uri_values!
-    Bulkrax.qa_controlled_properties.each do |field|
-      next if parsed_metadata[field].blank?
-
-      if multiple?(field)
-        parsed_metadata[field].each_with_index do |value, i|
-          next if value.blank?
-          parsed_metadata[field][i] = sanitize_controlled_uri_value(field, value)
-        end
-      else
-        parsed_metadata[field] = sanitize_controlled_uri_value(field, parsed_metadata[field])
-      end
-    end
-
-    true
-  end
-
-  def sanitize_controlled_uri_value(field, value)
-    if (validated_uri_value = validate_value(value, field))
-      validated_uri_value
-    else
-      debug_msg = %(Unable to locate active authority ID "#{value}" in config/authorities/#{field.pluralize}.yml)
-      Rails.logger.debug(debug_msg)
-      error_msg = %("#{value}" is not a valid and/or active authority ID for the :#{field} field)
-      raise ::StandardError, error_msg
-    end
-  end
-
   # [hyc-override] set rights_statement as a single value rather an an array to match our model
   def add_rights_statement
     self.parsed_metadata['rights_statement'] = parser.parser_fields['rights_statement'] if override_rights_statement || self.parsed_metadata['rights_statement'].blank?

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -29,12 +29,6 @@
   <%= menu.nav_link('/sidekiq', target: :_blank) do %>
     <span class="fa fa-area-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.links.sidekiq') %></span>
   <% end %>
-  <%= menu.nav_link('/importers') do %>
-    <span class="fa fa-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.links.importers') %></span>
-  <% end %>
-  <%= menu.nav_link('/exporters') do %>
-    <span class="fa fa-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.links.exporters') %></span>
-  <% end %>
 <% end %>
 
 <% if current_ability.can_create_any_work? && Hyrax.config.analytics? %>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -205,6 +205,9 @@ Bulkrax.setup do |config|
 
   # Overriding removed_image_path which by default refers to a file in the spec folder
   config.removed_image_path = Rails.root.join('app', 'assets', 'images', 'bulkrax', 'removed.png')
+
+  # Cleanup blank values during import
+  Bulkrax::ObjectFactory.transformation_removes_blank_hash_values = true
 end
 
 # Sidebar for hyrax 3+ support


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1605

* Using recent commit of bulkrax to pull in upstream fixes, removed overlapping local overrides
* Enables new config option to cleanup empty fields during import
* Adds in two new ability methods which are required by upstream changes
* Remove the old bulkrax links from the dashboard menu in favor of the ones now being added by bulkrax, and restrict bulkrax permissions to admins (to match previous permissions)