### PR TITLE
HYC-1617 - DeregisterLongleafJob - ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/deregister_longleaf_job.rb
+++ b/app/jobs/deregister_longleaf_job.rb
@@ -5,15 +5,12 @@ require 'open3'
 class DeregisterLongleafJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
 
-  def perform(file_set)
-    repository_file = file_set.original_file
-
+  def perform(checksum)
     if ENV['LONGLEAF_BASE_COMMAND'].blank?
       Rails.logger.error('LONGLEAF_BASE_COMMAND is not set, skipping deregistration of file to Longleaf.')
       return
     end
 
-    checksum = repository_file.checksum.value
     # Calculate the path to the file in fedora, assuming modeshape behavior of hashing based on sha1
     binary_path = File.join(ENV['LONGLEAF_STORAGE_PATH'], checksum.scan(/.{2}/)[0..2].join('/'), checksum)
 

--- a/app/models/concerns/hyc/file_set_behavior.rb
+++ b/app/models/concerns/hyc/file_set_behavior.rb
@@ -9,8 +9,9 @@ module Hyc
     end
 
     def deregister_longleaf
-      Rails.logger.info("Calling deregistration from longleaf after delete of #{original_file}")
-      DeregisterLongleafJob.perform_later(self)
+      checksum = original_file.checksum.value
+      Rails.logger.info("Calling deregistration from longleaf after delete of #{original_file} #{checksum}")
+      DeregisterLongleafJob.perform_later(checksum)
     end
   end
 end

--- a/spec/jobs/deregister_longleaf_job_spec.rb
+++ b/spec/jobs/deregister_longleaf_job_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe DeregisterLongleafJob, type: :job do
     end
 
     it 'calls deregistration script with the expected parameters' do
-      job.perform(file_set)
+      job.perform(file_set.original_file.checksum.value)
 
       arguments = File.read(output_path)
 

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -3,10 +3,19 @@ require 'rails_helper'
 
 RSpec.describe FileSet do
   describe 'after destroy' do
-    it 'calls longleaf deregister hook' do
-      expect(DeregisterLongleafJob).to receive(:perform_later).with(subject)
+    let(:checksum_value) { '12345checksum' }
+    let(:checksum) { double('checksum', value: checksum_value) }
+    let(:original_file) { instance_double(Hydra::PCDM::File, checksum: checksum, mime_type: 'application/octet-stream') }
 
+    before do
+      allow(subject).to receive(:original_file).and_return(original_file)
+      allow(DeregisterLongleafJob).to receive(:perform_later).with(checksum_value)
+    end
+
+    it 'calls longleaf deregister hook' do
       subject.destroy
+
+      expect(DeregisterLongleafJob).to have_received(:perform_later).with(checksum_value)
     end
   end
 end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1617

Pass checksum to deregister job (used to compute the fedora path) instead of the fileset, since the fileset will likely not exist anymore by the time the job executes