### PR TITLE
HYC-1628 - Fix missing work-id on file-set-in-work-download events

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] No thumbnail when not showing download link %>
 <%# [hyc-override] Style download link %>
+<%# [hyc-override] Include missing data on link for analytics %>
 <% if display_media_download_link?(file_set: file_set) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
@@ -10,7 +11,7 @@
       </audio>
       <%= link_to t('hyrax.file_set.show.downloadable_content.audio_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   class: "btn btn-info",
                   id: "file_download" %>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,12 +1,13 @@
 <%# [hyc-override] No thumbnail when not showing download link %>
 <%# [hyc-override] Style download link %>
+<%# [hyc-override] Include missing data on link for analytics %>
 <% if display_media_download_link?(file_set: file_set) %>
   <div class="no-preview">
     <%= t('hyrax.works.show.no_preview') %>
       <p /><%= link_to t('hyrax.file_set.show.download'),
         hyrax.download_path(file_set),
         id: "file_download",
-        data: { label: file_set.id },
+        data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
         class: "btn btn-info",
         target: "_new" %>
   </div>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -12,7 +12,7 @@
       <% end %>
       <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   class: "btn btn-info",
                   id: "file_download" %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] No thumbnail when not showing download link %>
 <%# [hyc-override] Style download link %>
+<%# [hyc-override] Include missing data on link for analytics %>
 <% if display_media_download_link?(file_set: file_set) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
@@ -12,6 +13,6 @@
                   target: :_blank,
                   id: "file_download",
                   class: "btn btn-info",
-                  data: { label: file_set.id } %>
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
     </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,4 +1,5 @@
 <%# [hyc-override] Style download link %>
+<%# [hyc-override] Include missing data on link for analytics %>
 <% if display_media_download_link?(file_set: file_set) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
@@ -11,6 +12,6 @@
                   target: :_blank,
                   id: "file_download",
                   class: "btn btn-info",
-                  data: { label: file_set.id } %>
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
     </div>
 <% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,5 +1,6 @@
 <%# [hyc-override] No thumbnail when not showing download link %>
 <%# [hyc-override] Style download link %>
+<%# [hyc-override] Include missing data on link for analytics %>
 <% if display_media_download_link?(file_set: file_set) %>
     <div>
       <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
@@ -10,7 +11,7 @@
       </video>
       <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
                   hyrax.download_path(file_set),
-                  data: { label: file_set.id },
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids },
                   target: :_blank,
                   class: "btn btn-info",
                   id: "file_download" %>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1628

* Include all the same data in the various download links as are in the fileset list download link