### PR TITLE
HYC-1630 - Use DownloadIR in place of file-set-in-work-download for display

### DIFF
--- a/app/overrides/services/hyrax/analytics/google/events_daily_override.rb
+++ b/app/overrides/services/hyrax/analytics/google/events_daily_override.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/blob/hyrax-v3.5.0/app/services/hyrax/analytics/google/events_daily.rb
+Hyrax::Analytics::Google::EventsDaily.module_eval do
+  # [hyc-override] use DownloadIR instead of file-set-in-work-download for download count
+  filter(:file_set_in_work_download) { |_event_action| matches(:eventAction, 'DownloadIR') }
+end

--- a/app/overrides/services/hyrax/analytics/google/events_override.rb
+++ b/app/overrides/services/hyrax/analytics/google/events_override.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/blob/hyrax-v3.5.0/app/services/hyrax/analytics/google/events.rb
+Hyrax::Analytics::Google::Events.module_eval do
+  # [hyc-override] use DownloadIR instead of file-set-in-work-download for download count
+  filter(:file_set_in_work_download) { |_event_action| matches(:eventAction, 'DownloadIR') }
+end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1630

* Present DownloadIR stat for work downloads instead of file-set-in-work-download, since DownloadIR records all downloads (not just via the UI) and it includes stats from hyrax 2 and 3