### PR TITLE
HYC-1632 - adjust and clarify time periods of stats

### DIFF
--- a/app/views/hyrax/stats/_downloads.html.erb
+++ b/app/views/hyrax/stats/_downloads.html.erb
@@ -1,0 +1,20 @@
+<%# [hyc-override] Changing the stats period from a month to a year %>
+<%# https://github.com/samvera/hyrax/blob/hyrax-v3.5.0/app/views/hyrax/stats/_downloads.html.erb %>
+<script>
+  Morris.Bar({
+      element: 'downloads',
+      data: [
+        <% @downloads.list.take(365).reverse.each do |result| %>
+          { date: "<%= result[0] %>", metric: <%= result[1] %>},
+        <% end %>
+      ],  
+      xkey: 'date',
+      ykeys: ['metric'],
+      labels: ["<%= t('.downloads') %>"],
+      gridTextSize: '12px',
+      gridLineColor: '#E5E5E5',
+      gridIntegers: true,
+      ymin: 0,
+      resize: true
+    });
+</script>

--- a/app/views/hyrax/stats/_pageviews.html.erb
+++ b/app/views/hyrax/stats/_pageviews.html.erb
@@ -1,0 +1,20 @@
+<%# [hyc-override] Changing the stats period from a month to a year %>
+<%# https://github.com/samvera/hyrax/blob/hyrax-v3.5.0/app/views/hyrax/stats/_pageviews.html.erb %>
+<script>
+  Morris.Bar({
+      element: 'pageviews',
+      data: [
+        <% @pageviews.list.take(365).reverse.each do |result| %>
+          { date: "<%= result[0] %>", metric: <%= result[1] %>},
+        <% end %>
+      ],  
+      xkey: 'date',
+      ykeys: ['metric'],
+      labels: ["<%= t('.pageviews') %>"],
+      gridTextSize: '12px',
+      gridLineColor: '#E5E5E5',
+      gridIntegers: true,
+      ymin: 0,
+      resize: true
+    });
+</script>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -115,6 +115,11 @@ en:
         option:
           all:
             label_long: All of the CDR
+    stats:
+      work:
+        header: Work Analytics
+        pageviews: Pageviews for the Past Year
+        downloads: Downloads for the Past Year
     visibility:
       authenticated:
         note_html: "Restrict access to Onyen login"


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1632

* Change the period of stats displayed for works from 30 to 365 days
* Update headers of graphs to indicate they display a year