### PR TITLE
HYC-1637 - Fix inability to add to collections when a search term is present

### DIFF
--- a/app/overrides/controllers/hyrax/my/works_controller_override.rb
+++ b/app/overrides/controllers/hyrax/my/works_controller_override.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/blob/hyrax-v3.5.0/app/controllers/hyrax/my/works_controller.rb
+Hyrax::My::WorksController.class_eval do
+  private
+  # [hyc-override] fix for https://github.com/samvera/hyrax/issues/5969
+  def collections_service
+    cloned = self.clone
+    cloned.params = {}
+    Hyrax::CollectionsService.new(cloned)
+  end
+end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1637

* Clear search parameters in CollectionService when populating list of possible collections to add works to, otherwise it will often result in it stating no collections are available