### PR TITLE
HYC-1646 - Use vocab extension from mimetype when no original filename extension

### DIFF
--- a/app/overrides/controllers/hydra/controller/download_behavior_override.rb
+++ b/app/overrides/controllers/hydra/controller/download_behavior_override.rb
@@ -14,11 +14,11 @@ Hydra::Controller::DownloadBehavior.class_eval do
     filename = params[:filename] || file.original_name || (asset.respond_to?(:label) && asset.label) || file.id
     file_parts = filename.split('.')
     existing_extension = file_parts.length > 1 ? file_parts.last : nil
-    if MimeTypeService.valid?(existing_extension)
-      extension = MimeTypeService.label(file.mime_type)
-      "#{filename}.#{extension}"
-    else
+    vocab_extension = MimeTypeService.label(file.mime_type)
+    if vocab_extension.nil? || existing_extension == vocab_extension
       filename
+    else
+      "#{filename}.#{vocab_extension}"
     end
   end
 end

--- a/spec/fixtures/files/no_extension
+++ b/spec/fixtures/files/no_extension
@@ -1,0 +1,1 @@
+without extension


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1646
* Adjust download filename logic to add extensions when they don't match the vocab, and to return the original filename if it already has the right extension.