### PR TITLE
HYC-1676 - Fix issue assigning reviewers in depts containing /

### DIFF
--- a/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
+++ b/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
@@ -4,8 +4,8 @@ module Hyrax::Workflow::AssignReviewerByAffiliation
   def self.call(target:, **)
     target.creators.each do |creator|
       creator['affiliation'].each do |affiliation|
-        # Replace spaces, dashes and commas. PostGres doesn't seem to do well with dashes and commas
-        department = affiliation.strip.to_s.downcase.gsub(/\s|–|,/, '_')
+        # Replace all non-alphanumeric characters, since postgres has a hard time with some punctuation
+        department = affiliation.strip.to_s.downcase.gsub(/[^a-z0-9_]/, '_')
         reviewer = find_reviewer_for(department: department)
         permission_template_id = Hyrax::PermissionTemplate.find_by_source_id(target.admin_set_id).id
 

--- a/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
+++ b/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
@@ -5,7 +5,7 @@ module Hyrax::Workflow::AssignReviewerByAffiliation
     target.creators.each do |creator|
       creator['affiliation'].each do |affiliation|
         # Replace all non-alphanumeric characters, since postgres has a hard time with some punctuation
-        department = affiliation.strip.to_s.downcase.gsub(/[^a-z0-9_]/, '_')
+        department = affiliation.strip.to_s.downcase.gsub(/[^a-z0-9]+/, '_')
         reviewer = find_reviewer_for(department: department)
         permission_template_id = Hyrax::PermissionTemplate.find_by_source_id(target.admin_set_id).id
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1676
* Escape all non-alphanumeric characters in department names when generating reviewer groups, and reduce multiple _'s in a row down to one.