### PR TITLE
HYC-1675 add delete permission check

### DIFF
--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -18,7 +18,9 @@
           <%= t("hyrax.dashboard.my.action.edit_work") %>
         <% end %>
       </li>
+    <% end %>
 
+    <% if can? :delete, document.id %>
       <li role="menuitem" tabindex="-1">
         <%= link_to [main_app, document],
                     method: :delete,


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1675

This PR adjusts the override hy-c has for the work action menu. It moves the edit permission check to just around the edit option, and adds a new permission check just for deletion around the deletion option.