### PR TITLE
HYC-1374 - CLEANUP_FTP_PACKAGES is supplied as a string

### DIFF
--- a/app/services/tasks/ingest_service.rb
+++ b/app/services/tasks/ingest_service.rb
@@ -98,6 +98,10 @@ module Tasks
       end
     end
 
+    def cleanup_enabled?
+      @cleanup_enabled ||= ENV['CLEANUP_FTP_PACKAGES'].to_s.downcase == 'true'
+    end
+
     def extract_files(package_path)
       dirname = unzip_dir(package_path)
       logger.info("Extracting files from #{package_path} to #{dirname}")

--- a/app/services/tasks/proquest_ingest_service.rb
+++ b/app/services/tasks/proquest_ingest_service.rb
@@ -112,7 +112,7 @@ module Tasks
       resource.ordered_members << fileset
 
       # delete zip file after files have been extracted and ingested successfully
-      File.delete(package_path) if ENV['CLEANUP_FTP_PACKAGES']
+      File.delete(package_path) if cleanup_enabled?
     end
 
     def metadata_file_path(dir:)

--- a/app/services/tasks/sage_ingest_service.rb
+++ b/app/services/tasks/sage_ingest_service.rb
@@ -41,7 +41,7 @@ module Tasks
       mark_done(orig_file_name(package_path), unzipped_package_dir, file_names)
 
       # delete zip file after files have been extracted and ingested successfully
-      File.delete(package_path) if ENV['CLEANUP_FTP_PACKAGES']
+      File.delete(package_path) if cleanup_enabled?
 
       work_id
     end


### PR DESCRIPTION
Continuation of https://jira.lib.unc.edu/browse/HYC-1374

* Handle when CLEANUP_FTP_PACKAGES is supplied as a string, and break into a helper method