### PR TITLE
HYC-1705 - DOI creation handle date_issued arrays

### DIFF
--- a/app/services/tasks/doi_create_service.rb
+++ b/app/services/tasks/doi_create_service.rb
@@ -160,7 +160,8 @@ module Tasks
 
     def publication_year(work)
       date_issued = parse_field(work, 'date_issued')
-      year_match = Array.wrap(date_issued).first.to_s.match(/[0-9x]{4}/)
+      date_issued = date_issued.class == ActiveTriples::Relation ? date_issued.to_a : Array.wrap(date_issued)
+      year_match = date_issued.first.to_s.match(/[0-9x]{4}/)
       if year_match.nil?
         puts "#{get_time} Invalid date_issued '#{date_issued}' for record #{work.id}, falling back to create_date"
         work.create_date.year.to_s

--- a/spec/services/tasks/doi_create_service_spec.rb
+++ b/spec/services/tasks/doi_create_service_spec.rb
@@ -210,6 +210,22 @@ RSpec.describe Tasks::DoiCreateService do
         expect(JSON.parse(result)['data']['attributes']['rightsList']['rightsUri']).to eq 'http://rightsstatements.org/vocab/InC/1.0/'
       end
     end
+
+    context 'for a general with date_issued as an array' do
+      let(:general) do
+        General.create(title: ['new general date issued array'],
+                    date_issued: ['2023-07-12'],
+                    rights_statement: 'http://rightsstatements.org/vocab/InC/1.0/')
+      end
+
+      it 'includes a valid publication year ' do
+        result = described_class.new.format_data(general)
+        expect(JSON.parse(result)['data']['attributes']['titles']).to match_array [{ 'title' => 'new general date issued array' }]
+        expect(JSON.parse(result)['data']['attributes']['publicationYear']).to eq '2023'
+        expect(JSON.parse(result)['data']['attributes']['rightsList']['rights']).to eq 'In Copyright'
+        expect(JSON.parse(result)['data']['attributes']['rightsList']['rightsUri']).to eq 'http://rightsstatements.org/vocab/InC/1.0/'
+      end
+    end
   end
 
   describe '#create_doi' do


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1705

* Handle extraction of publication year when date_issued is an array, which gets returned as a ActiveTriples::Relation. This was causing the year to get set to 0000 or 0x00