### PR TITLE
HYC-1718 - Honors thesis approval permissions bug

### DIFF
--- a/app/overrides/services/hyrax/workflow/workflow_action_service_override.rb
+++ b/app/overrides/services/hyrax/workflow/workflow_action_service_override.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/blob/hyrax-v3.6.0/app/services/hyrax/workflow/workflow_action_service.rb
+Hyrax::Workflow::WorkflowActionService.class_eval do
+  MAX_RETRIES = 3
+  attr_writer :retry_delay_seconds
+
+  private
+    def retry_delay_seconds
+      @retry_delay_seconds ||= 2
+    end
+
+    alias_method :original_handle_additional_sipity_workflow_action_processing, :handle_additional_sipity_workflow_action_processing
+
+    # [hyc-override] Add retries to method for model mismatches to allow the system time to resolve them
+    def handle_additional_sipity_workflow_action_processing(comment:)
+      (1..MAX_RETRIES).each do |retry_num|
+        begin
+          return original_handle_additional_sipity_workflow_action_processing(comment: comment)
+        rescue ActiveFedora::ModelMismatch => e
+          if retry_num < MAX_RETRIES
+            Rails.logger.warn("Failed to perform handle_additional_sipity_workflow_action_processing for #{subject.work.id}, try #{retry_num}: #{e.message}")
+            sleep retry_delay_seconds
+          else
+            raise e
+          end
+        end
+      end
+    end
+end

--- a/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
+++ b/app/services/hyrax/workflow/assign_reviewer_by_affiliation.rb
@@ -16,12 +16,15 @@ module Hyrax::Workflow::AssignReviewerByAffiliation
                                                   agents: [reviewer],
                                                   roles: ['viewing'],
                                                   workflow: workflow)
+        group_name = "#{department}_reviewer"
+        # This grants read access to the Fedora object.
+        target.update permissions_attributes: [{ name: group_name, type: 'group', access: 'read' }]
 
         notify_reviewers(target,
                          target.id,
-                         "#{department}_reviewer",
+                         group_name,
                          'group',
--                        'read')
+                         'read')
       end
     end
   end

--- a/spec/services/hyrax/workflow/workflow_action_service_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_action_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Workflow::WorkflowActionService do
   let(:comment) { 'I approve' }
   let(:work) { double }
   let(:service) { Hyrax::Workflow::WorkflowActionService.new(subject: workflow_subject, action: action, comment: comment) }
-  
+
   before do
     allow(workflow_subject).to receive(:work).and_return(work)
     allow(work).to receive(:id).and_return('99')
@@ -42,6 +42,4 @@ RSpec.describe Hyrax::Workflow::WorkflowActionService do
       end
     end
   end
-
-
 end

--- a/spec/services/hyrax/workflow/workflow_action_service_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_action_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::Workflow::WorkflowActionService do
+  let(:workflow_subject) { double }
+  let(:action) { 'approve' }
+  let(:comment) { 'I approve' }
+  let(:work) { double }
+  let(:service) { Hyrax::Workflow::WorkflowActionService.new(subject: workflow_subject, action: action, comment: comment) }
+  
+  before do
+    allow(workflow_subject).to receive(:work).and_return(work)
+    allow(work).to receive(:id).and_return('99')
+    allow(workflow_subject).to receive(:user).and_return('user')
+    allow(service).to receive(:update_sipity_workflow_state)
+    allow(service).to receive(:create_sipity_comment)
+    allow(service).to receive(:handle_sipity_notifications)
+    allow(work).to receive(:update_index)
+  end
+
+  describe '#run' do
+    context 'additional actions fail with mismatch error every time' do
+      before do
+        allow(Hyrax::Workflow::ActionTakenService).to receive(:handle_action_taken).and_raise(ActiveFedora::ModelMismatch)
+      end
+
+      it 'retries and eventually raises error' do
+        expect { service.run }.to raise_error(ActiveFedora::ModelMismatch)
+        expect(Hyrax::Workflow::ActionTakenService).to have_received(:handle_action_taken).exactly(3).times
+      end
+    end
+
+    context 'additional actions succeeds' do
+      before do
+        allow(Hyrax::Workflow::ActionTakenService).to receive(:handle_action_taken)
+      end
+
+      it 'executes once and returns' do
+        service.run
+
+        expect(Hyrax::Workflow::ActionTakenService).to have_received(:handle_action_taken).exactly(1).times
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1718

* Adds retry for sipity additional actions when a ModelMismatch occurs, since they appears to be transient while permissions of children are being modified in Fedora
* Add back in fedora permissions update.
* Remove weird stray -