### PR TITLE
HYC-1730 - Remove model fields which duplicate basic metadata

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -123,10 +123,6 @@ class Article < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :use, predicate: ::RDF::Vocab::DC11.rights do |index|
-    index.as :stored_searchable
-  end
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,10 +13,6 @@ class Article < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :access, predicate: ::RDF::Vocab::DC.accessRights, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/dissertation.rb
+++ b/app/models/dissertation.rb
@@ -80,10 +80,6 @@ class Dissertation < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :use, predicate: ::RDF::Vocab::DC11.rights do |index|
-    index.as :stored_searchable
-  end
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/dissertation.rb
+++ b/app/models/dissertation.rb
@@ -13,10 +13,6 @@ class Dissertation < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :access, predicate: ::RDF::Vocab::DC.accessRights, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/general.rb
+++ b/app/models/general.rb
@@ -17,10 +17,6 @@ class General < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :access, predicate: ::RDF::Vocab::DC.accessRights, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/general.rb
+++ b/app/models/general.rb
@@ -210,10 +210,6 @@ class General < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :use, predicate: ::RDF::Vocab::DC11.rights do |index|
-    index.as :stored_searchable
-  end
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/honors_thesis.rb
+++ b/app/models/honors_thesis.rb
@@ -88,10 +88,6 @@ class HonorsThesis < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :use, predicate: ::RDF::Vocab::DC11.rights do |index|
-    index.as :stored_searchable
-  end
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/honors_thesis.rb
+++ b/app/models/honors_thesis.rb
@@ -17,10 +17,6 @@ class HonorsThesis < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :access, predicate: ::RDF::Vocab::DC.accessRights, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/masters_paper.rb
+++ b/app/models/masters_paper.rb
@@ -80,10 +80,6 @@ class MastersPaper < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :use, predicate: ::RDF::Vocab::DC11.rights do |index|
-    index.as :stored_searchable
-  end
-
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/masters_paper.rb
+++ b/app/models/masters_paper.rb
@@ -21,10 +21,6 @@ class MastersPaper < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :access, predicate: ::RDF::Vocab::DC.accessRights, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
   property :advisors, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ths'), class_name: 'Person' do |index|
     index.as :stored_searchable
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Article do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
-      expect(subject).to respond_to(:access)
       expect(subject).to respond_to(:admin_note)
       expect(subject).to respond_to(:alternative_title)
       expect(subject).to respond_to(:bibliographic_citation)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Article do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
@@ -72,7 +73,6 @@ RSpec.describe Article do
       expect(subject).to respond_to(:place_of_publication)
       expect(subject).to respond_to(:rights_holder)
       expect(subject).to respond_to(:translators)
-      expect(subject).to respond_to(:use)
       expect(subject).to respond_to(:language_label)
       expect(subject).to respond_to(:license_label)
       expect(subject).to respond_to(:rights_statement_label)

--- a/spec/models/artwork_spec.rb
+++ b/spec/models/artwork_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Artwork do
       expect(subject).to respond_to(:rights_statement)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)

--- a/spec/models/artwork_spec.rb
+++ b/spec/models/artwork_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Artwork do
       expect(subject).to respond_to(:license)
       expect(subject).to respond_to(:rights_statement)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)

--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe DataSet do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Custom fields
       expect(subject).to respond_to(:abstract)

--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe DataSet do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Custom fields
       expect(subject).to respond_to(:abstract)

--- a/spec/models/dissertation_spec.rb
+++ b/spec/models/dissertation_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Dissertation do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
@@ -60,7 +61,6 @@ RSpec.describe Dissertation do
       expect(subject).to respond_to(:note)
       expect(subject).to respond_to(:place_of_publication)
       expect(subject).to respond_to(:reviewers)
-      expect(subject).to respond_to(:use)
       expect(subject).to respond_to(:language_label)
       expect(subject).to respond_to(:license_label)
       expect(subject).to respond_to(:rights_statement_label)

--- a/spec/models/dissertation_spec.rb
+++ b/spec/models/dissertation_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe Dissertation do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
-      expect(subject).to respond_to(:access)
       expect(subject).to respond_to(:admin_note)
       expect(subject).to respond_to(:advisors)
       expect(subject).to respond_to(:alternative_title)

--- a/spec/models/general_spec.rb
+++ b/spec/models/general_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe General do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
@@ -92,7 +93,6 @@ RSpec.describe General do
       expect(subject).to respond_to(:table_of_contents)
       expect(subject).to respond_to(:translators)
       expect(subject).to respond_to(:url)
-      expect(subject).to respond_to(:use)
       expect(subject).to respond_to(:language_label)
       expect(subject).to respond_to(:license_label)
       expect(subject).to respond_to(:rights_statement_label)

--- a/spec/models/general_spec.rb
+++ b/spec/models/general_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe General do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
       expect(subject).to respond_to(:academic_concentration)
-      expect(subject).to respond_to(:access)
       expect(subject).to respond_to(:admin_note)
       expect(subject).to respond_to(:advisors)
       expect(subject).to respond_to(:alternative_title)

--- a/spec/models/honors_thesis_spec.rb
+++ b/spec/models/honors_thesis_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe HonorsThesis do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
@@ -60,7 +61,6 @@ RSpec.describe HonorsThesis do
       expect(subject).to respond_to(:dcmi_type)
       expect(subject).to respond_to(:graduation_year)
       expect(subject).to respond_to(:note)
-      expect(subject).to respond_to(:use)
       expect(subject).to respond_to(:language_label)
       expect(subject).to respond_to(:license_label)
       expect(subject).to respond_to(:rights_statement_label)

--- a/spec/models/honors_thesis_spec.rb
+++ b/spec/models/honors_thesis_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe HonorsThesis do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
       expect(subject).to respond_to(:academic_concentration)
-      expect(subject).to respond_to(:access)
       expect(subject).to respond_to(:admin_note)
       expect(subject).to respond_to(:advisors)
       expect(subject).to respond_to(:award)

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Journal do
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:related_url)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Custom fields
       expect(subject).to respond_to(:abstract)

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Journal do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:related_url)
+      expect(subject).to respond_to(:access_right)
 
       # Custom fields
       expect(subject).to respond_to(:abstract)

--- a/spec/models/masters_paper_spec.rb
+++ b/spec/models/masters_paper_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe MastersPaper do
       expect(subject).to respond_to(:license)
       expect(subject).to respond_to(:rights_statement)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
       expect(subject).to respond_to(:academic_concentration)
-      expect(subject).to respond_to(:access)
       expect(subject).to respond_to(:admin_note)
       expect(subject).to respond_to(:advisors)
       expect(subject).to respond_to(:date_issued)

--- a/spec/models/masters_paper_spec.rb
+++ b/spec/models/masters_paper_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe MastersPaper do
       expect(subject).to respond_to(:rights_statement)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)
@@ -52,7 +53,6 @@ RSpec.describe MastersPaper do
       expect(subject).to respond_to(:graduation_year)
       expect(subject).to respond_to(:note)
       expect(subject).to respond_to(:reviewers)
-      expect(subject).to respond_to(:use)
       expect(subject).to respond_to(:language_label)
       expect(subject).to respond_to(:license_label)
       expect(subject).to respond_to(:rights_statement_label)

--- a/spec/models/multimed_spec.rb
+++ b/spec/models/multimed_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Multimed do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)

--- a/spec/models/multimed_spec.rb
+++ b/spec/models/multimed_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Multimed do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)

--- a/spec/models/scholarly_work_spec.rb
+++ b/spec/models/scholarly_work_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ScholarlyWork do
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:rights_notes)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)

--- a/spec/models/scholarly_work_spec.rb
+++ b/spec/models/scholarly_work_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ScholarlyWork do
       expect(subject).to respond_to(:identifier)
       expect(subject).to respond_to(:source)
       expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:access_right)
 
       # Additional metadata
       expect(subject).to respond_to(:abstract)


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/HYC-1730

* Remove 'use' field in favor of basic metadata 'rights_notes' field. Add expectation that rights_notes field is present for all work types
* Remove 'access' field in favor of basic metadata 'access_right' field. Add expectation that access_right field is present for all work types