### PR TITLE
HYC-1731 - Remove access and use fields from solr document

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,6 @@ group :test do
   gem 'selenium-webdriver', '~> 4.8'
   gem 'shoulda-matchers', '~> 5.1.0'
   gem 'simplecov'
-  gem 'webdrivers'
+  gem 'webdrivers', '~> 5.3'
   gem 'webmock', '~> 3.14.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,6 @@ group :test do
   gem 'selenium-webdriver', '~> 4.8'
   gem 'shoulda-matchers', '~> 5.1.0'
   gem 'simplecov'
-  gem 'webdrivers', '~> 5.3'
+  gem 'webdrivers', '~> 5.3', require: false
   gem 'webmock', '~> 3.14.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1021,10 +1021,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (5.2.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -1102,7 +1102,7 @@ DEPENDENCIES
   turbolinks (~> 5.2.1)
   uglifier (~> 4.2.0)
   web-console (~> 3.7.0)
-  webdrivers
+  webdrivers (~> 5.3)
   webmock (~> 3.14.0)
 
 RUBY VERSION

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,10 +56,6 @@ class SolrDocument
     self['academic_concentration_tesim']
   end
 
-  def access
-    self['access_tesim']
-  end
-
   def admin_note
     self['admin_note_tesim']
   end
@@ -338,9 +334,5 @@ class SolrDocument
 
   def url
     self['url_tesim']
-  end
-
-  def use
-    self['use_tesim']
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,7 @@ require 'rspec/rails'
 require 'webmock/rspec'
 
 WebMock.disable_net_connect!(allow_localhost: true, allow: ['fedora:8080', 'solr8:8983', 'fcrepo:8080', 'solr:8983', 'opaquenamespace.org',
-                                                            'chromedriver.storage.googleapis.com'])
+                                                            'googlechromelabs.github.io', 'chromedriver.storage.googleapis.com', 'https://edgedl.me.gvt1.com'])
 Capybara.default_normalize_ws = true
 
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,11 +39,6 @@ SimpleCov.start 'rails' do
 end
 
 require 'capybara/rspec'
-# Temporarily fix chromedriver version, as newer versions are not accessible from the original
-# download path. We could revisit this when we are on ruby 3 and there may be appropriate
-# versions of selenium available
-require 'webdrivers'
-Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 require 'webmock/rspec'
 require 'shoulda/matchers'
 Shoulda::Matchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ SimpleCov.start 'rails' do
 end
 
 require 'capybara/rspec'
+require 'webdrivers/chromedriver'
 require 'webmock/rspec'
 require 'shoulda/matchers'
 Shoulda::Matchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ SimpleCov.start 'rails' do
 end
 
 require 'capybara/rspec'
-require 'webdrivers/chromedriver'
+require 'webdrivers'
 require 'webmock/rspec'
 require 'shoulda/matchers'
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Part of https://unclibrary.atlassian.net/browse/HYC-1731

* Removes from solr document that we already removed from all the models.
* Update webdrivers and list of expected download paths for chromium so unrelated feature tests will pass again.