### PR TITLE
HYC-1754 - Preserve fcrepo data (hyrax 4)

### DIFF
--- a/config/local_env_sample.yml
+++ b/config/local_env_sample.yml
@@ -4,7 +4,7 @@
 SECRET_KEY_BASE: some_long_hash
 SOLR_PRODUCTION_URL: 'http://127.0.0.1:8983/solr/blacklight-core'
 FEDORA_PRODUCTION_URL: 'http://127.0.0.1:8984/fcrepo/rest'
-FEDORA_BINARY_STORAGE: /opt/fedora/binaries
+FEDORA_BINARY_STORAGE: /opt/fedora/fcrepo.binary.directory
 FITS_LOCATION: '/fits/fits-1.0.5/fits.sh'
 DEFAULT_ADMIN_SET: 'default'
 DATABASE_URL: 'postgresql://db:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - mount-code:/hyrax
       - mount-gems:/hyc-gems
-      - fcrepo_data:/opt/fedora/binaries
+      - fcrepo_data:/opt/fedora/
       - hyrax_data:/opt/hyrax
     stdin_open: true
     tty: true
@@ -42,7 +42,7 @@ services:
     volumes:
       - mount-code:/hyrax
       - mount-gems:/hyc-gems
-      - fcrepo_data:/opt/fedora/binaries
+      - fcrepo_data:/opt/fedora/
       - hyrax_data:/opt/hyrax
     networks:
       - hycdev
@@ -72,7 +72,7 @@ services:
     ports:
       - "8984:8080"
     volumes:
-      - fcrepo_data:/usr/local/tomcat/fcrepo4-data/fcrepo.binary.directory
+      - fcrepo_data:/usr/local/tomcat/fcrepo4-data/
     environment:
       CATALINA_OPTS: "-Djava.awt.headless=true -server -Xms1G -Xmx2G -XX:MaxNewSize=1G -XX:+HeapDumpOnOutOfMemoryError -Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json"
     stdin_open: true


### PR DESCRIPTION
Resolves https://unclibrary.atlassian.net/browse/HYC-1754

* Store fcrepo-data volume at one directory up, otherwise all the other fcrepo-data directories will get lost sometimes (maybe after editing docker-compose? I'm not sure of the exact trigger, but anything outside of a declared volume is basically temp storage)
* This resolves issues with the forms not loading, since that was caused by the default admin set getting deleted due to fcrepo-data disappearing