### PR TITLE
HYC-1754 - Preserve fcrepo data (Hyrax 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # Ignore all logfiles and tempfiles.
 /log/*
-/tmp/*
+tmp/
 !/log/.keep
 !/tmp/.keep
 

--- a/config/local_env_sample.yml
+++ b/config/local_env_sample.yml
@@ -4,7 +4,7 @@
 SECRET_KEY_BASE: some_long_hash
 SOLR_PRODUCTION_URL: 'http://127.0.0.1:8983/solr/blacklight-core'
 FEDORA_PRODUCTION_URL: 'http://127.0.0.1:8984/fcrepo/rest'
-FEDORA_BINARY_STORAGE: /opt/fedora/binaries
+FEDORA_BINARY_STORAGE: /opt/fedora/fcrepo.binary.directory
 FITS_LOCATION: '/fits/fits-1.0.5/fits.sh'
 DEFAULT_ADMIN_SET: 'default'
 DATABASE_URL: 'postgresql://db:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     volumes:
       - mount-code:/hyrax
       - mount-gems:/hyc-gems
-      - fcrepo_data:/opt/fedora/binaries
+      - fcrepo_data:/opt/fedora/
       - hyrax_data:/opt/hyrax
     stdin_open: true
     tty: true
@@ -57,7 +57,7 @@ services:
     ports:
       - "8984:8080"
     volumes:
-      - fcrepo_data:/usr/local/tomcat/fcrepo4-data/fcrepo.binary.directory
+      - fcrepo_data:/usr/local/tomcat/fcrepo4-data/
     environment:
       CATALINA_OPTS: "-Djava.awt.headless=true -server -Xms1G -Xmx2G -XX:MaxNewSize=1G -XX:+HeapDumpOnOutOfMemoryError -Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json"
     stdin_open: true

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -4,6 +4,9 @@ source scl_source enable rh-ruby27
 source scl_source enable devtoolset-8
 
 mkdir -p /opt/hyrax/log/
+gem install rubygems-update -v '~> 3.4'
+update_rubygems  >> /dev/null
+
 bundle check || bundle install
 # The bundle config and package are needed for the odd way we manage gems in production
 bundle config --local cache_path /hyc-gems


### PR DESCRIPTION
Backport of fixes for https://unclibrary.atlassian.net/browse/HYC-1754 so that fcrpeo-data won't get lost when switching branchs.

* Store fcrepo-data volume at one directory up, otherwise all the other fcrepo-data directories will get lost sometimes (maybe after editing docker-compose? I'm not sure of the exact trigger, but anything outside of a declared volume is basically temp storage)
* Force rubygems to update when starting app, otherwise it won't be able to find recent gems
* Ignore all temp folders, so it won't try to commit tmp folders leftover by tests