### PR TITLE
HYC-1765 - Duplicate people entries, bootstrap, file upload form (hyrax-4)

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/required_fields.es6
+++ b/app/assets/javascripts/hyrax/save_work/required_fields.es6
@@ -18,7 +18,7 @@ export class RequiredFields {
         let selector = $(elem);
         let parentHidden = selector.parent().closest('div.cloning');
 
-        if (parentHidden.hasClass('hidden')) {
+        if (parentHidden.hasClass('d-none')) {
             return false;
         }
 

--- a/app/assets/javascripts/person_objects.js
+++ b/app/assets/javascripts/person_objects.js
@@ -72,7 +72,7 @@ $(document).on('turbolinks:load', function () {
             // stop page from reloading
             event.preventDefault();
 
-            $(remove_selector).removeClass('hidden');
+            $(remove_selector).removeClass('d-none');
 
             // Retrieve an index for the new person
             var current_index = getNextPersonIndex(person_type);
@@ -87,7 +87,7 @@ $(document).on('turbolinks:load', function () {
 
             // remove $new_row's id so we don't find it again when looking for blank row to clone
             $new_row.removeAttr('id');
-            $new_row.removeClass('hidden');
+            $new_row.removeClass('d-none');
             $('div#' + person_type).append($new_row);
 
             attachRemovePersonListener(person_type, $new_row);

--- a/app/assets/javascripts/unc/unc_custom.js
+++ b/app/assets/javascripts/unc/unc_custom.js
@@ -8,7 +8,7 @@ $(function() {
 
         // Remove any currently hidden student work types
         $('.all-unc-work-types').on('click', function() {
-            all_work_types.removeClass('hidden');
+            all_work_types.removeClass('d-none');
         });
 
         // Filter form options based on which button is clicked
@@ -19,7 +19,7 @@ $(function() {
             var regex;
 
             // Clear all hidden forms before hiding current clicked options
-            all_work_types.removeClass('hidden');
+            all_work_types.removeClass('d-none');
 
             if (clicked_link === 'student-papers-work-types') {
                 regex = /MastersPaper|HonorsThesis/;
@@ -38,7 +38,7 @@ $(function() {
                 } else {
                     return regex.test(work_type);
                 }
-            }).addClass('hidden');
+            }).addClass('d-none');
         });
     }
 
@@ -71,7 +71,7 @@ $(function() {
 
     function hideNonRequiredFieldsBtn() {
         $('#metadata a.additional-fields').on('click', function () {
-            $(this).addClass('hidden');
+            $(this).addClass('d-none');
         });
     }
 
@@ -96,15 +96,15 @@ $(function() {
         var less_text = $('.truncated');
 
         $('#collection-description-text-btn').on('click touchstart', function() {
-            var show_less_text = less_text.hasClass('hidden');
+            var show_less_text = less_text.hasClass('d-none');
             var btn_text = (show_less_text) ? 'Show More' : 'Show Less';
 
             if (show_less_text) {
-                full_text.addClass('hidden');
-                less_text.removeClass('hidden');
+                full_text.addClass('d-none');
+                less_text.removeClass('d-none');
             } else {
-                full_text.removeClass('hidden');
-                less_text.addClass('hidden');
+                full_text.removeClass('d-none');
+                less_text.addClass('d-none');
             }
 
             $(this).text(btn_text);

--- a/app/assets/javascripts/unc/unc_save_work_control.es6
+++ b/app/assets/javascripts/unc/unc_save_work_control.es6
@@ -36,11 +36,11 @@ export default class UncSaveWorkControl extends SaveWorkControl {
         const $cancelBtn = this.uploads.form.find('#file-upload-cancel-btn');
 
         $uploadsEl.bind('fileuploadstart', () => {
-            $cancelBtn.removeClass('hidden');
+            $cancelBtn.removeClass('d-none');
         });
 
         $uploadsEl.bind('fileuploadstop', () => {
-            $cancelBtn.addClass('hidden');
+            $cancelBtn.addClass('d-none');
         });
     }
 }

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -51,7 +51,7 @@
                         target: '_blank' %>
           </label>
         <% else %>
-          <label class="hidden">
+          <label class="d-none">
             <%= f.input :agreement,
                         as: :boolean,
                         checked: f.object.agreement_accepted,

--- a/app/views/hyrax/base/_form_relationships.html.erb
+++ b/app/views/hyrax/base/_form_relationships.html.erb
@@ -26,7 +26,7 @@
                 selected: admin_set_id,
                 include_blank: true,
                 collection: admin_set_options,
-                input_html: { class: 'form-control hidden' },
+                input_html: { class: 'form-control d-none' },
                 readonly: true,
                 label: false %>
   <% end%>

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -23,15 +23,15 @@
       <!-- Tab panes -->
       <div class="tab-content card">
         <% (tabs - ['share']).each_with_index do | tab, i | %>
-          <%# [hyc-override] only show files partial on metadata page %>
-          <% if tab == 'metadata' %>
-            <div class="table-responsive">
-              <%= render 'form_files' %>
-            </div>
-            <hr class="file-upload-divider">
-          <% end %>
-
           <div role="tabpanel" class="tab-pane <% if i == 0 %>show active<% end %>" id="<%= tab %>">
+            <%# [hyc-override] only show files partial on metadata page %>
+            <% if tab == 'metadata' %>
+              <div class="table-responsive">
+                <%= render 'form_files' %>
+              </div>
+              <hr class="file-upload-divider">
+            <% end %>
+
             <%# [hyc-override] Don't add undisplayable "files" tab text to dom %>
             <div class="form-tab-content">
               <% # metadata_tab is sometimes provided %>

--- a/app/views/hyrax/collections/_collection_description.erb
+++ b/app/views/hyrax/collections/_collection_description.erb
@@ -3,7 +3,7 @@
     <div class="truncated">
       <%= simple_format(auto_link(description.truncate_words(100))) %>
     </div>
-    <div class="full hidden">
+    <div class="full d-none">
       <%= simple_format(auto_link(description)) %>
     </div>
     <button id="collection-description-text-btn" class="btn btn-default">Show More</button>

--- a/app/views/records/edit_fields/_language_label.html.erb
+++ b/app/views/records/edit_fields/_language_label.html.erb
@@ -1,3 +1,3 @@
-<div class="hidden">
+<div class="d-none">
   <%= f.input :language_label, as: :multi_value %>
 </div>

--- a/app/views/records/edit_fields/_license_label.html.erb
+++ b/app/views/records/edit_fields/_license_label.html.erb
@@ -1,3 +1,3 @@
-<div class="hidden">
+<div class="d-none">
   <%= f.input :license_label, as: :multi_value %>
 </div>

--- a/app/views/records/edit_fields/_person.html.erb
+++ b/app/views/records/edit_fields/_person.html.erb
@@ -67,7 +67,7 @@
     </div>
   <% end %>
 
-  <div class="<%= person_term %> row cloning hidden field-wrapper" id='<%= person_term %>-cloning_row'>
+  <div class="<%= person_term %> row cloning d-none field-wrapper" id='<%= person_term %>-cloning_row'>
     <%= f.fields_for person_key do |person| %>
       <% if person.index <= @form.instance_eval(person_key.to_s).count %>
         <div class="<%= person_term %> row well">

--- a/app/views/records/edit_fields/_rights_statement_label.html.erb
+++ b/app/views/records/edit_fields/_rights_statement_label.html.erb
@@ -1,3 +1,3 @@
-<div class="hidden">
+<div class="d-none">
   <%= f.input :rights_statement_label, as: :select %>
 </div>


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1765

* Fix the duplicate people entries in the deposit forms by switching from `hidden` classes to `d-none`, which is part of the upgrade from bootstrap 3 to 4, so made this change everywhere
* Fixed the file upload form showing up on all the editor tabs, not just the metadata one.