### PR TITLE
Ensure test base created in hyrax 4 docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'terser', '~> 1.1'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', '~> 11.1.3', platform: :mri
+  gem 'database_cleaner'
   gem 'fcrepo_wrapper', '~> 0.9.0'
   gem 'rspec-rails', '~> 5.1.2'
   # Rubocop for style and error checking (linter)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,12 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     declarative (0.0.20)
     deprecation (1.1.0)
@@ -1071,6 +1077,7 @@ DEPENDENCIES
   capybara (~> 3.36)
   clamav-client
   coffee-rails (~> 5.0.0)
+  database_cleaner
   devise (~> 4.8.0)
   devise-guests (~> 0.8.1)
   edtf-humanize (= 2.0.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,15 @@ Capybara.default_normalize_ws = true
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
+
+# Setup test database
+db_config = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]
+ActiveRecord::Tasks::DatabaseTasks.create(db_config)
+
+ActiveRecord::Migrator.migrations_paths = [Pathname.new('.').join('db', 'migrate').to_s]
+ActiveRecord::Tasks::DatabaseTasks.migrate
+ActiveRecord::Base.descendants.each(&:reset_column_information)
+
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,17 +32,26 @@ Capybara.default_normalize_ws = true
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 
-# Setup test database
-db_config = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]
-ActiveRecord::Tasks::DatabaseTasks.create(db_config)
-
-ActiveRecord::Migrator.migrations_paths = [Pathname.new('.').join('db', 'migrate').to_s]
-ActiveRecord::Tasks::DatabaseTasks.migrate
-ActiveRecord::Base.descendants.each(&:reset_column_information)
-
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  DatabaseCleaner.url_allowlist = [ENV['DATABASE_URL']]
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with :truncation
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before do
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  rescue
+    puts 'database clean failed'
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
* Switched to using data_cleaner, since the previous method was failing to create the hyrax_test database most of the time. The ActiveRecord method used in hyrax seemed to fail to find some bulkrax tables, even though they were getting created.