### PR TITLE
HYC-1790 - Advanced search "start over" button (hyrax-4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'active-fedora', '~> 14.0'
+gem 'blacklight', git: 'https://github.com/UNC-Libraries/blacklight.git', branch: 'advanced_start_over'
 gem 'blacklight_advanced_search', '~> 8.0.0.alpha2'
 gem 'blacklight_oai_provider', '7.0.2'
 gem 'blacklight_range_limit', '~> 8.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/UNC-Libraries/blacklight.git
-  revision: 8b344aa9273d307b3fe93e3915ce5d762e53a28f
+  revision: a68a03f3871aeb49ec897b9007122c0ad033e4e6
   branch: advanced_start_over
   specs:
     blacklight (7.34.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/UNC-Libraries/blacklight.git
+  revision: 8b344aa9273d307b3fe93e3915ce5d762e53a28f
+  branch: advanced_start_over
+  specs:
+    blacklight (7.34.0)
+      deprecation
+      globalid
+      hashdiff
+      i18n (>= 1.7.0)
+      jbuilder (~> 2.7)
+      kaminari (>= 0.15)
+      ostruct (>= 0.3.2)
+      rails (>= 5.1, < 7.1)
+      view_component (>= 2.66, < 4)
+
+GIT
   remote: https://github.com/UNC-Libraries/bulkrax.git
   revision: ccbc380e1a51543017b9ddab5cd5d03f46fd293d
   branch: unc-bulkrax-5-development
@@ -202,16 +218,6 @@ GEM
       i18n
     bcrypt (3.1.19)
     bindex (0.8.1)
-    blacklight (7.33.1)
-      deprecation
-      globalid
-      hashdiff
-      i18n (>= 1.7.0)
-      jbuilder (~> 2.7)
-      kaminari (>= 0.15)
-      ostruct (>= 0.3.2)
-      rails (>= 5.1, < 7.1)
-      view_component (~> 2.66)
     blacklight-access_controls (6.0.1)
       blacklight (> 6.0, < 8)
       cancancan (>= 1.8)
@@ -1076,6 +1082,7 @@ PLATFORMS
 
 DEPENDENCIES
   active-fedora (~> 14.0)
+  blacklight!
   blacklight_advanced_search (~> 8.0.0.alpha2)
   blacklight_oai_provider (= 7.0.2)
   blacklight_range_limit (~> 8.3.0)


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1790

* Use a local branch of blacklight 7.34.0 which has a fix for the advanced search start over button (see the PR here https://github.com/projectblacklight/blacklight/pull/3092 for details)
* Incidentally, this updates blacklight from 7.33.1 to 7.34.0