### PR TITLE
HYC-1780 - Assign group roles to sage and proquest

### DIFF
--- a/app/services/tasks/proquest_ingest_service.rb
+++ b/app/services/tasks/proquest_ingest_service.rb
@@ -95,6 +95,7 @@ module Tasks
           file_set = ingest_proquest_file(parent: resource,
                                           resource: metadata.merge({ title: [f] }),
                                           f: file_path)
+          file_set.update permissions_attributes: group_permissions
           ordered_members << file_set if file_set
         end
       end
@@ -106,8 +107,7 @@ module Tasks
 
       # Force visibility to private since it seems to be saving as public
       fileset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      fileset.permissions_attributes = group_permissions
-      fileset.save
+      fileset.update permissions_attributes: group_permissions
 
       resource.ordered_members << fileset
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - mount-gems:/hyc-gems
       - fcrepo_data:/opt/fedora/
       - hyrax_data:/opt/hyrax
+      - ftp_data:/opt/data/ftp
     stdin_open: true
     tty: true
     networks:
@@ -44,6 +45,7 @@ services:
       - mount-gems:/hyc-gems
       - fcrepo_data:/opt/fedora/
       - hyrax_data:/opt/hyrax
+      - ftp_data:/opt/data/ftp
     networks:
       - hycdev
   clamav:
@@ -113,6 +115,7 @@ volumes:
   fcrepo_data:
   redis_data:
   hyrax_data:
+  ftp_data:
 
 networks:
   hycdev:


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1780

* Fix group role assignments in proquest so it applies to all files. Add test to verify.
* Set group role assignments for sage ingests on work and files. Add test to verify
* Fix issue with docker vm where ftp files were not shared between the web and sidekiq containers