### PR TITLE
HYC-1810 - MissingTemplate error for info.json requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,15 +23,16 @@ class ApplicationController < ActionController::Base
   rescue_from Hyrax::ObjectNotFoundError, with: :render_404
   rescue_from ActiveFedora::ObjectNotFoundError, with: :render_404
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_401
+  rescue_from ActionController::UnknownFormat, with: :render_404
 
   protected
 
   def render_400
-    render 'errors/not_found', status: 400
+    render 'errors/not_found', status: 400, formats: :html
   end
 
   def render_401
-    render 'errors/not_found', status: 401
+    render 'errors/not_found', status: 401, formats: :html
   end
 
   def render_riiif_404
@@ -44,11 +45,11 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404
-    render 'errors/not_found', status: 404
+    render 'errors/not_found', status: 404, formats: :html
   end
 
   def render_500
-    render 'errors/internal_server_error', status: 500
+    render 'errors/internal_server_error', status: 500, formats: :html
   end
 
   # Error caught in catalogController

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,11 @@ class ApplicationController < ActionController::Base
     render_json_response(response_type: :not_found)
   end
 
+  def render_json_response(response_type: :success, message: nil, options: {})
+    json_body = Hyrax::API.generate_response_body(response_type: response_type, message: message, options: options)
+    render json: json_body, status: response_type
+  end
+
   def render_404
     render 'errors/not_found', status: 404
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class ErrorsController < ApplicationController
   def not_found
-    render nothing: true, status: 404
+    render nothing: true, status: 404, formats: :html
   end
 
   def internal_server_error
-    render nothing: true, status: 500
+    render nothing: true, status: 500, formats: :html
   end
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1810

* Fixes errors when invalid info.json URLs are requested, which were throwing a 500 error due to two issues:  
    * It was trying to find a json version of the base error pages, but we only had html (now it explicitly will use the html format error page instead of trying to find a non-existent json version)
    * for riiif errors, it was trying to use `render_json_response` from `Hyrax::Controller` which is included in our `ApplicationController`, but for some reason the helper method is not available (maybe because its private? not sure) 

