### PR TITLE
HYC-1812 - Collection page masonry view errors

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,15 +81,16 @@ class CatalogController < ApplicationController
     config.index.thumbnail_field = 'thumbnail_path_ss'
     config.index.constraints_component = Hyc::ConstraintsComponent
 
-    config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    # We have disabled the bookmark routes, so commenting out all bookmark related config
+    # config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)
-    config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    # config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
     config.add_show_tools_partial(:citation)
-    config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)
+    # config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)
     config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
 
     # solr fields that will be treated as facets by the blacklight application


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1812

* Comment out CatalogController lines which were setting up bookmark behaviors, since we have disabled the routes for it. Removing these lines resolves `undefined method `bookmark_path'` errors directly, and seem to indirectly resolve the original `guest_uid_authentication_key` error. See the ticket for more details.