### PR TITLE
HYC-1814 - Resolve rows not set warning from fileset pages

### DIFF
--- a/app/overrides/presenters/hyrax/file_set_presenter_override.rb
+++ b/app/overrides/presenters/hyrax/file_set_presenter_override.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-# https://github.com/samvera/hyrax/blob/v3.4.2/app/presenters/hyrax/file_set_presenter.rb
+# [hyc-override] https://github.com/samvera/hyrax/blob/hyrax-v4.0.0/app/presenters/hyrax/file_set_presenter.rb
 Hyrax::FileSetPresenter.class_eval do
   def fetch_parent_presenter
-    ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field)
+    # [hyc-override] set a rows field to avoid warnings about no rows being explicitly set
+    ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field, rows: 10)
                             .map { |x| x.fetch(Hyrax.config.id_field) }
     Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.") if ids.empty?
     ids.each do |id|

--- a/app/overrides/presenters/hyrax/file_set_presenter_override.rb
+++ b/app/overrides/presenters/hyrax/file_set_presenter_override.rb
@@ -2,19 +2,19 @@
 # [hyc-override] https://github.com/samvera/hyrax/blob/hyrax-v4.0.0/app/presenters/hyrax/file_set_presenter.rb
 Hyrax::FileSetPresenter.class_eval do
   def fetch_parent_presenter
-    # [hyc-override] set a rows field to avoid warnings about no rows being explicitly set
-    ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field, rows: 10)
+    ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field, rows: 1)
                             .map { |x| x.fetch(Hyrax.config.id_field) }
-    Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.") if ids.empty?
-    ids.each do |id|
-      doc = ::SolrDocument.find(id)
-      next if current_ability.can?(:edit, doc)
-      # [hyc-override] throw exception when suppressed if user CANNOT read the doc, rather than if they can
-      raise Hyrax::WorkflowAuthorizationException if doc.suppressed? && !current_ability.can?(:read, doc)
+    if ids.empty?
+      Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.")
+    else
+      doc = ::SolrDocument.find(ids.first)
+      unless current_ability.can?(:edit, doc)
+        # [hyc-override] throw exception when suppressed if user CANNOT read the doc, rather than if they can
+        raise Hyrax::WorkflowAuthorizationException if doc.suppressed? && !current_ability.can?(:read, doc)
+      end
     end
     Hyrax::PresenterFactory.build_for(ids: ids,
                                       presenter_class: Hyrax::WorkShowPresenter,
                                       presenter_args: current_ability).first
-
   end
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1814

* Set a rows param on file_set query to find parent work so that it won't generate warnings every time