### PR TITLE
HYC-1597 - Eliminating redundant whitespace and preventing duplicate display of countries in Locations autocomplete

### DIFF
--- a/app/overrides/lib/qa/authorities/geonames_override.rb
+++ b/app/overrides/lib/qa/authorities/geonames_override.rb
@@ -6,4 +6,16 @@ Qa::Authorities::Geonames.class_eval do
     query = ERB::Util.url_encode(untaint(q))
     File.join(query_url_host, "searchJSON?q=#{query}&username=#{username}&maxRows=25")
   end
+
+  # [hyc-override] Modification to remove whitespace and only display the name field if the location is a country (fcode == PCLI or PCLS)
+  # https://www.geonames.org/export/codes.html
+  self.label = lambda do |item|
+    if item['fcode'] == 'PCLI' || item['fcode'] == 'PCLS'
+      values = [item['name']]
+    else
+      # Exclude nil, empty string, and whitespace-only values
+      values = [item['name'], item['adminName1'], item['countryName']].reject { |v| v.nil? || v.strip.empty? }
+    end
+    values.join(', ')
+  end
 end

--- a/spec/lib/qa/authorities/geonames_spec.rb
+++ b/spec/lib/qa/authorities/geonames_spec.rb
@@ -12,4 +12,31 @@ describe Qa::Authorities::Geonames do
     subject { authority.build_query_url('foo') }
     it { is_expected.to eq 'http://api.geonames.org/searchJSON?q=foo&username=dummy&maxRows=25' }
   end
+
+  describe '.label' do
+  subject { authority.label.call(item) } 
+  shared_examples 'correct label formatting' do |name, countryName, adminName1, fcode, expected_label|
+    let(:item) do
+      {
+      'name' => name,
+      'countryName' => countryName,
+      'adminName1' => "",
+      'fcode' => fcode
+      }
+    end
+    it "formats the label correctly when fcode is #{fcode}" do
+      is_expected.to eq expected_label
+    end
+  end
+
+  context 'when fcode is not PCLI or PCLS' do
+    include_examples 'correct label formatting', 'Chapel Rock', 'Falkland Islands', '', 'HLL', 'Chapel Rock, Falkland Islands'
+  end
+  context 'when fcode is PCLI' do
+    include_examples 'correct label formatting', 'Canada', 'Canada', '', 'PCLI', 'Canada'
+  end
+  context 'when fcode is PCLS' do
+    include_examples 'correct label formatting', 'Macao', 'Macao', '', 'PCLS', 'Macao'
+  end
+  end
 end

--- a/spec/lib/qa/authorities/geonames_spec.rb
+++ b/spec/lib/qa/authorities/geonames_spec.rb
@@ -14,29 +14,29 @@ describe Qa::Authorities::Geonames do
   end
 
   describe '.label' do
-  subject { authority.label.call(item) } 
-  shared_examples 'correct label formatting' do |name, countryName, adminName1, fcode, expected_label|
-    let(:item) do
-      {
-      'name' => name,
-      'countryName' => countryName,
-      'adminName1' => "",
-      'fcode' => fcode
-      }
+    subject { authority.label.call(item) }
+    shared_examples 'correct label formatting' do |name, countryName, adminName1, fcode, expected_label|
+      let(:item) do
+        {
+        'name' => name,
+        'countryName' => countryName,
+        'adminName1' => '',
+        'fcode' => fcode
+        }
+      end
+      it "formats the label correctly when fcode is #{fcode}" do
+        is_expected.to eq expected_label
+      end
     end
-    it "formats the label correctly when fcode is #{fcode}" do
-      is_expected.to eq expected_label
-    end
-  end
 
-  context 'when fcode is not PCLI or PCLS' do
-    include_examples 'correct label formatting', 'Chapel Rock', 'Falkland Islands', '', 'HLL', 'Chapel Rock, Falkland Islands'
-  end
-  context 'when fcode is PCLI' do
-    include_examples 'correct label formatting', 'Canada', 'Canada', '', 'PCLI', 'Canada'
-  end
-  context 'when fcode is PCLS' do
-    include_examples 'correct label formatting', 'Macao', 'Macao', '', 'PCLS', 'Macao'
-  end
+    context 'when fcode is not PCLI or PCLS' do
+      include_examples 'correct label formatting', 'Chapel Rock', 'Falkland Islands', '', 'HLL', 'Chapel Rock, Falkland Islands'
+    end
+    context 'when fcode is PCLI' do
+      include_examples 'correct label formatting', 'Canada', 'Canada', '', 'PCLI', 'Canada'
+    end
+    context 'when fcode is PCLS' do
+      include_examples 'correct label formatting', 'Macao', 'Macao', '', 'PCLS', 'Macao'
+    end
   end
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1597

made adjustments for entities returned within location autocomplete