### PR TITLE
HYC-1843 - UNC-CH ROR metadata inclusion for new DOIs

### DIFF
--- a/app/services/tasks/doi_create_service.rb
+++ b/app/services/tasks/doi_create_service.rb
@@ -107,7 +107,6 @@ module Tasks
       # Required fields
       #
       #########################
-      # yaml_data = YAML.load(File.read(File.expand_path('../../../../config/authorities/departments.yml', __FILE__)))
       creators = parse_people(work, 'creators')
       data[:data][:attributes][:creators] = if creators.blank?
                                               {
@@ -230,16 +229,7 @@ module Tasks
       values
     end
 
-    # Removing after tests
-    # def log_all_attributes(record)
-    #   record.attributes.each do |attribute, value|
-    #     Rails.logger.error("=========Logging All Attributes For Record Fields=========")
-    #     Rails.logger.error("#{attribute}: #{value}")
-    #   end
-    # end
     def parse_field(record, field)
-      # Removing after tests
-      # log_all_attributes(record)
       record.attributes.keys.member?(field) ? record[field.to_sym] : []
     end
 
@@ -322,8 +312,6 @@ module Tasks
         other_affil = p_json['other_affiliation']&.first
 
         if !affil.blank?
-          # expanded_affils = DepartmentsService.term(affil)
-          # person[:affiliation] = expanded_affils.split('; ') unless expanded_affils.nil?
           person[:affiliation] = [unc_affiliation_metadata]
         elsif !other_affil.blank?
           person[:affiliation] = [other_affil]

--- a/app/services/tasks/doi_create_service.rb
+++ b/app/services/tasks/doi_create_service.rb
@@ -107,29 +107,14 @@ module Tasks
       # Required fields
       #
       #########################
-      yaml_data = YAML.load(File.read(File.expand_path('../../../../config/authorities/departments.yml', __FILE__)))
+      # yaml_data = YAML.load(File.read(File.expand_path('../../../../config/authorities/departments.yml', __FILE__)))
       creators = parse_people(work, 'creators')
-      unc_affiliation_metadata = {
-        "name": "University of North Carolina at Chapel Hill",
-        "schemeUri": "https://ror.org",
-        "affiliationIdentifier": "https://ror.org/0130frc33",
-        "affiliationIdentifierScheme": "ROR"
-        }
       data[:data][:attributes][:creators] = if creators.blank?
                                               {
                                                 name: 'The University of North Carolina at Chapel Hill University Libraries',
                                                 nameType: 'Organizational'
                                               }
                                             else
-                                              short_labels = yaml_data['terms'].map { |term| term['short_label'] }
-                                              creators.each do |creator|
-                                                creator_affiliations = creator[:affiliation]
-                                                if creator_affiliations.any? { |affil| short_labels.include?(affil) }
-                                                  creator[:affiliation] << unc_affiliation_metadata
-                                                end
-                                              end
-                                              # Remove later
-                                              Rails.logger.debug "Contents of creators: #{creators.inspect}"
                                               creators                    
                                             end
 
@@ -245,7 +230,16 @@ module Tasks
       values
     end
 
+    # Removing after tests
+    # def log_all_attributes(record)
+    #   record.attributes.each do |attribute, value|
+    #     Rails.logger.error("=========Logging All Attributes For Record Fields=========")
+    #     Rails.logger.error("#{attribute}: #{value}")
+    #   end
+    # end    
     def parse_field(record, field)
+      # Removing after tests
+      # log_all_attributes(record)
       record.attributes.keys.member?(field) ? record[field.to_sym] : []
     end
 
@@ -313,6 +307,12 @@ module Tasks
       return [] unless work.attributes.keys.member?(person_field)
 
       people = []
+      unc_affiliation_metadata = {
+        "name": "University of North Carolina at Chapel Hill",
+        "schemeUri": "https://ror.org",
+        "affiliationIdentifier": "https://ror.org/0130frc33",
+        "affiliationIdentifierScheme": "ROR"
+        }
 
       work[person_field].each do |p|
         p_json = JSON.parse(p.to_json)
@@ -322,8 +322,9 @@ module Tasks
         other_affil = p_json['other_affiliation']&.first
 
         if !affil.blank?
-          expanded_affils = DepartmentsService.term(affil)
-          person[:affiliation] = expanded_affils.split('; ') unless expanded_affils.nil?
+          # expanded_affils = DepartmentsService.term(affil)
+          # person[:affiliation] = expanded_affils.split('; ') unless expanded_affils.nil?
+          person[:affiliation] = unc_affiliation_metadata
         elsif !other_affil.blank?
           person[:affiliation] = [other_affil]
         end

--- a/app/services/tasks/doi_create_service.rb
+++ b/app/services/tasks/doi_create_service.rb
@@ -115,7 +115,7 @@ module Tasks
                                                 nameType: 'Organizational'
                                               }
                                             else
-                                              creators                    
+                                              creators
                                             end
 
       publisher = parse_field(work, 'publisher')
@@ -236,7 +236,7 @@ module Tasks
     #     Rails.logger.error("=========Logging All Attributes For Record Fields=========")
     #     Rails.logger.error("#{attribute}: #{value}")
     #   end
-    # end    
+    # end
     def parse_field(record, field)
       # Removing after tests
       # log_all_attributes(record)
@@ -308,10 +308,10 @@ module Tasks
 
       people = []
       unc_affiliation_metadata = {
-        "name": "University of North Carolina at Chapel Hill",
-        "schemeUri": "https://ror.org",
-        "affiliationIdentifier": "https://ror.org/0130frc33",
-        "affiliationIdentifierScheme": "ROR"
+        "name": 'University of North Carolina at Chapel Hill',
+        "schemeUri": 'https://ror.org',
+        "affiliationIdentifier": 'https://ror.org/0130frc33',
+        "affiliationIdentifierScheme": 'ROR'
         }
 
       work[person_field].each do |p|

--- a/app/services/tasks/doi_create_service.rb
+++ b/app/services/tasks/doi_create_service.rb
@@ -324,7 +324,7 @@ module Tasks
         if !affil.blank?
           # expanded_affils = DepartmentsService.term(affil)
           # person[:affiliation] = expanded_affils.split('; ') unless expanded_affils.nil?
-          person[:affiliation] = unc_affiliation_metadata
+          person[:affiliation] = [unc_affiliation_metadata]
         elsif !other_affil.blank?
           person[:affiliation] = [other_affil]
         end

--- a/app/services/tasks/doi_create_service.rb
+++ b/app/services/tasks/doi_create_service.rb
@@ -107,14 +107,30 @@ module Tasks
       # Required fields
       #
       #########################
+      yaml_data = YAML.load(File.read(File.expand_path('../../../../config/authorities/departments.yml', __FILE__)))
       creators = parse_people(work, 'creators')
+      unc_affiliation_metadata = {
+        "name": "University of North Carolina at Chapel Hill",
+        "schemeUri": "https://ror.org",
+        "affiliationIdentifier": "https://ror.org/0130frc33",
+        "affiliationIdentifierScheme": "ROR"
+        }
       data[:data][:attributes][:creators] = if creators.blank?
                                               {
                                                 name: 'The University of North Carolina at Chapel Hill University Libraries',
                                                 nameType: 'Organizational'
                                               }
                                             else
-                                              creators
+                                              short_labels = yaml_data['terms'].map { |term| term['short_label'] }
+                                              creators.each do |creator|
+                                                creator_affiliations = creator[:affiliation]
+                                                if creator_affiliations.any? { |affil| short_labels.include?(affil) }
+                                                  creator[:affiliation] << unc_affiliation_metadata
+                                                end
+                                              end
+                                              # Remove later
+                                              Rails.logger.debug "Contents of creators: #{creators.inspect}"
+                                              creators                    
                                             end
 
       publisher = parse_field(work, 'publisher')

--- a/spec/services/tasks/doi_create_service_spec.rb
+++ b/spec/services/tasks/doi_create_service_spec.rb
@@ -118,6 +118,8 @@ RSpec.describe Tasks::DoiCreateService do
         # method uses first element in array, and rdf does not preserve order
         expect(['Video', 'Honors Thesis', 'Journal']).to include JSON.parse(result)['data']['attributes']['types']['resourceType']
         expect(['Audiovisual', 'Text']).to include JSON.parse(result)['data']['attributes']['types']['resourceTypeGeneral']
+        # Remove later
+        puts "Test Output: #{JSON.parse(result)['data']['attributes']['creators']}"
         expect(JSON.parse(result)['data']['attributes']['creators']).to match_array [{ 'name' => 'Person, Test',
                                                                                        'nameType' => 'Personal',
                                                                                        'affiliation' => ['College of Arts and Sciences', 'Department of Biology'],

--- a/spec/services/tasks/doi_create_service_spec.rb
+++ b/spec/services/tasks/doi_create_service_spec.rb
@@ -120,7 +120,12 @@ RSpec.describe Tasks::DoiCreateService do
         expect(['Audiovisual', 'Text']).to include JSON.parse(result)['data']['attributes']['types']['resourceTypeGeneral']
         expect(JSON.parse(result)['data']['attributes']['creators']).to match_array [{ 'name' => 'Person, Test',
                                                                                        'nameType' => 'Personal',
-                                                                                       'affiliation' => ['College of Arts and Sciences', 'Department of Biology'],
+                                                                                       'affiliation' => [{
+                                                                                        'name' => 'University of North Carolina at Chapel Hill',
+                                                                                        'schemeUri' => 'https://ror.org',
+                                                                                        'affiliationIdentifier' => 'https://ror.org/0130frc33',
+                                                                                        'affiliationIdentifierScheme'=> 'ROR'
+                                                                                        }],
                                                                                        'nameIdentifiers' => [{ 'nameIdentifier' => 'some orcid',
                                                                                                                'nameIdentifierScheme' => 'ORCID' }] },
                                                                                      { 'name' => 'Person, Non-UNC',
@@ -152,7 +157,12 @@ RSpec.describe Tasks::DoiCreateService do
         expect(JSON.parse(result)['data']['attributes']['types']['resourceTypeGeneral']).to eq 'Text'
         expect(JSON.parse(result)['data']['attributes']['creators']).to match_array [{ 'name' => 'Person, Test',
                                                                                        'nameType' => 'Personal',
-                                                                                       'affiliation' => ['College of Arts and Sciences', 'Department of Biology'],
+                                                                                       'affiliation' => [{
+                                                                                        'name' => 'University of North Carolina at Chapel Hill',
+                                                                                        'schemeUri' => 'https://ror.org',
+                                                                                        'affiliationIdentifier' => 'https://ror.org/0130frc33',
+                                                                                        'affiliationIdentifierScheme'=> 'ROR'
+                                                                                        }],
                                                                                        'nameIdentifiers' => [{ 'nameIdentifier' => 'some orcid',
                                                                                                                'nameIdentifierScheme' => 'ORCID' }] }]
         expect(JSON.parse(result)['data']['attributes']['publisher']).to eq 'Some Publisher'
@@ -180,7 +190,12 @@ RSpec.describe Tasks::DoiCreateService do
         expect(JSON.parse(result)['data']['attributes']['types']['resourceTypeGeneral']).to eq 'Image'
         expect(JSON.parse(result)['data']['attributes']['creators']).to match_array [{ 'name' => 'Person, Test',
                                                                                        'nameType' => 'Personal',
-                                                                                       'affiliation' => ['College of Arts and Sciences', 'Department of Biology'],
+                                                                                       'affiliation' => [{
+                                                                                        'name' => 'University of North Carolina at Chapel Hill',
+                                                                                        'schemeUri' => 'https://ror.org',
+                                                                                        'affiliationIdentifier' => 'https://ror.org/0130frc33',
+                                                                                        'affiliationIdentifierScheme'=> 'ROR'
+                                                                                        }],
                                                                                        'nameIdentifiers' => [{ 'nameIdentifier' => 'some orcid',
                                                                                                                'nameIdentifierScheme' => 'ORCID' }] }]
         expect(JSON.parse(result)['data']['attributes']['publisher']).to eq 'Some Publisher'

--- a/spec/services/tasks/doi_create_service_spec.rb
+++ b/spec/services/tasks/doi_create_service_spec.rb
@@ -118,8 +118,6 @@ RSpec.describe Tasks::DoiCreateService do
         # method uses first element in array, and rdf does not preserve order
         expect(['Video', 'Honors Thesis', 'Journal']).to include JSON.parse(result)['data']['attributes']['types']['resourceType']
         expect(['Audiovisual', 'Text']).to include JSON.parse(result)['data']['attributes']['types']['resourceTypeGeneral']
-        # Remove later
-        puts "Test Output: #{JSON.parse(result)['data']['attributes']['creators']}"
         expect(JSON.parse(result)['data']['attributes']['creators']).to match_array [{ 'name' => 'Person, Test',
                                                                                        'nameType' => 'Personal',
                                                                                        'affiliation' => ['College of Arts and Sciences', 'Department of Biology'],


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1843

- Modified parse_people function in DOI creation service to include UNC ROR metadata
- Updating tests for creation service to check for the ROR information instead of department terms