### PR TITLE
HYC-1861 - Reduce logging of common errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   rescue_from Riiif::ImageNotFoundError, with: :render_riiif_404
   rescue_from Blacklight::Exceptions::RecordNotFound, with: :render_404
   rescue_from Hyrax::ObjectNotFoundError, with: :render_404
+  rescue_from Ldp::Gone, with: :render_404
   rescue_from ActiveFedora::ObjectNotFoundError, with: :render_404
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_401
   rescue_from ActionController::UnknownFormat, with: :render_404
@@ -45,7 +46,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404
-    render 'errors/not_found', status: 404, formats: :html
+    render 'errors/not_found', status: 404, formats: :html, layout: 'layouts/hyrax/1_column'
   end
 
   def render_500

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,8 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveFedora::ObjectNotFoundError, with: :render_404
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_401
   rescue_from ActionController::UnknownFormat, with: :render_404
+  rescue_from Riiif::ConversionError, with: :render_400
+  rescue_from Faraday::TimeoutError, with: :render_408
 
   protected
 
@@ -48,6 +50,10 @@ class ApplicationController < ActionController::Base
 
   def render_404
     render 'errors/not_found', status: 404, formats: :html, layout: 'layouts/hyrax/1_column'
+  end
+
+  def render_408
+    head :request_timeout
   end
 
   def render_500

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   rescue_from Riiif::ImageNotFoundError, with: :render_riiif_404
   rescue_from Blacklight::Exceptions::RecordNotFound, with: :render_404
   rescue_from Hyrax::ObjectNotFoundError, with: :render_404
+  rescue_from BlacklightRangeLimit::InvalidRange, with: :render_400
   rescue_from Ldp::Gone, with: :render_404
   rescue_from ActiveFedora::ObjectNotFoundError, with: :render_404
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_401

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -16,6 +16,7 @@ module ActionDispatch
       return true if wrapper.exception.is_a? ActionController::BadRequest
       return true if wrapper.exception.is_a? ActionDispatch::Http::Parameters::ParseError
       return true if wrapper.exception.is_a? ActionDispatch::Http::MimeNegotiation::InvalidType
+      return true if wrapper.exception.is_a? Ldp::Gone
       return false
     end
   end

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -4,11 +4,19 @@ module ActionDispatch
   class DebugExceptions
     alias_method :old_log_error, :log_error
     def log_error(request, wrapper)
-      if wrapper.exception.is_a?  ActionController::RoutingError
+      if should_reduce_log_level?(wrapper)
         logger(request).send(:warn, "[404] #{wrapper.exception.class.name} (#{wrapper.exception.message})")
       else
         old_log_error request, wrapper
       end
+    end
+
+    def should_reduce_log_level?(wrapper)
+      return true if wrapper.exception.is_a? ActionController::RoutingError
+      return true if wrapper.exception.is_a? ActionController::BadRequest
+      return true if wrapper.exception.is_a? ActionDispatch::Http::Parameters::ParseError
+      return true if wrapper.exception.is_a? ActionDispatch::Http::MimeNegotiation::InvalidType
+      return false
     end
   end
 end

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -1,0 +1,14 @@
+# [hyc-override] Downgrading certain errors that we do not need to receive as FATAL
+# https://github.com/rails/rails/blob/v6.1.7.6/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+module ActionDispatch
+  class DebugExceptions
+    alias_method :old_log_error, :log_error
+    def log_error(request, wrapper)
+      if wrapper.exception.is_a?  ActionController::RoutingError
+        logger(request).send(:warn, "[404] #{wrapper.exception.class.name} (#{wrapper.exception.message})")
+      else
+        old_log_error request, wrapper
+      end
+    end
+  end
+end

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -7,7 +7,7 @@ module ActionDispatch
       if should_reduce_log_level?(wrapper)
         logger(request).send(:warn, "[404] #{wrapper.exception.class.name} (#{wrapper.exception.message})")
       else
-        old_log_error request, wrapper
+        old_log_error(request, wrapper)
       end
     end
 

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # [hyc-override] Downgrading certain errors that we do not need to receive as FATAL
 # https://github.com/rails/rails/blob/v6.1.7.6/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
 module ActionDispatch

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -18,6 +18,7 @@ module ActionDispatch
       return true if wrapper.exception.is_a? ActionDispatch::Http::MimeNegotiation::InvalidType
       return true if wrapper.exception.is_a? Ldp::Gone
       return true if wrapper.exception.is_a? BlacklightRangeLimit::InvalidRange
+      return true if wrapper.exception.is_a? Riiif::ConversionError
       return false
     end
   end

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -17,6 +17,7 @@ module ActionDispatch
       return true if wrapper.exception.is_a? ActionDispatch::Http::Parameters::ParseError
       return true if wrapper.exception.is_a? ActionDispatch::Http::MimeNegotiation::InvalidType
       return true if wrapper.exception.is_a? Ldp::Gone
+      return true if wrapper.exception.is_a? BlacklightRangeLimit::InvalidRange
       return false
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  describe 'handling Faraday::TimeoutError' do
+    controller(ApplicationController) do
+      def index
+        raise Faraday::TimeoutError, 'Connection timed out'
+      end
+    end
+
+    it 'renders a 408 response' do
+      get :index
+      expect(response).to have_http_status(:request_timeout)
+    end
+  end
+end

--- a/spec/features/edit_sage_ingested_works_spec.rb
+++ b/spec/features/edit_sage_ingested_works_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature 'Edit works created through the Sage ingest', :sage, js: false do
       end
     end
   end
-  
+
   context 'with file 2' do
     before do
       FileUtils.cp('spec/fixtures/sage/GSJ_2021_11_1_10.1177_2192568219888179.zip', ingest_from_dir)

--- a/spec/features/edit_sage_ingested_works_spec.rb
+++ b/spec/features/edit_sage_ingested_works_spec.rb
@@ -6,23 +6,22 @@ include Warden::Test::Helpers
 RSpec.feature 'Edit works created through the Sage ingest', :sage, js: false do
   let(:ingest_progress_log_path) { File.join(Rails.configuration.log_directory, 'sage_progress.log') }
   let(:path_to_tmp) { FileUtils.mkdir_p(File.join(fixture_path, 'sage', 'tmp')).first }
+  let(:ingest_from_dir) { Dir.mktmpdir }
   let(:config) {
     {
       'unzip_dir' => 'spec/fixtures/sage/tmp',
-      'package_dir' => 'spec/fixtures/sage',
+      'package_dir' => ingest_from_dir.to_s,
       'admin_set' => 'Open_Access_Articles_and_Book_Chapters',
       'depositor_onyen' => 'admin'
     }
   }
   let(:status_service) { Tasks::IngestStatusService.new(File.join(path_to_tmp, 'deposit_status.json')) }
   let(:ingest_service) { Tasks::SageIngestService.new(config, status_service) }
-  let(:article_count) { Article.count }
   let(:articles) { Article.all }
   # We're not clearing out the database, Fedora, and Solr before this test, so to find the first work created in this
   # test, we need to count backwards from the last work created.
-  let(:first_work) { articles[-4] }
-  let(:first_work_id) { first_work.id }
-  let(:third_work_id) { articles[-2].id }
+  let(:work)  { articles[-1] }
+  let(:work_id) { work.id }
 
   let(:permission_template) do
     FactoryBot.create(:permission_template, source_id: admin_set.id)
@@ -46,6 +45,7 @@ RSpec.feature 'Edit works created through the Sage ingest', :sage, js: false do
     example.run
     File.open(ingest_progress_log_path, 'w') { |file| file.truncate(0) }
     FileUtils.remove_entry(path_to_tmp)
+    FileUtils.remove_entry(ingest_from_dir)
   end
 
   before(:each) do
@@ -66,74 +66,87 @@ RSpec.feature 'Edit works created through the Sage ingest', :sage, js: false do
     permission_template
     workflow
     workflow_state
-    ingest_service.process_all_packages
   end
 
-  context 'as a regular user' do
-    let(:user) { FactoryBot.create(:user) }
-    it 'gives an unauthorized message' do
-      login_as user
-      visit "concern/articles/#{first_work_id}/edit"
-      expect(page).to have_content('Unauthorized')
-    end
-  end
-
-  context 'as an admin user' do
-    it 'can open the edit page' do
-      login_as admin
-      visit "concern/articles/#{first_work_id}"
-      expect(page).to have_content('Inequalities in Cervical Cancer Screening Uptake Between')
-      expect(page).to have_content('Smith, Jennifer S.')
-      expect(page).to have_content('Open_Access_Articles_and_Book_Chapters')
-      expect(page).to have_content('Attribution-NonCommercial 4.0 International')
-      expect(page).to have_content('February 1, 2021')
-      expect(page).to have_content('In Copyright')
-      # expect(page).to have_button('Withdraw')
-      click_link('Edit', match: :first)
-      expect(page).to have_link('Work Deposit Form')
+  context 'with article 1' do
+    before do
+      FileUtils.cp('spec/fixtures/sage/CCX_2021_28_10.1177_1073274820985792.zip', ingest_from_dir)
+      ingest_service.process_all_packages
     end
 
-    # Creator 2 only visible with Javascript on
-    it 'can render the pre-populated edit page', js: true do
-      login_as admin
-      visit "concern/articles/#{first_work_id}/edit"
-      # These values are also tested in the spec/services/tasks/sage_ingest_service_spec.rb
-      # form order
-      expect(page).to have_field('Title', with: 'Inequalities in Cervical Cancer Screening Uptake Between Chinese Migrant Women and Local Women: A Cross-Sectional Study')
-      expect(page).to have_field('Creator #1', with: 'Holt, Hunter K.')
+    context 'as a regular user' do
+      let(:user) { FactoryBot.create(:user) }
+      it 'gives an unauthorized message' do
+        login_as user
+        visit "concern/articles/#{work_id}/edit"
+        expect(page).to have_content('Unauthorized')
+      end
+    end
+
+    context 'as an admin user' do
+      it 'can open the edit page' do
+        login_as admin
+        visit "concern/articles/#{work_id}"
+        expect(page).to have_content('Inequalities in Cervical Cancer Screening Uptake Between')
+        expect(page).to have_content('Smith, Jennifer S.')
+        expect(page).to have_content('Open_Access_Articles_and_Book_Chapters')
+        expect(page).to have_content('Attribution-NonCommercial 4.0 International')
+        expect(page).to have_content('February 1, 2021')
+        expect(page).to have_content('In Copyright')
+        # expect(page).to have_button('Withdraw')
+        click_link('Edit', match: :first)
+        expect(page).to have_link('Work Deposit Form')
+      end
+
       # Creator 2 only visible with Javascript on
-      expect(page).to have_field('Creator #2', with: 'Zhang, Xi')
-      expect(page).to have_field('Additional affiliation (Creator #1)', with: 'Department of Family and Community Medicine, University of California, San Francisco, CA, USA')
-      expect(page).to have_field('ORCID (Creator #1)', with: 'https://orcid.org/0000-0001-6833-8372')
-      expect(page).to have_field('Abstract', with: /Efforts to increase education opportunities, provide insurance/)
-      click_link('Optional fields')
-      # alpha order below
-      expect(page).to have_field('Copyright date', with: '2021')
-      expect(page).to have_field('Date of publication', with: 'February 1, 2021') # aka date_issued
-      expect(page).to have_select('Dcmi type', with_selected: 'Text')
-      expect(page).to have_field('Funder', with: 'Fogarty International Center')
-      expect(page).to have_field('Identifier', with: 'https://doi.org/10.1177/1073274820985792')
-      expect(page).to have_field('ISSN', with: '1073-2748')
-      expect(page).to have_field('Journal issue', with: '')
-      expect(page).to have_field('Journal title', with: 'Cancer Control')
-      expect(page).to have_field('Journal volume', with: '28')
-      # keywords
-      expected_keywords = ['HPV', 'HPV knowledge and awareness', 'cervical cancer screening', 'migrant women', 'China', '']
-      keyword_fields = page.all(:css, '.article_keyword input')
-      keywords = keyword_fields.map(&:value)
-      expect(keyword_fields.count).to eq 6
-      expect(keywords).to match_array(expected_keywords)
-      expect(page).to have_select('License', with_selected: 'Attribution-NonCommercial 4.0 International')
-      expect(page).to have_field('Publisher', with: 'SAGE Publications')
-      expect(page).to have_select('Resource type', with_selected: 'Article')
-      expect(page).to have_field('Rights holder', with: /SAGE Publications Inc, unless otherwise noted. Manuscript/)
-      expect(page).to have_select('Rights statement', with_selected: 'In Copyright')
-      expect(page).to have_checked_field('Public')
+      it 'can render the pre-populated edit page', js: true do
+        login_as admin
+        visit "concern/articles/#{work_id}/edit"
+        # These values are also tested in the spec/services/tasks/sage_ingest_service_spec.rb
+        # form order
+        expect(page).to have_field('Title', with: 'Inequalities in Cervical Cancer Screening Uptake Between Chinese Migrant Women and Local Women: A Cross-Sectional Study')
+        expect(page).to have_field('Creator #1', with: 'Holt, Hunter K.')
+        # Creator 2 only visible with Javascript on
+        expect(page).to have_field('Creator #2', with: 'Zhang, Xi')
+        expect(page).to have_field('Additional affiliation (Creator #1)', with: 'Department of Family and Community Medicine, University of California, San Francisco, CA, USA')
+        expect(page).to have_field('ORCID (Creator #1)', with: 'https://orcid.org/0000-0001-6833-8372')
+        expect(page).to have_field('Abstract', with: /Efforts to increase education opportunities, provide insurance/)
+
+        # Javascript execution is inconsistent in the test environment, so rather than expanding the rest
+        # of the form elements, checking for the remainder of the elements whether they are visible or not.
+        expect(page).to have_field('Date of publication', with: 'February 1, 2021', visible: :all) # aka date_issued
+        expect(page).to have_select('Dcmi type', with_selected: 'Text', visible: :all)
+        expect(page).to have_field('Funder', with: 'Fogarty International Center', visible: :all)
+        expect(page).to have_field('Identifier', with: 'https://doi.org/10.1177/1073274820985792', visible: :all)
+        expect(page).to have_field('ISSN', with: '1073-2748', visible: :all)
+        expect(page).to have_field('Journal issue', with: '', visible: :all)
+        expect(page).to have_field('Journal title', with: 'Cancer Control', visible: :all)
+        expect(page).to have_field('Journal volume', with: '28', visible: :all)
+        # keywords
+        expected_keywords = ['HPV', 'HPV knowledge and awareness', 'cervical cancer screening', 'migrant women', 'China', '']
+        keyword_fields = page.all(:css, '.article_keyword input', visible: :all)
+        keywords = keyword_fields.map(&:value)
+        expect(keyword_fields.count).to eq 6
+        expect(keywords).to match_array(expected_keywords)
+        expect(page).to have_select('License', with_selected: 'Attribution-NonCommercial 4.0 International', visible: :all)
+        expect(page).to have_field('Publisher', with: 'SAGE Publications', visible: :all)
+        expect(page).to have_select('Resource type', with_selected: 'Article', visible: :all)
+        expect(page).to have_field('Rights holder', with: /SAGE Publications Inc, unless otherwise noted. Manuscript/, visible: :all)
+        expect(page).to have_select('Rights statement', with_selected: 'In Copyright', visible: :all)
+        expect(page).to have_checked_field('Public', visible: :all)
+      end
+    end
+  end
+  
+  context 'with file 2' do
+    before do
+      FileUtils.cp('spec/fixtures/sage/GSJ_2021_11_1_10.1177_2192568219888179.zip', ingest_from_dir)
+      ingest_service.process_all_packages
     end
 
     it 'can render values only present on the second work' do
       login_as admin
-      visit "concern/articles/#{third_work_id}/edit"
+      visit "concern/articles/#{work_id}/edit"
       expect(page).to have_field('Title', with: /The Prevalence of Bacterial Infection in Patients Undergoing/)
       # date that includes only month and year on the edit page
       expect(page).to have_field('Date of publication', with: 'January 2021') # aka date_issued

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,8 @@ require 'rspec/rails'
 require 'webmock/rspec'
 
 WebMock.disable_net_connect!(allow_localhost: true, allow: ['fedora:8080', 'solr8:8983', 'fcrepo:8080', 'solr:8983', 'opaquenamespace.org',
-                                                            'googlechromelabs.github.io', 'chromedriver.storage.googleapis.com', 'https://edgedl.me.gvt1.com'])
+                                                            'googlechromelabs.github.io', 'chromedriver.storage.googleapis.com', 'https://edgedl.me.gvt1.com',
+                                                            'storage.googleapis.com'])
 Capybara.default_normalize_ws = true
 
 # Add additional requires below this line. Rails is not loaded until this point!


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1861

* Reduces logging of a number of errors from FATAL to WARN without a full stack trace
* Directs additional errors to appropriate error pages
* Ensures 404 errors use the correct layout, otherwise some errors (such as Ldp::Gone on an edit link) will fail since they try to use the dashboard layout, which throws an error if the user isn't logged in.
* Adds additional chromedriver url to list of real URLs allowed to be accessed during tests, since it keeps moving around and causing tests to fail
* Gets `edit_sage_ingested_works_spec.rb` to pass locally again, which was failing due to javascript not executing. This came to my attention because the test failed in ghactions due to the chromedriver issue. Refactors it to only ingest one work at a time instead of every single Sage work for each test, since otherwise the test takes 5-6 minutes to run locally.