### PR TITLE
HYC-1862 - Update RIIIF and set cache_store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'pg', '~> 1.3.5'
 gem 'rails', '~> 6.0'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.5.0'
-gem 'riiif', '~> 2.4.0'
+gem 'riiif', '~> 2.5.0'
 gem 'roo', '~>2.9.0'
 gem 'rsolr', '~> 2.5.0'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -841,7 +841,7 @@ GEM
       railties (>= 5.2)
     retriable (3.1.2)
     rexml (3.2.6)
-    riiif (2.4.0)
+    riiif (2.5.0)
       deprecation (>= 1.0.0)
       iiif-image-api (>= 0.1.0)
       railties (>= 4.2, < 8)
@@ -1114,7 +1114,7 @@ DEPENDENCIES
   puma
   rails (~> 6.0)
   redis (~> 4.5.0)
-  riiif (~> 2.4.0)
+  riiif (~> 2.5.0)
   roo (~> 2.9.0)
   rsolr (~> 2.5.0)
   rspec-mocks

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,6 +51,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :file_store, "#{ENV['TEMP_STORAGE']}/rails/cache"
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :sidekiq

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -10,11 +10,11 @@ ActiveSupport::Reloader.to_prepare do
   Riiif::Image.file_resolver.id_to_uri = if Hyrax.config.use_valkyrie?
                                          # Use Valkyrie adapter to make sure file is available locally. Riiif will just open it then
                                          # id comes in with the format "FILE_SET_ID/files/FILE_ID"
-                                         lambda do |id|
-                                           file_metadata = Hyrax.query_service.find_by(id: id.split('/').last)
-                                           file = Hyrax.storage_adapter.find_by(id: file_metadata.file_identifier)
-                                           file.disk_path.to_s
-                                         end
+                                           lambda do |id|
+                                             file_metadata = Hyrax.query_service.find_by(id: id.split('/').last)
+                                             file = Hyrax.storage_adapter.find_by(id: file_metadata.file_identifier)
+                                             file.disk_path.to_s
+                                           end
                                        else
                                          lambda do |id|
                                            Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -7,11 +7,21 @@ ActiveSupport::Reloader.to_prepare do
   Rails.logger.debug('[ImageProcessor] calling ImageService.external_identify_command from Riiif initializer')
   Riiif::ImageMagickInfoExtractor.external_command = ImageService.external_identify_command
 
-  Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-    ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
-      logger.info "Riiif resolved #{id} to #{url}"
-    end
-  end
+  Riiif::Image.file_resolver.id_to_uri = if Hyrax.config.use_valkyrie?
+                                         # Use Valkyrie adapter to make sure file is available locally. Riiif will just open it then
+                                         # id comes in with the format "FILE_SET_ID/files/FILE_ID"
+                                         lambda do |id|
+                                           file_metadata = Hyrax.query_service.find_by(id: id.split('/').last)
+                                           file = Hyrax.storage_adapter.find_by(id: file_metadata.file_identifier)
+                                           file.disk_path.to_s
+                                         end
+                                       else
+                                         lambda do |id|
+                                           Hyrax::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+                                             Rails.logger.info "Riiif resolved #{id} to #{url}"
+                                           end
+                                         end
+                                       end
 
   Riiif::Image.info_service = lambda do |id, _file|
     # id will look like a path to a pcdm:file
@@ -27,7 +37,8 @@ ActiveSupport::Reloader.to_prepare do
     {
       height: doc['height_is'] || 100,
       width: doc['width_is'] || 100,
-      format: doc['mime_type_ssi']
+      format: doc['mime_type_ssi'],
+      channels: doc['alpha_channels_ssi']
     }
   end
 


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1862

* Updates RIIIF to most recent version and syncs initializer up hyrax 4 version of the file (with our local modification retained)
* Sets a rails cache_store for production environments, so that caching will go to a path more consistent with the rest of the application