### PR TITLE
HYC-1890 - Fix oai undefined method utc error

### DIFF
--- a/app/overrides/blacklight_oai_provider/resumption_token_override.rb
+++ b/app/overrides/blacklight_oai_provider/resumption_token_override.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# [hyc-override] https://github.com/projectblacklight/blacklight_oai_provider/blob/v7.0.2/lib/blacklight_oai_provider/resumption_token.rb
+BlacklightOaiProvider::ResumptionToken.class_eval do
+  def encode_conditions
+    encoded_token = @prefix.to_s.dup
+    encoded_token << ".s(#{set})" if set
+    # [hyc-override] only call utc if it is supported, which is not the case for Date objects
+    encoded_token << ".f(#{date_field_value(from)})" if from
+    encoded_token << ".u(#{date_field_value(self.until)})" if self.until
+    encoded_token << ".t(#{total})" if total
+    encoded_token << ":#{last}"
+  end
+
+  def date_field_value(date_field)
+    if from.respond_to?(:utc)
+      return date_field.utc.xmlschema
+    else
+      return date_field.xmlschema
+    end
+  end
+end

--- a/spec/requests/oai_pmh_endpoint_spec.rb
+++ b/spec/requests/oai_pmh_endpoint_spec.rb
@@ -99,6 +99,17 @@ RSpec.describe 'OAI-PMH catalog endpoint' do
         expect(token.count).to be 1
         expect(token.text).to be_empty
       end
+
+      scenario 'a resumption token is provided when a "from" parameter has a date value' do
+        params = { verb: 'ListRecords', metadataPrefix: format, from: '2010-01-01' }
+        expected_token = "oai_dc.f(2010-01-01T00:00:00Z).u(2021-11-23T00:00:00Z).t(#{timestamps.count}):25"
+        get oai_catalog_path(params)
+        token = xpath '//xmlns:resumptionToken'
+        records = xpath '//xmlns:record'
+
+        expect(records.count).to be 25
+        expect(token.text).to eq expected_token
+      end
     end
 
     context 'with a set' do


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1890

Override ResumptionToken in order to handle error when a date is provided, rather than a datetime. Also handle until field. Add test