### PR TITLE
HYC-1894 - Handle null character in download URLs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,8 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::UnknownFormat, with: :render_404
   rescue_from Riiif::ConversionError, with: :render_400
   rescue_from Faraday::TimeoutError, with: :render_408
+  rescue_from ArgumentError, with: :render_400
+  rescue_from URI::InvalidURIError, with: :render_400
 
   protected
 

--- a/config/initializers/routing_error_logger_defatalizer.rb
+++ b/config/initializers/routing_error_logger_defatalizer.rb
@@ -20,13 +20,15 @@ module ActionDispatch
       ActionDispatch::Http::MimeNegotiation::InvalidType,
       ActionDispatch::Http::Parameters::ParseError,
       ActiveFedora::ObjectNotFoundError,
+      ArgumentError,
       Blacklight::Exceptions::RecordNotFound,
       BlacklightRangeLimit::InvalidRange,
       Faraday::TimeoutError,
       Hyrax::ObjectNotFoundError,
       Ldp::Gone,
       Riiif::ConversionError,
-      Riiif::ImageNotFoundError
+      Riiif::ImageNotFoundError,
+      URI::InvalidURIError
     ].to_set
 
     def should_reduce_log_level?(wrapper)


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1894

* Handle null character in file parameter and in other parts of the requested URL, which addressed "ArgumentError (path name contains null byte)" errors