### PR TITLE
HYC-1895 - Prevent error when logged in with invalid locale

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -79,7 +79,7 @@ module Hyrax::Controller
     I18n.locale = params[:locale] || I18n.default_locale
   rescue I18n::InvalidLocale => e
     I18n.locale = I18n.default_locale
-    params[:locale] = I18n.default_locale
+    params[:locale] = I18n.default_locale.to_s
   end
 
   # Called by Hydra::Controller::ControllerBehavior when CanCan::AccessDenied is caught

--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -77,8 +77,9 @@ module Hyrax::Controller
   # [hyc-override] Add begin/rescue for locale setting
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
-  rescue I18n::InvalidLocale
+  rescue I18n::InvalidLocale => e
     I18n.locale = I18n.default_locale
+    params[:locale] = I18n.default_locale
   end
 
   # Called by Hydra::Controller::ControllerBehavior when CanCan::AccessDenied is caught

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -32,4 +32,24 @@ RSpec.describe ApplicationController, type: :controller do
       expect(subject.instance_variable_get(:@params)[:f]).to eq(ActionController::Parameters.new({'resource_type_sim' => ['Article']}))
     end
   end
+
+  describe '#set_locale' do
+    controller(ApplicationController) do
+      def index
+        @params = params
+      end
+    end
+
+    it 'retains valid locale' do
+      get :index, params: { locale: 'fr' }
+      expect(I18n.locale).to eq :fr
+      expect(subject.instance_variable_get(:@params)[:locale]).to eq 'fr'
+    end
+
+    it 'overrides invalid locale' do
+      get :index, params: { locale: 'http://example.com/why' }
+      expect(I18n.locale).to eq :en
+      expect(subject.instance_variable_get(:@params)[:locale]).to eq 'en'
+    end
+  end
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1895

* Change the locale param too when an invalid value is provided, so that other parts of the code base that directly access it rather than `I18n.locale` won't receive an invalid locale, such as render_notifications