### PR TITLE
HYC-1896 - Decode equal signs in query string before parsing params

### DIFF
--- a/app/middleware/decode_query_string.rb
+++ b/app/middleware/decode_query_string.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class DecodeQueryString
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env['QUERY_STRING']
+      # Decode the '%3D' character
+      query_string = URI.decode_www_form_component(env['QUERY_STRING']).gsub('%3D', '=')
+      env['QUERY_STRING'] = query_string
+    end
+    @app.call(env)
+  end
+end

--- a/app/middleware/decode_query_string.rb
+++ b/app/middleware/decode_query_string.rb
@@ -7,7 +7,7 @@ class DecodeQueryString
   def call(env)
     if env['QUERY_STRING']
       # Decode the '%3D' character
-      query_string = URI.decode_www_form_component(env['QUERY_STRING']).gsub('%3D', '=')
+      query_string = env['QUERY_STRING'].gsub('%5D%3D', '%5D=')
       env['QUERY_STRING'] = query_string
     end
     @app.call(env)

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,8 @@ module Hyrax
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end
+
+    require_relative '../app/middleware/decode_query_string'
+    config.middleware.insert_before Rack::Runtime, DecodeQueryString
   end
 end

--- a/spec/middleware/decode_query_string_spec.rb
+++ b/spec/middleware/decode_query_string_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DecodeQueryString do
 
     context 'query string with encoded equal sign' do
       let(:env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D%3DPharmacogenetics&locale=en' } }
-      let(:decoded_env) { { 'QUERY_STRING' => 'f[keyword_sim][]=Pharmacogenetics&locale=en' } }
+      let(:decoded_env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D=Pharmacogenetics&locale=en' } }
 
       it 'decodes the %3D character in the query string' do
         middleware = DecodeQueryString.new(app)
@@ -21,9 +21,22 @@ RSpec.describe DecodeQueryString do
       end
     end
 
+    context 'query string with encoded equal in middle of param' do
+      let(:env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D=Pharmacoge%3Dnetics&locale=en' } }
+      let(:decoded_env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D=Pharmacoge%3Dnetics&locale=en' } }
+
+      it 'leaves query string unchanged' do
+        middleware = DecodeQueryString.new(app)
+        middleware.call(env)
+
+        expect(app).to have_received(:call).with(decoded_env)
+      end
+    end
+
+
     context 'query string with decoded equal sign' do
       let(:env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D=Pharmaco=genetics&locale=en' } }
-      let(:decoded_env) { { 'QUERY_STRING' => 'f[keyword_sim][]=Pharmaco=genetics&locale=en' } }
+      let(:decoded_env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D=Pharmaco=genetics&locale=en' } }
 
       it 'leaves query string unchanged' do
         middleware = DecodeQueryString.new(app)

--- a/spec/middleware/decode_query_string_spec.rb
+++ b/spec/middleware/decode_query_string_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DecodeQueryString do
+  describe '#call' do
+    let(:app) { double('app') }
+
+    before do
+      allow(app).to receive(:call).and_return({})
+    end
+
+    context 'query string with encoded equal sign' do
+      let(:env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D%3DPharmacogenetics&locale=en' } }
+      let(:decoded_env) { { 'QUERY_STRING' => 'f[keyword_sim][]=Pharmacogenetics&locale=en' } }
+
+      it 'decodes the %3D character in the query string' do
+        middleware = DecodeQueryString.new(app)
+        middleware.call(env)
+
+        expect(app).to have_received(:call).with(decoded_env)
+      end
+    end
+
+    context 'query string with decoded equal sign' do
+      let(:env) { { 'QUERY_STRING' => 'f%5Bkeyword_sim%5D%5B%5D=Pharmaco=genetics&locale=en' } }
+      let(:decoded_env) { { 'QUERY_STRING' => 'f[keyword_sim][]=Pharmaco=genetics&locale=en' } }
+
+      it 'leaves query string unchanged' do
+        middleware = DecodeQueryString.new(app)
+        middleware.call(env)
+
+        expect(app).to have_received(:call).with(decoded_env)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1896

Add middleware which decodes equal signs in query strings prior to parameter parsing, to prevent failures when the equal sign separator between the param name and value is encoded

For example, prior to this PR this request fails:
`/catalog?f%5Bkeyword_sim%5D%5B%5D%3DPharmacogenetics&locale=en`

This PR results the query string becoming:
`/catalog?f%5Bkeyword_sim%5D%5B%5D=Pharmacogenetics&locale=en`
So that param parsing will correctly be able to parse out the keyword_sim = Pharmacogenetics search