### PR TITLE
HYC-1934 - Send download events to database

### DIFF
--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -64,7 +64,9 @@ module Hyc
         admin_set_id = @admin_set_name
         work_type = fetch_record.dig(0, 'has_model_ssim', 0)
         date = Date.today
-        download_count = 1
+        
+        Rails.logger.debug("Creating or updating hyc-download-stat database entry with the following attributes:")
+        Rails.logger.debug("fileset_id: #{fileset_id}, work_id: #{work_id}, admin_set_id: #{admin_set_id}, work_type: #{work_type}, date: #{date.beginning_of_month}")
 
         stat = HycDownloadStat.find_or_initialize_by(
           fileset_id: fileset_id,
@@ -74,7 +76,11 @@ module Hyc
           date: date.beginning_of_month
         )
         stat.download_count += 1
-        stat.save!
+        if stat.save
+          Rails.logger.debug("Database entry for fileset_id: #{fileset_id} successfully saved with download count: #{stat.download_count}.")
+        else
+          Rails.logger.error("Failed to update database entry for fileset_id: #{fileset_id}.")
+        end
       end
 
       def bot_request?(user_agent)

--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -77,7 +77,8 @@ module Hyc
         if stat.save
           Rails.logger.debug("Database entry for fileset_id: #{fileset_id} successfully saved with download count: #{stat.download_count}.")
         else
-          Rails.logger.error("Failed to update database entry for fileset_id: #{fileset_id}.")
+          Rails.logger.error("Failed to update database entry for fileset_id: #{fileset_id}." \
+                             "Errors: #{stat.errors.full_messages}")
         end
       end
 

--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -52,7 +52,29 @@ module Hyc
           end
           Rails.logger.debug("DownloadAnalyticsBehavior request completed #{response.code}")
           response.code
+
+          # Send download events to db
+          create_download_stat
         end
+      end
+
+      def create_download_stat
+        fileset_id = params[:id]
+        work_id = record_id
+        admin_set_id = @admin_set_name
+        work_type = fetch_record.dig(0, 'has_model_ssim', 0)
+        date = Date.today
+        download_count = 1
+
+        stat = HycDownloadStat.find_or_initialize_by(
+          fileset_id: fileset_id,
+          work_id: work_id,
+          admin_set_id: admin_set_id,
+          work_type: work_type,
+          date: date.beginning_of_month
+        )
+        stat.download_count += 1
+        stat.save!
       end
 
       def bot_request?(user_agent)

--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -60,18 +60,18 @@ module Hyc
 
       def create_download_stat
         fileset_id = params[:id]
-        work_id = record_id
-        admin_set_id = @admin_set_name
+        record_id_value = record_id
+        admin_set_id_value = admin_set_id
         work_type = fetch_record.dig(0, 'has_model_ssim', 0)
         date = Date.today
-        
-        Rails.logger.debug("Creating or updating hyc-download-stat database entry with the following attributes:")
-        Rails.logger.debug("fileset_id: #{fileset_id}, work_id: #{work_id}, admin_set_id: #{admin_set_id}, work_type: #{work_type}, date: #{date.beginning_of_month}")
+
+        Rails.logger.debug('Creating or updating hyc-download-stat database entry with the following attributes:')
+        Rails.logger.debug("fileset_id: #{fileset_id}, work_id: #{record_id_value}, admin_set_id: #{admin_set_id_value}, work_type: #{work_type}, date: #{date.beginning_of_month}")
 
         stat = HycDownloadStat.find_or_initialize_by(
           fileset_id: fileset_id,
-          work_id: work_id,
-          admin_set_id: admin_set_id,
+          work_id: record_id_value,
+          admin_set_id: admin_set_id_value,
           work_type: work_type,
           date: date.beginning_of_month
         )
@@ -90,6 +90,14 @@ module Hyc
 
       def fetch_record
         @record ||= ActiveFedora::SolrService.get("file_set_ids_ssim:#{params[:id]}", rows: 1)['response']['docs']
+      end
+
+      def fetch_admin_set
+        @admin_set ||= ActiveFedora::SolrService.get("title_tesim:#{@admin_set_name}", rows: 1)['response']['docs']
+      end
+
+      def admin_set_id
+        @admin_set_id ||= fetch_admin_set.dig(0, 'id')
       end
 
       def record_id

--- a/app/models/hyc_download_stat.rb
+++ b/app/models/hyc_download_stat.rb
@@ -1,0 +1,12 @@
+class HycDownloadStat < ApplicationRecord
+    scope :with_fileset_id_and_date, ->(fileset_id, start_date, end_date) { where(fileset_id: fileset_id, date: start_date..end_date) }
+    scope :with_work_id_and_date, ->(work_id, start_date, end_date) { where(work_id: work_id, date: start_date..end_date) }
+    scope :with_admin_set_id, ->(admin_set_id) { where(admin_set_id: admin_set_id) }
+    scope :with_work_type, ->(work_type) { where(work_type: work_type) }
+    
+    # Additional scopes for flexibility
+    scope :with_fileset_id, ->(fileset_id) { where(fileset_id: fileset_id) }
+    scope :with_work_id, ->(work_id) { where(work_id: work_id) }
+    scope :within_date_range, ->(start_date, end_date) { where(date: start_date..end_date) }
+  end
+  

--- a/app/models/hyc_download_stat.rb
+++ b/app/models/hyc_download_stat.rb
@@ -1,12 +1,12 @@
+# frozen_string_literal: true
 class HycDownloadStat < ApplicationRecord
-    scope :with_fileset_id_and_date, ->(fileset_id, start_date, end_date) { where(fileset_id: fileset_id, date: start_date..end_date) }
-    scope :with_work_id_and_date, ->(work_id, start_date, end_date) { where(work_id: work_id, date: start_date..end_date) }
-    scope :with_admin_set_id, ->(admin_set_id) { where(admin_set_id: admin_set_id) }
-    scope :with_work_type, ->(work_type) { where(work_type: work_type) }
-    
+  scope :with_fileset_id_and_date, ->(fileset_id, start_date, end_date) { where(fileset_id: fileset_id, date: start_date..end_date) }
+  scope :with_work_id_and_date, ->(work_id, start_date, end_date) { where(work_id: work_id, date: start_date..end_date) }
+  scope :with_admin_set_id, ->(admin_set_id) { where(admin_set_id: admin_set_id) }
+  scope :with_work_type, ->(work_type) { where(work_type: work_type) }
+
     # Additional scopes for flexibility
-    scope :with_fileset_id, ->(fileset_id) { where(fileset_id: fileset_id) }
-    scope :with_work_id, ->(work_id) { where(work_id: work_id) }
-    scope :within_date_range, ->(start_date, end_date) { where(date: start_date..end_date) }
+  scope :with_fileset_id, ->(fileset_id) { where(fileset_id: fileset_id) }
+  scope :with_work_id, ->(work_id) { where(work_id: work_id) }
+  scope :within_date_range, ->(start_date, end_date) { where(date: start_date..end_date) }
   end
-  

--- a/db/migrate/20240714234200_create_hyc_download_stats.rb
+++ b/db/migrate/20240714234200_create_hyc_download_stats.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateHycDownloadStats < ActiveRecord::Migration[6.1]
   def change
     create_table :hyc_download_stats do |t|

--- a/db/migrate/20240714234200_create_hyc_download_stats.rb
+++ b/db/migrate/20240714234200_create_hyc_download_stats.rb
@@ -1,0 +1,19 @@
+class CreateHycDownloadStats < ActiveRecord::Migration[6.1]
+  def change
+    create_table :hyc_download_stats do |t|
+      t.string :fileset_id, null: false
+      t.string :work_id, null: false
+      t.string :admin_set_id, null: false
+      t.string :work_type, null: false
+      t.date :date, null: false
+      t.integer :download_count, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_index :hyc_download_stats, [:fileset_id, :date]
+    add_index :hyc_download_stats, [:work_id, :date]
+    add_index :hyc_download_stats, :admin_set_id
+    add_index :hyc_download_stats, :work_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_08_153601) do
+ActiveRecord::Schema.define(version: 2024_07_14_234200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -247,6 +247,21 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.integer "user_id"
     t.index ["file_id"], name: "index_file_view_stats_on_file_id"
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
+  end
+
+  create_table "hyc_download_stats", force: :cascade do |t|
+    t.string "fileset_id", null: false
+    t.string "work_id", null: false
+    t.string "admin_set_id", null: false
+    t.string "work_type", null: false
+    t.date "date", null: false
+    t.integer "download_count", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["admin_set_id"], name: "index_hyc_download_stats_on_admin_set_id"
+    t.index ["fileset_id", "date"], name: "index_hyc_download_stats_on_fileset_id_and_date"
+    t.index ["work_id", "date"], name: "index_hyc_download_stats_on_work_id_and_date"
+    t.index ["work_type"], name: "index_hyc_download_stats_on_work_type"
   end
 
   create_table "hyrax_collection_types", id: :serial, force: :cascade do |t|

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -63,11 +63,27 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
 
     context 'with a created work' do
       let(:user) { FactoryBot.create(:user) }
+      let(:example_admin_set_id) { 'h128zk07m' }
+      let(:example_work_id) { '1z40m031g' }
       before { sign_in user }
       let(:file_set) do
         FactoryBot.create(:file_with_work, user: user, content: File.open("#{fixture_path}/files/image.png"))
       end
       let(:default_image) { ActionController::Base.helpers.image_path 'default.png' }
+      let(:mock_admin_set) { [{
+        'has_model_ssim' => ['AdminSet'],
+        'id' => example_admin_set_id,
+        'title_tesim' => ['Open_Access_Articles_and_Book_Chapters']}
+      ]
+      }
+      let(:mock_record) { [{
+        'has_model_ssim' => ['Article'],
+        'id' => example_work_id,
+        'title_tesim' => ['Key ethical issues discussed at CDC-sponsored international, regional meetings to explore cultural perspectives and contexts on pandemic influenza preparedness and response'],
+        'admin_set_tesim' => ['Open_Access_Articles_and_Book_Chapters']}
+      ]
+      }
+
 
       it 'sends a download event to analytics tracking platform upon successful download' do
         allow(Hyrax::VirusCheckerService).to receive(:file_has_virus?) { false }
@@ -87,21 +103,10 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
       end
 
       it 'records the download event in the database' do
-        example_admin_set_id = 'h128zk07m'
-        example_work_id = '1z40m031g'
         allow(Hyrax::VirusCheckerService).to receive(:file_has_virus?) { false }
         allow(SecureRandom).to receive(:uuid).and_return('555')
-        allow(controller).to receive(:fetch_record).and_return([{
-          'has_model_ssim' => ['Article'],
-          'id' => example_work_id,
-          'title_tesim' => ['Key ethical issues discussed at CDC-sponsored international, regional meetings to explore cultural perspectives and contexts on pandemic influenza preparedness and response'],
-          'admin_set_tesim' => ['Open_Access_Articles_and_Book_Chapters']}
-        ])
-        allow(controller).to receive(:fetch_admin_set).and_return([{
-          'has_model_ssim' => ['AdminSet'],
-          'id' => example_admin_set_id,
-          'title_tesim' => ['Open_Access_Articles_and_Book_Chapters']}
-        ])
+        allow(controller).to receive(:fetch_record).and_return(mock_record)
+        allow(controller).to receive(:fetch_admin_set).and_return(mock_admin_set)
         request.env['HTTP_REFERER'] = 'http://example.com'
 
         expect {
@@ -114,6 +119,35 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
         expect(stat.admin_set_id).to eq(example_admin_set_id)
         expect(stat.date).to eq(Date.today.beginning_of_month)
         expect(stat.download_count).to eq(1)
+      end
+
+      it 'updates the download count if the record already exists' do
+        existing_download_count = 5
+        allow(Hyrax::VirusCheckerService).to receive(:file_has_virus?) { false }
+        allow(SecureRandom).to receive(:uuid).and_return('555')
+        allow(controller).to receive(:fetch_record).and_return(mock_record)
+        allow(controller).to receive(:fetch_admin_set).and_return(mock_admin_set)
+        request.env['HTTP_REFERER'] = 'http://example.com'
+
+        existing_stat = HycDownloadStat.create!(
+          fileset_id: file_set.id,
+          work_id: example_work_id,
+          admin_set_id: example_admin_set_id,
+          work_type: 'Article',
+          date: Date.today.beginning_of_month,
+          download_count: existing_download_count
+        )
+
+        expect {
+          get :show, params: { id: file_set.id }
+        }.not_to change { HycDownloadStat.count }
+
+        stat = HycDownloadStat.last
+        expect(stat.fileset_id).to eq(file_set.id)
+        expect(stat.work_id).to eq(example_work_id)
+        expect(stat.admin_set_id).to eq(example_admin_set_id)
+        expect(stat.date).to eq(Date.today.beginning_of_month)
+        expect(stat.download_count).to eq(existing_download_count + 1)
       end
 
       it 'does not track downloads for well known bot user agents' do

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
         stub = stub_request(:get, "#{spec_base_analytics_url}/matomo.php")
           .with(query: hash_including({'e_a' => 'DownloadIR',
                                       'e_c' => 'Unknown',
+                                      'e_n' => file_set.id,
                                       'e_v' => 'referral',
                                       'urlref' => 'http://example.com',
                                       'url' => "http://test.host/downloads/#{file_set.id}"
@@ -151,6 +152,7 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
             .with(query: hash_including({
               'e_a' => 'DownloadIR',
               'e_c' => 'Unknown',
+              'e_n' => file_set.id,
               'e_v' => 'referral',
               'urlref' => 'http://example.com',
               'url' => "http://test.host/downloads/#{file_set.id}"
@@ -174,6 +176,7 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
         stub = stub_request(:get, "#{spec_base_analytics_url}/matomo.php")
         .with(query: hash_including({'e_a' => 'DownloadIR',
                                     'e_c' => 'Unknown',
+                                    'e_n' => file_set.id,
                                     'e_v' => 'direct',
                                     'urlref' => nil,
                                     'url' => "http://test.host/downloads/#{file_set.id}"

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -5,7 +5,7 @@ require Rails.root.join('app/overrides/controllers/hyrax/downloads_controller_ov
 
 RSpec.describe Hyrax::DownloadsController, type: :controller do
   routes { Hyrax::Engine.routes }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, uid: 'downloads_controller_test_user') }
   let(:spec_base_analytics_url) { 'https://analytics-qa.lib.unc.edu' }
   let(:spec_site_id) { '5' }
   let(:spec_auth_token) { 'testtoken' }

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -87,20 +87,31 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
       end
 
       it 'records the download event in the database' do
+        example_admin_set_id = 'h128zk07m'
+        example_work_id = '1z40m031g'
         allow(Hyrax::VirusCheckerService).to receive(:file_has_virus?) { false }
         allow(SecureRandom).to receive(:uuid).and_return('555')
-        allow(controller).to receive(:record_id).and_return('spec_work_id')
+        allow(controller).to receive(:fetch_record).and_return([{
+          'has_model_ssim' => ['Article'],
+          'id' => example_work_id,
+          'title_tesim' => ['Key ethical issues discussed at CDC-sponsored international, regional meetings to explore cultural perspectives and contexts on pandemic influenza preparedness and response'],
+          'admin_set_tesim' => ['Open_Access_Articles_and_Book_Chapters']}
+        ])
+        allow(controller).to receive(:fetch_admin_set).and_return([{
+          'has_model_ssim' => ['AdminSet'],
+          'id' => example_admin_set_id,
+          'title_tesim' => ['Open_Access_Articles_and_Book_Chapters']}
+        ])
         request.env['HTTP_REFERER'] = 'http://example.com'
-        
+
         expect {
           get :show, params: { id: file_set.id }
         }.to change { HycDownloadStat.count }.by(1)
-  
+
         stat = HycDownloadStat.last
         expect(stat.fileset_id).to eq(file_set.id)
-        expect(stat.work_id).to eq('spec_work_id')
-        # expect(stat.admin_set_id).to eq('admin_set_example')
-        # expect(stat.work_type).to eq('work_type_example')
+        expect(stat.work_id).to eq(example_work_id)
+        expect(stat.admin_set_id).to eq(example_admin_set_id)
         expect(stat.date).to eq(Date.today.beginning_of_month)
         expect(stat.download_count).to eq(1)
       end

--- a/spec/factories/hyc_download_stats.rb
+++ b/spec/factories/hyc_download_stats.rb
@@ -1,12 +1,12 @@
+# frozen_string_literal: true
 # spec/factories/hyc_download_stats.rb
 FactoryBot.define do
-    factory :hyc_download_stat do
-      sequence(:fileset_id) { |n| n.to_s }
-      sequence(:work_id) { |n| n.to_s }
-      sequence(:admin_set_id) { |n| n.to_s }
-      sequence(:work_type) { |n| n.to_s }
-      date { Date.today }
-      download_count { 0 }
-    end
+  factory :hyc_download_stat do
+    sequence(:fileset_id) { |n| n.to_s }
+    sequence(:work_id) { |n| n.to_s }
+    sequence(:admin_set_id) { |n| n.to_s }
+    sequence(:work_type) { |n| n.to_s }
+    date { Date.today }
+    download_count { 0 }
   end
-  
+end

--- a/spec/factories/hyc_download_stats.rb
+++ b/spec/factories/hyc_download_stats.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sequence(:work_id) { |n| n.to_s }
     sequence(:admin_set_id) { |n| n.to_s }
     sequence(:work_type) { |n| n.to_s }
-    date { Date.today }
+    date { Date.today.beginning_of_month }
     download_count { 0 }
   end
 end

--- a/spec/factories/hyc_download_stats.rb
+++ b/spec/factories/hyc_download_stats.rb
@@ -1,0 +1,12 @@
+# spec/factories/hyc_download_stats.rb
+FactoryBot.define do
+    factory :hyc_download_stat do
+      sequence(:fileset_id) { |n| n.to_s }
+      sequence(:work_id) { |n| n.to_s }
+      sequence(:admin_set_id) { |n| n.to_s }
+      sequence(:work_type) { |n| n.to_s }
+      date { Date.today }
+      download_count { 0 }
+    end
+  end
+  

--- a/spec/models/hyc_download_stat_spec.rb
+++ b/spec/models/hyc_download_stat_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe HycDownloadStat, type: :model do
+  describe 'scopes' do
+    let!(:stat1) { FactoryBot.create(:hyc_download_stat, fileset_id: 'fs1', work_id: 'w1', admin_set_id: 'as1', work_type: 'Article', date: '2024-07-01', download_count: 10) }
+    let!(:stat2) { FactoryBot.create(:hyc_download_stat, fileset_id: 'fs2', work_id: 'w2', admin_set_id: 'as2', work_type: 'Dataset', date: '2024-07-01', download_count: 5) }
+    let!(:stat3) { FactoryBot.create(:hyc_download_stat, fileset_id: 'fs1', work_id: 'w1', admin_set_id: 'as1', work_type: 'Article', date: '2024-08-01', download_count: 20) }
+
+    it 'returns records with a specific fileset_id and date range' do
+      expect(HycDownloadStat.with_fileset_id_and_date('fs1', '2024-07-01', '2024-07-31')).to include(stat1)
+      expect(HycDownloadStat.with_fileset_id_and_date('fs1', '2024-07-01', '2024-07-31')).not_to include(stat3)
+    end
+
+    it 'returns records with a specific work_id and date range' do
+      expect(HycDownloadStat.with_work_id_and_date('w1', '2024-07-01', '2024-07-31')).to include(stat1)
+      expect(HycDownloadStat.with_work_id_and_date('w1', '2024-07-01', '2024-07-31')).not_to include(stat3)
+    end
+
+    it 'returns records with a specific admin_set_id' do
+      expect(HycDownloadStat.with_admin_set_id('as1')).to include(stat1, stat3)
+      expect(HycDownloadStat.with_admin_set_id('as1')).not_to include(stat2)
+    end
+
+    it 'returns records with a specific work_type' do
+      expect(HycDownloadStat.with_work_type('Article')).to include(stat1, stat3)
+      expect(HycDownloadStat.with_work_type('Article')).not_to include(stat2)
+    end
+
+    it 'returns records with a specific fileset_id' do
+      expect(HycDownloadStat.with_fileset_id('fs1')).to include(stat1, stat3)
+      expect(HycDownloadStat.with_fileset_id('fs1')).not_to include(stat2)
+    end
+
+    it 'returns records with a specific work_id' do
+      expect(HycDownloadStat.with_work_id('w1')).to include(stat1, stat3)
+      expect(HycDownloadStat.with_work_id('w1')).not_to include(stat2)
+    end
+
+    it 'returns records within a specific date range' do
+      expect(HycDownloadStat.within_date_range('2024-07-01', '2024-07-31')).to include(stat1, stat2)
+      expect(HycDownloadStat.within_date_range('2024-07-01', '2024-07-31')).not_to include(stat3)
+    end
+  end
+end

--- a/spec/models/hyc_download_stat_spec.rb
+++ b/spec/models/hyc_download_stat_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe HycDownloadStat, type: :model do


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1934

* Add model and migration for HycDownloadStat table
* Modify download analytics tracking behavior so that downloading a file prompts an entry in the table, either adding a new record or updating an existing one.