### PR TITLE
HYC-1941 - Expand mutex when freezing RDF::URIs

### DIFF
--- a/app/overrides/lib/rdf/model/uri_override.rb
+++ b/app/overrides/lib/rdf/model/uri_override.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# [hyc-override] https://github.com/ruby-rdf/rdf/blob/3.2.11/lib/rdf/model/uri.rb
+RDF::URI.class_eval do
+  # [hyc-override] Wrap the entire method in mutex, rather than just the interior of the unless block
+  def freeze
+    @mutex.synchronize do
+      unless frozen?
+        # Create derived components
+        authority; userinfo; user; password; host; port
+        @value  = value.freeze
+        @object = object.freeze
+        @hash = hash.freeze
+        super
+      end
+    end
+    self
+  end
+end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1941

Override RDF::URI in order to wrap the entire freeze method in mutex to try to prevent concurrent attempts to freeze the same URI