### PR TITLE
HYC-1937 - Expand Migration Utility to Include Matomo Stats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,12 +138,12 @@ jobs:
         POSTGRES_PASSWORD: password
         TMPDIR: /tmp
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: test-coverage
         path: coverage
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: test-coverage-report
         path: coverage/coverage.json

--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -18,7 +18,7 @@ module Hyc
           client_ip = request.remote_ip
           user_agent = request.user_agent
 
-          matomo_id_site = ENV['MATOMO_SITE_ID']
+          matomo_site_id = ENV['MATOMO_SITE_ID']
           matomo_security_token = ENV['MATOMO_AUTH_TOKEN']
           tracking_uri = URI("#{ENV['MATOMO_BASE_URL']}/matomo.php")
 
@@ -27,7 +27,7 @@ module Hyc
           uri_params = {
             token_auth: matomo_security_token,
             rec: '1',
-            idsite: matomo_id_site,
+            idsite: matomo_site_id,
             action_name: 'Download',
             url: request.url,
             urlref: request.referrer,

--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -18,9 +18,9 @@ module Hyc
           client_ip = request.remote_ip
           user_agent = request.user_agent
 
-          matomo_id_site = site_id
-          matomo_security_token = auth_token
-          uri = URI("#{base_url}/matomo.php")
+          matomo_id_site = ENV['MATOMO_SITE_ID']
+          matomo_security_token = ENV['MATOMO_AUTH_TOKEN']
+          tracking_uri = URI("#{ENV['MATOMO_BASE_URL']}/matomo.php")
 
           # Some parameters are optional, but included since tracking would not work otherwise
           # https://developer.matomo.org/api-reference/tracking-api
@@ -44,11 +44,11 @@ module Hyc
             dimension1: work_data[:work_id],
             dimension2: work_data[:title]
           }
-          uri.query = URI.encode_www_form(uri_params)
-          response = HTTParty.get(uri.to_s)
-          Rails.logger.debug("Matomo download tracking URL: #{uri}")
+          tracking_uri.query = URI.encode_www_form(uri_params)
+          response = HTTParty.get(tracking_uri.to_s)
+          Rails.logger.debug("Matomo download tracking URL: #{tracking_uri}")
           if response.code >= 300
-            Rails.logger.error("DownloadAnalyticsBehavior received an error response #{response.code} for matomo query: #{uri}")
+            Rails.logger.error("DownloadAnalyticsBehavior received an error response #{response.code} for matomo query: #{tracking_uri}")
           end
           # Send download events to db
           create_download_stat
@@ -90,18 +90,6 @@ module Hyc
 
       def work_data
         @work_data ||= WorkUtilsHelper.fetch_work_data_by_fileset_id(fileset_id)
-      end
-
-      def site_id
-        @site_id ||= ENV['MATOMO_SITE_ID']
-      end
-
-      def auth_token
-        @auth_token ||= ENV['MATOMO_AUTH_TOKEN']
-      end
-
-      def base_url
-        @base_url ||= ENV['MATOMO_BASE_URL']
       end
 
       def client_id

--- a/app/helpers/work_utils_helper.rb
+++ b/app/helpers/work_utils_helper.rb
@@ -9,7 +9,7 @@ module WorkUtilsHelper
     Rails.logger.warn("No work found associated with fileset id: #{fileset_id}") if work_data.blank?
     # Set the admin set to an empty hash if the solr query returns nil
     admin_set_name = work_data['admin_set_tesim']&.first
-    admin_set_data =  ActiveFedora::SolrService.get("title_tesim:#{admin_set_name}", { :rows => 1, 'df' => 'title_tesim'})['response']['docs'].first || {}
+    admin_set_data = admin_set_name ? ActiveFedora::SolrService.get("title_tesim:#{admin_set_name}", { :rows => 1, 'df' => 'title_tesim'})['response']['docs'].first : {}
     Rails.logger.warn(self.generate_warning_message(admin_set_name, fileset_id)) if admin_set_data.blank?
     {
       work_id: fileset_data['id'],

--- a/app/helpers/work_utils_helper.rb
+++ b/app/helpers/work_utils_helper.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 module WorkUtilsHelper
   def self.fetch_work_data_by_fileset_id(fileset_id)
-    work = ActiveFedora::SolrService.get("file_set_ids_ssim:#{fileset_id}", rows: 1)['response']['docs'].first || {}
-    Rails.logger.warn("No work found for fileset id: #{fileset_id}") if work.blank?
-    # Fetch the admin set related to the work
-    admin_set_name = work['admin_set_tesim']&.first
-    # If the admin set name is not nil, fetch the admin set
+    # Retrieve the fileset data
+    fileset_data = ActiveFedora::SolrService.get("id:#{fileset_id}", rows: 1)['response']['docs'].first || {}
+    Rails.logger.warn("No fileset data found for fileset id: #{fileset_id}") if fileset_data.blank?
+    # Retrieve the work related to the fileset
+    work_data = ActiveFedora::SolrService.get("file_set_ids_ssim:#{fileset_id}", rows: 1)['response']['docs'].first || {}
+    Rails.logger.warn("No work found associated with fileset id: #{fileset_id}") if work_data.blank?
     # Set the admin set to an empty hash if the solr query returns nil
-    admin_set = admin_set_name ? ActiveFedora::SolrService.get("title_tesim:#{admin_set_name}", { :rows => 1, 'df' => 'title_tesim'})['response']['docs'].first || {} : {}
-    Rails.logger.warn(self.generate_warning_message(admin_set_name, fileset_id)) if admin_set.blank?
-
+    admin_set_name = work_data['admin_set_tesim']&.first
+    admin_set_data =  ActiveFedora::SolrService.get("title_tesim:#{admin_set_name}", { :rows => 1, 'df' => 'title_tesim'})['response']['docs'].first || {}
+    Rails.logger.warn(self.generate_warning_message(admin_set_name, fileset_id)) if admin_set_data.blank?
     {
-      work_id: work['id'],
-      work_type: work.dig('has_model_ssim', 0),
-      title: work['title_tesim']&.first,
-      admin_set_id: admin_set['id'],
+      work_id: fileset_data['id'],
+      work_type: work_data.dig('has_model_ssim', 0),
+      title: work_data['title_tesim']&.first,
+      admin_set_id: admin_set_data['id'],
       admin_set_name: admin_set_name
     }
   end

--- a/app/services/tasks/dimensions_query_service.rb
+++ b/app/services/tasks/dimensions_query_service.rb
@@ -195,7 +195,7 @@ module Tasks
 
     # Query with paramaters to retrieve publications related to UNC
     def generate_query_string(start_date, end_date, page_size, cursor)
-      search_clauses = ['where type = "article"', "date >= \"#{start_date}\"", "date < \"#{end_date}\""].join(' and ')
+      search_clauses = ['where type = "article"', "date_inserted >= \"#{start_date}\"", "date_inserted < \"#{end_date}\""].join(' and ')
       return_fields = ['basics', 'extras', 'abstract', 'issn', 'publisher', 'journal_title_raw', 'linkout', 'concepts'].join(' + ')
       unc_affiliation_variants = ['"UNC-CH"', '"University of North Carolina at Chapel Hill"', '"UNC-Chapel Hill"', '"University of North Carolina-Chapel Hill"', '"University of North Carolina, Chapel Hill"'].join(' OR ')
       <<~QUERY

--- a/app/services/tasks/download_stats_migration_service.rb
+++ b/app/services/tasks/download_stats_migration_service.rb
@@ -22,6 +22,9 @@ module Tasks
         when DownloadMigrationSource::CACHE
           aggregated_work_stats = fetch_local_cache_stats(after_timestamp, output_path)
           write_to_csv(output_path, aggregated_work_stats)
+        when DownloadMigrationSource::MATOMO
+          aggregated_work_stats = fetch_matomo_stats(after_timestamp, before_timestamp, output_path)
+          write_to_csv(output_path, aggregated_work_stats)
         else
           raise ArgumentError, "Unsupported source: #{source}"
         end
@@ -74,7 +77,7 @@ module Tasks
       Rails.logger.info("Fetching work stats #{timestamp_clause} from Matomo.")
 
       # Query Matomo API for each month in the range and aggregate the data
-      month.each_with_index do |month, index|
+      months_array.each_with_index do |month, index|
         uri_params = {
           module: 'API',
           idSite: matomo_site_id,

--- a/app/services/tasks/download_stats_migration_service.rb
+++ b/app/services/tasks/download_stats_migration_service.rb
@@ -64,12 +64,10 @@ module Tasks
 
     # Method to fetch and aggregate work stats from Matomo
     def fetch_matomo_stats(after_timestamp, before_timestamp, output_path)
-      puts 'Inspect arguments: ', after_timestamp, before_timestamp, output_path
       aggregated_data = {}
       retrieved_work_stats_total = 0
       # Fetch the first of each month in the range
       months_array = first_of_each_month_in_range(after_timestamp, before_timestamp)
-      puts 'Inspect months_array: ', months_array
       timestamp_clause = "in specified range #{after_timestamp} to #{before_timestamp}"
       matomo_site_id = ENV['MATOMO_SITE_ID']
       matomo_security_token = ENV['MATOMO_AUTH_TOKEN']
@@ -95,7 +93,6 @@ module Tasks
         }
         reporting_uri.query = URI.encode_www_form(uri_params)
         response = HTTParty.get(reporting_uri.to_s)
-        puts "Inspecting response: #{response.parsed_response}"
         Rails.logger.info("Processing Matomo response for #{month}. (#{index + 1}/#{months_array.count})")
         response.parsed_response.each do |stat|
           # Events_EventName is the file_id, nb_events is the number of downloads
@@ -103,7 +100,6 @@ module Tasks
         end
         retrieved_work_stats_total += response.parsed_response.length
       end
-      puts 'Inspect aggregated_data: ', aggregated_data.values
       Rails.logger.info("Aggregated #{aggregated_data.values.count} monthly stats from #{retrieved_work_stats_total} daily stats")
       # Return the aggregated data
       aggregated_data.values

--- a/app/services/tasks/download_stats_migration_service.rb
+++ b/app/services/tasks/download_stats_migration_service.rb
@@ -59,6 +59,12 @@ module Tasks
 
     private
 
+    # Method to fetch and aggregate work stats from Matomo
+    def fetch_matomo_stats(after_timestamp, before_timestamp, output_path)
+
+    end
+
+    # Method to fetch and aggregate work stats from the local cache
     def fetch_local_cache_stats(after_timestamp, output_path)
       query = FileDownloadStat.all
       query = query.where('updated_at > ?', after_timestamp) if after_timestamp.present?

--- a/app/services/tasks/download_stats_migration_service.rb
+++ b/app/services/tasks/download_stats_migration_service.rb
@@ -14,7 +14,7 @@ module Tasks
       def self.valid?(source)
         all_sources.include?(source)
       end
-      end
+    end
     def list_work_stat_info(output_path, after_timestamp = nil, before_timestamp = nil, source)
       aggregated_work_stats = []
       begin

--- a/app/services/tasks/download_stats_migration_service.rb
+++ b/app/services/tasks/download_stats_migration_service.rb
@@ -15,7 +15,7 @@ module Tasks
         all_sources.include?(source)
       end
       end
-    def list_work_stat_info(output_path, after_timestamp = nil)
+    def list_work_stat_info(output_path, before_timestamp = nil, after_timestamp = nil, source)
       begin
         query = FileDownloadStat.all
         query = query.where('updated_at > ?', after_timestamp) if after_timestamp.present?

--- a/app/services/tasks/download_stats_migration_service.rb
+++ b/app/services/tasks/download_stats_migration_service.rb
@@ -2,6 +2,19 @@
 module Tasks
   class DownloadStatsMigrationService
     PAGE_SIZE = 1000
+    module DownloadMigrationSource
+      MATOMO = :matomo
+      GA4 = :ga4
+      CACHE = :cache
+
+      def self.all_sources
+        [MATOMO, GA4, CACHE]
+      end
+
+      def self.valid?(source)
+        all_sources.include?(source)
+      end
+      end
     def list_work_stat_info(output_path, after_timestamp = nil)
       begin
         query = FileDownloadStat.all

--- a/lib/tasks/migrate_download_stats.rake
+++ b/lib/tasks/migrate_download_stats.rake
@@ -5,7 +5,7 @@ require 'optparse/date'
 
 namespace :migrate_download_stats do
   desc 'output rows for download stat migration into a csv'
-  task :list_rows, [:output_dir, :before, :after, :source] => :environment do |_t, _args|
+  task :list_rows, [:output_dir, :after, :before, :source] => :environment do |_t, _args|
     start_time = Time.now
     puts "[#{start_time.utc.iso8601}] starting listing of work data"
     options = {}
@@ -37,7 +37,7 @@ namespace :migrate_download_stats do
 
 
     migration_service = Tasks::DownloadStatsMigrationService.new
-    old_stats_csv = migration_service.list_work_stat_info(options[:output_dir], options[:before], options[:after], options[:source])
+    old_stats_csv = migration_service.list_work_stat_info(options[:output_dir], options[:after],  options[:before], options[:source])
     puts "Listing completed in #{Time.now - start_time}s"
     puts "Stored id list to file: #{options[:output_dir]}"
     exit 0

--- a/lib/tasks/migrate_download_stats.rake
+++ b/lib/tasks/migrate_download_stats.rake
@@ -5,7 +5,7 @@ require 'optparse/date'
 
 namespace :migrate_download_stats do
   desc 'output rows for download stat migration into a csv'
-  task :list_rows, [:output_dir, :after, :before, :source] => :environment do |_t, _args|
+  task :list_rows, [:output_dir, :before, :after, :source] => :environment do |_t, _args|
     start_time = Time.now
     puts "[#{start_time.utc.iso8601}] starting listing of work data"
     options = {}
@@ -31,7 +31,7 @@ namespace :migrate_download_stats do
 
 
     migration_service = Tasks::DownloadStatsMigrationService.new
-    old_stats_csv = migration_service.list_work_stat_info(options[:output_dir], options[:after])
+    old_stats_csv = migration_service.list_work_stat_info(options[:output_dir], options[:before], options[:after], options[:source])
     puts "Listing completed in #{Time.now - start_time}s"
     puts "Stored id list to file: #{options[:output_dir]}"
     exit 0

--- a/lib/tasks/migrate_download_stats.rake
+++ b/lib/tasks/migrate_download_stats.rake
@@ -29,6 +29,12 @@ namespace :migrate_download_stats do
       exit 1
     end
 
+    # Require both 'before' and 'after' arguments if the source is not 'cache'
+    if options[:source] != Tasks::DownloadStatsMigrationService::DownloadMigrationSource::CACHE && (!options[:before].present? || !options[:after].present?)
+      puts "Both 'before' and 'after' timestamps are required for sources other than #{Tasks::DownloadStatsMigrationService::DownloadMigrationSource::CACHE}"
+      exit 1
+    end
+
 
     migration_service = Tasks::DownloadStatsMigrationService.new
     old_stats_csv = migration_service.list_work_stat_info(options[:output_dir], options[:before], options[:after], options[:source])

--- a/lib/tasks/migrate_download_stats.rake
+++ b/lib/tasks/migrate_download_stats.rake
@@ -14,7 +14,7 @@ namespace :migrate_download_stats do
     opts.banner = 'Usage: bundle exec rake migrate_download_stats:list_rows -- [options]'
     opts.on('-o', '--output-dir ARG', String, 'Directory list will be saved to') { |val| options[:output_dir] = val }
     opts.on('-a', '--after ARG', String, 'List objects which have been updated after this timestamp') { |val| options[:after] = val }
-    opts.on('-b', '--before ARG', String, 'List objects updated before this timestamp') { |val| options[:before] = val }
+    opts.on('-b', '--before ARG', String, 'List objects updated before this timestamp, only meant for matomo and ga4 migrations') { |val| options[:before] = val }
     opts.on('-s', '--source ARG', String, 'Data source (matomo, ga4, cache)') { |val| options[:source] = val.to_sym }
     args = opts.order!(ARGV) {}
     opts.parse!(args)

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -345,9 +345,4 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
     end
   end
 
-  describe '#site_id' do
-    it 'returns the site id from ENV' do
-      expect(controller.send(:site_id)).to eq('5')
-    end
-  end
 end

--- a/spec/fixtures/files/matomo_stats_migration_fixture.json
+++ b/spec/fixtures/files/matomo_stats_migration_fixture.json
@@ -1,6 +1,6 @@
 {
     "2024-01-01": [
-        {
+       {
         "label": "file_id_1 - DownloadIR",
         "nb_events": 120,
         "Events_EventName": "file_id_1",
@@ -23,8 +23,8 @@
         "nb_events": 50,
         "Events_EventName": "file_id_2",
         "Events_EventAction": "DownloadIR"
-        }
-    ],
+        }]
+        ,
     "2024-02-01": [
         {
         "label": "file_id_3 - DownloadIR",

--- a/spec/fixtures/files/matomo_stats_migration_fixture.json
+++ b/spec/fixtures/files/matomo_stats_migration_fixture.json
@@ -1,0 +1,80 @@
+{
+    "2024-01-01": [
+        {
+        "label": "file_id_1 - DownloadIR",
+        "nb_events": 120,
+        "Events_EventName": "file_id_1",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_1 - DownloadIR",
+        "nb_events": 70,
+        "Events_EventName": "file_id_1",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_2 - DownloadIR",
+        "nb_events": 100,
+        "Events_EventName": "file_id_2",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_2 - DownloadIR",
+        "nb_events": 50,
+        "Events_EventName": "file_id_2",
+        "Events_EventAction": "DownloadIR"
+        }
+    ],
+    "2024-02-01": [
+        {
+        "label": "file_id_3 - DownloadIR",
+        "nb_events": 10,
+        "Events_EventName": "file_id_3",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_3 - DownloadIR",
+        "nb_events": 90,
+        "Events_EventName": "file_id_3",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_4 - DownloadIR",
+        "nb_events": 50,
+        "Events_EventName": "file_id_4",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_4 - DownloadIR",
+        "nb_events": 30,
+        "Events_EventName": "file_id_4",
+        "Events_EventAction": "DownloadIR"
+        }
+    ],
+    "2024-03-01": [
+        {
+        "label": "file_id_5 - DownloadIR",
+        "nb_events": 80,
+        "Events_EventName": "file_id_5",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_5 - DownloadIR",
+        "nb_events": 100,
+        "Events_EventName": "file_id_5",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_6 - DownloadIR",
+        "nb_events": 250,
+        "Events_EventName": "file_id_6",
+        "Events_EventAction": "DownloadIR"
+        },
+        {
+        "label": "file_id_6 - DownloadIR",
+        "nb_events": 300,
+        "Events_EventName": "file_id_6",
+        "Events_EventAction": "DownloadIR"
+        }
+    ]
+}

--- a/spec/helpers/hyrax/work_utils_helper_spec.rb
+++ b/spec/helpers/hyrax/work_utils_helper_spec.rb
@@ -38,23 +38,22 @@ RSpec.describe WorkUtilsHelper, type: :module do
   }
   }
 
-  before do
-    allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{fileset_ids[0]}", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
-    allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name}",  {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => mock_admin_set })
-  end
-
   describe '#fetch_work_data_by_fileset_id' do
     it 'fetches the work data correctly' do
+      allow(ActiveFedora::SolrService).to receive(:get).with("id:#{fileset_ids[0]}", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
+      allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{fileset_ids[0]}", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
+      allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name}",  {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => mock_admin_set })
       result = WorkUtilsHelper.fetch_work_data_by_fileset_id(fileset_ids[0])
       expect(result).to eq(expected_work_data)
     end
 
     it 'logs appropriate messages for missing values' do
         # Mock the solr response to simulate a work with missing values, if it somehow makes it past the initial nil check
+      allow(ActiveFedora::SolrService).to receive(:get).with("id:#{fileset_ids[0]}", rows: 1).and_return('response' => { 'docs' => [] })
       allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{fileset_ids[0]}", rows: 1).and_return('response' => { 'docs' => [] })
       allow(Rails.logger).to receive(:warn)
       result = WorkUtilsHelper.fetch_work_data_by_fileset_id(fileset_ids[0])
-      expect(Rails.logger).to have_received(:warn).with("No work found for fileset id: #{fileset_ids[0]}")
+      expect(Rails.logger).to have_received(:warn).with("No fileset data found for fileset id: #{fileset_ids[0]}")
       expect(Rails.logger).to have_received(:warn).with("Could not find an admin set, the work with fileset id: #{fileset_ids[0]} has no admin set name.")
       expect(result[:work_id]).to be_nil
       expect(result[:work_type]).to be_nil
@@ -62,18 +61,10 @@ RSpec.describe WorkUtilsHelper, type: :module do
       expect(result[:admin_set_id]).to be_nil
     end
 
-    context 'when no work is found' do
-      it 'logs a warning if no work is found' do
-        allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{fileset_ids[1]}", rows: 1).and_return('response' => { 'docs' => [] })
-        allow(Rails.logger).to receive(:warn)
-        WorkUtilsHelper.fetch_work_data_by_fileset_id(fileset_ids[1])
-        expect(Rails.logger).to have_received(:warn).with("No work found for fileset id: #{fileset_ids[1]}")
-      end
-    end
-
     context 'when admin set is not found' do
       it 'logs an appropriate message if the work doesnt have an admin set title' do
         # Using the mock record without an admin set title
+        allow(ActiveFedora::SolrService).to receive(:get).with("id:#{fileset_ids[1]}", rows: 1).and_return('response' => { 'docs' => mock_records[1] })
         allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{fileset_ids[1]}", rows: 1).and_return('response' => { 'docs' => mock_records[1] })
         allow(Rails.logger).to receive(:warn)
         result = WorkUtilsHelper.fetch_work_data_by_fileset_id(fileset_ids[1])
@@ -83,8 +74,9 @@ RSpec.describe WorkUtilsHelper, type: :module do
 
       it 'logs an appropriate message if the query for an admin set returns nothing' do
         # Using the mock record with an admin set title
+        allow(ActiveFedora::SolrService).to receive(:get).with("id:#{fileset_ids[1]}", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
         allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{fileset_ids[1]}", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
-        allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name}", {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => [] })
+        allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name}", {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => [{}] })
         allow(Rails.logger).to receive(:warn)
         result = WorkUtilsHelper.fetch_work_data_by_fileset_id(fileset_ids[1])
         expect(Rails.logger).to have_received(:warn).with("No admin set found with title_tesim: #{admin_set_name}.")

--- a/spec/services/tasks/download_stats_migration_service_spec.rb
+++ b/spec/services/tasks/download_stats_migration_service_spec.rb
@@ -216,16 +216,16 @@ RSpec.describe Tasks::DownloadStatsMigrationService, type: :service do
     case source
     when Tasks::DownloadStatsMigrationService::DownloadMigrationSource::CACHE
         # Use mocked file_download_stats to create works for each file_set_id
-        mock_works = file_download_stats.flatten.map do |stat|
-          FactoryBot.create(:solr_query_result, :work, file_set_ids_ssim: [stat.file_id])
-        end
+      mock_works = file_download_stats.flatten.map do |stat|
+        FactoryBot.create(:solr_query_result, :work, file_set_ids_ssim: [stat.file_id])
+      end
         # Mock query responses for each file_set_id with the corresponding work
-        file_download_stats.flatten.each_with_index do |stat, index|
-          allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{stat.file_id}", rows: 1).and_return('response' => { 'docs' => [mock_works[index]] })
-        end
+      file_download_stats.flatten.each_with_index do |stat, index|
+        allow(ActiveFedora::SolrService).to receive(:get).with("file_set_ids_ssim:#{stat.file_id}", rows: 1).and_return('response' => { 'docs' => [mock_works[index]] })
+      end
     when Tasks::DownloadStatsMigrationService::DownloadMigrationSource::MATOMO
        # Mock query responses for file_set_ids 1-6
-       mock_works = (1..6).map do |index|
+      mock_works = (1..6).map do |index|
         FactoryBot.create(:solr_query_result, :work, file_set_ids_ssim: ["file_id_#{index}"])
       end
       (1..6).each do |index|

--- a/spec/services/tasks/download_stats_migration_service_spec.rb
+++ b/spec/services/tasks/download_stats_migration_service_spec.rb
@@ -6,8 +6,26 @@ RSpec.describe Tasks::DownloadStatsMigrationService, type: :service do
   let(:mock_admin_set) { FactoryBot.create(:solr_query_result, :admin_set, title_tesim: [admin_set_title]) }
   let(:output_path) { Rails.root.join('tmp', 'download_migration_test_output.csv') }
   let(:service) { described_class.new }
+  let(:spec_base_analytics_url) { 'https://analytics-qa.lib.unc.edu' }
+  let(:spec_site_id) { '5' }
+  let(:spec_auth_token) { 'testtoken' }
   let(:matomo_stats_migration_fixture) do
     JSON.parse(File.read(File.join(Rails.root, '/spec/fixtures/files/matomo_stats_migration_fixture.json')))
+  end
+
+  around do |example|
+    # Set the environment variables for the test
+    @auth_token = ENV['MATOMO_AUTH_TOKEN']
+    @site_id = ENV['MATOMO_SITE_ID']
+    @matomo_base_url = ENV['MATOMO_BASE_URL']
+    ENV['MATOMO_AUTH_TOKEN'] = spec_auth_token
+    ENV['MATOMO_SITE_ID'] = spec_site_id
+    ENV['MATOMO_BASE_URL'] = spec_base_analytics_url
+    example.run
+    # Reset the environment variables
+    ENV['MATOMO_AUTH_TOKEN'] = @auth_token
+    ENV['MATOMO_SITE_ID'] = @site_id
+    ENV['MATOMO_BASE_URL'] = @matomo_base_url
   end
 
   before do

--- a/spec/services/tasks/download_stats_migration_service_spec.rb
+++ b/spec/services/tasks/download_stats_migration_service_spec.rb
@@ -123,6 +123,14 @@ RSpec.describe Tasks::DownloadStatsMigrationService, type: :service do
         expect(csv_to_hash_array(output_path).map { |work| work[:file_id] }).not_to include(*old_stat_file_ids)
       end
     end
+
+    context 'with an unsupported source' do
+      it 'handles and logs an error' do
+        allow(Rails.logger).to receive(:error)
+        service.list_work_stat_info(output_path, nil, nil, :unsupported_source)
+        expect(Rails.logger).to have_received(:error).with('An error occurred while listing work stats: Unsupported source: unsupported_source')
+      end
+    end
   end
 
   describe '#migrate_to_new_table' do


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1937

* Removed helpers from download analytics behavior, using ENV variables instead
* WorkUtilsHelper now makes separate queries for the work and fileset data 
* ListWorkStatInfo function now calls helpers depending on the data source in the DownloadStatsMigrationService (fetch_matomo_stats and cache_stats)
* Test class for DownloadStatsMigrationService uses a case statement to validate list_work_stat_info and migrate_to_new_table work as expected for each source