### PR TITLE
HYC-1955 - 500 response when downloading

### DIFF
--- a/app/overrides/controllers/hyrax/downloads_controller_override.rb
+++ b/app/overrides/controllers/hyrax/downloads_controller_override.rb
@@ -19,15 +19,23 @@ Hyrax::DownloadsController.class_eval do
 
   private
 
-  # This is unmodified from hyrax
   def file_set_parent(file_set_id)
-    file_set = Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id, use_valkyrie: Hyrax.config.use_valkyrie?)
+    file_set = if defined?(Wings) && Hyrax.metadata_adapter.is_a?(Wings::Valkyrie::MetadataAdapter)
+                 Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: file_set_id, use_valkyrie: Hyrax.config.use_valkyrie?)
+               else
+                 Hyrax.query_service.find_by(id: file_set_id)
+               end
     @parent ||=
       case file_set
       when Hyrax::Resource
         Hyrax.query_service.find_parents(resource: file_set).first
       else
-        file_set.parent
+        # [hyc-override] If the object doesn't support parent, then throw an expected error
+        if file_set.respond_to?(:parent)
+          file_set.parent
+        else
+          raise Hyrax::WorkflowAuthorizationException
+        end
       end
   end
 

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -343,6 +343,16 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
         expect(response.headers['Content-Disposition']).to include 'filename="no_extension"'
       end
     end
+
+    context 'with work' do
+      let(:work) { Article.create(title: ['New Article']) }
+
+      it 'will deny permission if trying to download the work' do
+        allow(subject).to receive(:authorize!)
+        get :show, params: { id: work.id}
+        expect(response).to be_unauthorized
+      end
+    end
   end
 
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1955

* Adjust error when trying to download a work (which is not possible) so that an Auth exception occurs instead of a 500 error
* Updates `file_set_parent` to match the base state in hyrax 4, it was previously based on hyrax 3's version of the method.