### PR TITLE
HYC-1986 - Sanitize html in OAI-PMH

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ foo@bar:~$ bundle exec rspec spec/controllers/hyrax/users_controller_spec.rb --s
     ```
     * Copy the output of this to the sample_solr_documents file. Add a unique `:timestamp` value to the hash (e.g. `:timestamp => "2021-11-23T16:05:33.033Z"`) so that the `spec/requests/oai_pmh_endpoint_spec.rb` tests to continue to pass.
 
+#### Debugging database not found
+If tests fail with an error like `FATAL:  database "hyrax_test" does not exist` then you will likely need to create the test database manually:
+
+```
+docker compose exec web bash
+rails db:create RAILS_ENV=test
+```
+
 #### Debugging Capybara feature and javascript tests
 * Save a screenshot
   * Put `page.save_screenshot('screenshot.png')` on the line before the failing test (you can use a different name for the file if that's helpful)

--- a/app/overrides/models/concerns/blacklight/document/dublin_core_override.rb
+++ b/app/overrides/models/concerns/blacklight/document/dublin_core_override.rb
@@ -26,6 +26,8 @@ Blacklight::Document::DublinCore.module_eval do
           array_of_values = values_as_array(values)
           if field_s == 'source'
             add_source_to_xml(xml, array_of_values)
+          elsif field_s == 'description'
+            array_of_values.each { |v| add_field_to_xml(xml, field_s, ActionController::Base.helpers.strip_tags(v)) }
           else
             array_of_values.each { |v| add_field_to_xml(xml, field_s, v) }
           end

--- a/spec/models/concerns/blacklight/document/dublin_core_spec.rb
+++ b/spec/models/concerns/blacklight/document/dublin_core_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe 'Blacklight::Document::DublinCore' do
       end
     end
 
+    context 'with abstract containing html' do
+      let(:work) { Article.new(id: '123456', title: ['Testing HTML'],
+                    abstract: ['This <b>abstract</b> contains <i>html</i>']
+        )
+      }
+
+      it 'returns xml document with html tables sanitized from abstract' do
+        xml_doc = Nokogiri::XML(document.export_as_oai_dc_xml)
+        desc = xml_doc.xpath('//dc:description', 'dc' => 'http://purl.org/dc/elements/1.1/').map(&:text)
+        expect(desc).to eq ['This abstract contains html']
+      end
+    end
+
     context 'with thumbnail' do
       let(:work) { Article.new(id: '123456', title: ['654321']) }
       before do


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1986

* Remove html tags from abstract field (displayed as "description") in OAI-PMH. The "methodology" field is not displayed, so no updates were needed for that
* Update the readme to add note about creating test database, since I keep running into that problem in the docker environment.