### PR TITLE
HYC-1988 - Handle soffice pptx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'rails', '~> 6.0'
 gem 'rdf', git: 'https://github.com/ruby-rdf/rdf.git', branch: '3.2.11-patch'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.5.0'
+gem 'redlock' # version determined by hyrax
 gem 'riiif', '~> 2.5.0'
 gem 'roo', '~>2.9.0'
 gem 'rsolr', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1130,6 +1130,7 @@ DEPENDENCIES
   rails (~> 6.0)
   rdf!
   redis (~> 4.5.0)
+  redlock
   riiif (~> 2.5.0)
   roo (~> 2.9.0)
   rsolr (~> 2.5.0)

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -2,13 +2,6 @@
 class CreateDerivativesJob < Hyrax::ApplicationJob
   queue_as :derivatives
 
-  sidekiq_retry_in do |count, exception, jobhash|
-    case exception
-    when SofficeTimeoutError
-      :kill
-    end
-  end
-
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -2,6 +2,13 @@
 class CreateDerivativesJob < Hyrax::ApplicationJob
   queue_as :derivatives
 
+  sidekiq_retry_in do |count, exception, jobhash|
+    case exception
+    when SofficeTimeoutError
+      :kill
+    end
+  end
+
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path

--- a/app/overrides/lib/hydra/derivatives/processors/document_override.rb
+++ b/app/overrides/lib/hydra/derivatives/processors/document_override.rb
@@ -7,13 +7,13 @@ class SofficeTimeoutError < Hydra::Derivatives::TimeoutError; end
 Hydra::Derivatives::Processors::Document.class_eval do
   # [hyc-override] Use Redlock to manage soffice process lock
   LOCK_KEY = 'soffice:document_conversion'
-  LOCK_TIMEOUT = 6 * 60 * 1000
-  JOB_TIMEOUT_SECONDS = 30
+  LOCK_TIMEOUT = 6 * 60 * 1000 # Lock timeout should be longer than the job timeout
+  JOB_TIMEOUT_SECONDS = 5 * 60
   LOCK_MANAGER = Redlock::Client.new([Redis.current])
 
   # [hyc-override] Adding in a graceful termination before hard kill, use spawn for process group
   def self.execute_with_timeout(timeout, command, context)
-    stdout, stderr = "", ""
+    stdout, stderr = '', ''
     pid = nil
     status = nil
 
@@ -23,7 +23,7 @@ Hydra::Derivatives::Processors::Document.class_eval do
       stderr_r, stderr_w = IO.pipe
 
       # Use Process.spawn to start the command with process group
-      pid = Process.spawn(command, :pgroup => true, :out => stdout_w, :err => stderr_w)
+      pid = Process.spawn(command, pgroup: true, out: stdout_w, err: stderr_w)
 
       # Close unused ends in parent process
       stdout_w.close
@@ -43,39 +43,45 @@ Hydra::Derivatives::Processors::Document.class_eval do
     raise "Unable to execute command \"#{command}\". Exit code: #{status}\nError message: #{stderr}" unless status == 0
   rescue Timeout::Error
      # If it times out, terminate the process
-     if pid
+    if pid
+      Rails.logger.warn("Terminating soffice process #{pid} after #{timeout} seconds")
       Process.kill('TERM', pid) # Attempt a graceful termination
       sleep 5 # Give it a few seconds to exit
-      Process.kill('KILL', pid) if system("ps -p #{pid}") # Force kill if still running
-    end
+      if system("ps -p #{pid}")
+        Rails.logger.warn("Killing soffice process #{pid} after graceful termination failed")
+        Process.kill('KILL', pid)
+      end
+      # Harvest the defunct process so it doesn't linger forever
+      Process.wait(pid)
+   end
     # Raise a custom error to prevent Sidekiq from retrying
     raise SofficeTimeoutError, "soffice process timed out after #{timeout} seconds"
   rescue EOFError
-    Rails.logger.debug "Caught an eof error in ShellBasedProcessor"
+    Rails.logger.debug 'Caught an eof error in ShellBasedProcessor'
   end
 
-  # [hyc-override] Trigger kill if soffice process takes too long, and throw a non-retry error if that happens
   def self.encode(path, format, outdir, timeout = JOB_TIMEOUT_SECONDS)
-    Rails.logger.error("Converting document to #{format} from source path: #{path} to destination file: #{outdir}")
-    Rails.logger.error("Encode backtrace #{Thread.current.backtrace.join("\n")}")
-    command = "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} #{Shellwords.escape(path)}"
-    execute_with_timeout(timeout, command, {})
+    # [hyc-override] Use Redlock to manage soffice process lock, since only one soffice process can run at a time
+    LOCK_MANAGER.lock(LOCK_KEY, LOCK_TIMEOUT) do |locked|
+      if locked
+        Rails.logger.error("Acquired lock for document conversion of #{source_path}")
+        Rails.logger.debug("Encoding document to #{format} from source path: #{path} to destination file: #{outdir}")
+        command = "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} #{Shellwords.escape(path)}"
+        # [hyc-override] Use execute_with_timeout directly
+        execute_with_timeout(timeout, command, {})
+      else
+        sleep(0.5)
+        retry
+      end
+    end
+    Rails.logger.debug("Released soffice lock for #{source_path}")
   end
 
   # Converts the document to the format specified in the directives hash.
   # TODO: file_suffix and options are passed from ShellBasedProcessor.process but are not needed.
   #       A refactor could simplify this.
   def encode_file(_file_suffix, _options = {})
-    # [hyc-override] Use Redlock to manage soffice process lock, since only one soffice process can run at a time
-    LOCK_MANAGER.lock(LOCK_KEY, LOCK_TIMEOUT) do |locked|
-      if locked
-        Rails.logger.error("Acquired lock for document conversion of #{source_path}")
-        convert_to_format
-      else
-        raise "Could not acquire lock for document conversion of #{source_path}"
-      end
-    end
-    Rails.logger.error("Released lock for #{source_path}")
+    convert_to_format
   ensure
     FileUtils.rm_f(converted_file)
     # [hyc-override] clean up the parent temp dir

--- a/app/overrides/lib/hydra/derivatives/processors/document_override.rb
+++ b/app/overrides/lib/hydra/derivatives/processors/document_override.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # [hyc-override] https://github.com/samvera/hydra-derivatives/blob/v3.8.0/lib/hydra/derivatives/processors/document.rb
-class SofficeTimeoutError < Sidekiq::JobRetry::NoRetryError; end
+class SofficeTimeoutError; end
 
 Hydra::Derivatives::Processors::Document.class_eval do
   # [hyc-override] Trigger kill if soffice process takes too long, and throw a non-retry error if that happens

--- a/app/overrides/lib/hydra/derivatives/processors/document_override.rb
+++ b/app/overrides/lib/hydra/derivatives/processors/document_override.rb
@@ -6,9 +6,9 @@ class SofficeTimeoutError < StandardError; end
 
 Hydra::Derivatives::Processors::Document.class_eval do
   # [hyc-override] Use Redlock to manage soffice process lock
-  LOCK_KEY = "soffice:document_conversion"
+  LOCK_KEY = 'soffice:document_conversion'
   LOCK_TIMEOUT = 6 * 60 * 1000
-  JOB_TIMEOUT_SECONDS = 30
+  JOB_TIMEOUT_SECONDS = 300
   LOCK_MANAGER = Redlock::Client.new([Redis.current])
 
   # [hyc-override] Trigger kill if soffice process takes too long, and throw a non-retry error if that happens
@@ -32,9 +32,6 @@ Hydra::Derivatives::Processors::Document.class_eval do
       raise SofficeTimeoutError, "soffice process timed out after #{timeout} seconds"
     end
   end
-
-  # TODO: soffice can only run one command at a time. Right now we manage this by only running one
-  # background job at a time; however, if we want to up concurrency we'll need to deal with this
 
   # Converts the document to the format specified in the directives hash.
   # TODO: file_suffix and options are passed from ShellBasedProcessor.process but are not needed.

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -194,7 +194,7 @@ Hyrax.config do |config|
   config.fits_path = ENV['FITS_LOCATION']
 
   # Path to the file derivatives creation tool
-  # config.libreoffice_path = "soffice"
+  config.libreoffice_path = ENV['LIBREOFFICE_PATH'] || 'soffice'
 
   # Option to enable/disable full text extraction from PDFs
   # Default is true, set to false to disable full text extraction

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,7 @@
 ---
 # In production this is overridden by a template in the vagrant-rails project
 :concurrency: 6
-:max_retries: 5
+:max_retries: 3
 :queues:
   - default
   - derivatives

--- a/spec/lib/hydra/derivatives/processors/document_spec.rb
+++ b/spec/lib/hydra/derivatives/processors/document_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Hydra::Derivatives::Processors::Document do
         allow(Process).to receive(:spawn).and_return(PID)
         # Simulate timeout
         allow(Process).to receive(:wait2).with(PID).and_raise(Timeout::Error)
+        allow(Process).to receive(:wait).with(PID)
 
         # Mock Process.kill to simulate killing the process
         allow(Process).to receive(:kill)
@@ -74,6 +75,8 @@ RSpec.describe Hydra::Derivatives::Processors::Document do
         expect(Process).to have_received(:spawn)
         expect(Process).to have_received(:kill).with('TERM', PID) # Attempted graceful termination
         expect(Process).to have_received(:kill).with('KILL', PID) # Force kill if necessary
+        # Verify that process was reaped after being killed
+        expect(Process).to have_received(:wait).with(PID)
       end
     end
 


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1988

* If an soffice run times out, the job will attempt a graceful termination, followed by a hard kill. It also now reaps the process if it was killed, to prevent defunct processes from sticking around forever
* Added a lock to soffice processing to prevent multiple runs at once, since apparently it does not support this
    * Added explicit dependency on redlock, which was already getting included via hyrax
* Decreased the number of retries per job from 5 to 3, since jobs rarely recover and block up queues for long periods
* Allow soffice path to be configured from a property