### PR TITLE
HYC-1997 - Affiliation Updates

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -76,7 +76,6 @@ class CatalogController < ApplicationController
     end
   end
 
-
   configure_blacklight do |config|
     # Advanced search configuration
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
@@ -138,7 +137,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_facet_field solr_name('resource_type', :facetable), label: 'Resource Type', limit: 5
     config.add_facet_field solr_name('creator_label', :facetable), label: 'Creator', limit: 5
-    config.add_facet_field solr_name('affiliation_label', :facetable), label: 'Departments', limit: 5
+    config.add_facet_field solr_name('affiliation_label', :facetable), label: 'Departments', limit: 5, helper_method: :format_affiliation_facet
     # Search results version of the date_issued facet
     config.add_facet_field 'date_issued_isim', field: 'date_issued_isim', label: 'Date', range: true, range_config: {
       input_label_range_begin: 'from year',

--- a/app/helpers/hyc_helper.rb
+++ b/app/helpers/hyc_helper.rb
@@ -23,7 +23,6 @@ module HycHelper
   # Format affiliation to display short label if available, otherwise display the original facet value
   def format_affiliation_facet(facet_value)
     label = DepartmentsService.short_label(facet_value)
-    Rails.logger.error("Getting affiliation label for '#{facet_value}': #{label}")
     label.blank? ? facet_value : label
   end
 

--- a/app/helpers/hyc_helper.rb
+++ b/app/helpers/hyc_helper.rb
@@ -20,6 +20,13 @@ module HycHelper
     options
   end
 
+  # Format affiliation to display short label if available, otherwise display the original facet value
+  def format_affiliation_facet(facet_value)
+    label = DepartmentsService.short_label(facet_value)
+    Rails.logger.error("Getting affiliation label for '#{facet_value}': #{label}")
+    label.blank? ? facet_value : label
+  end
+
   def get_work_url(model, id)
     Rails.application.routes.url_helpers.send("#{Hyrax::Name.new(model).singular_route_key}_url", id)
   end

--- a/app/overrides/lib/active-fedora/rdf/indexing_service_override.rb
+++ b/app/overrides/lib/active-fedora/rdf/indexing_service_override.rb
@@ -125,7 +125,7 @@ ActiveFedora::RDF::IndexingService.class_eval do
         display_text << "ORCID: #{orcid.first}" unless orcid.first.blank?
         @orcid_label.push(orcid)
 
-        display_text = build_affiliations(person['affiliation'], display_text)
+        add_affiliation(person['affiliation'], display_text)
 
         other_affil = Array(person['other_affiliation'])
         display_text << "Other Affiliation: #{other_affil.first}" unless other_affil.first.blank?
@@ -137,31 +137,14 @@ ActiveFedora::RDF::IndexingService.class_eval do
     displays.flatten
   end
 
-  def build_affiliations(affiliation_identifier, display_text)
-    affiliations = split_affiliations(affiliation_identifier)
-    unless affiliations.blank?
-      display_text << "Affiliation: #{affiliations.join(', ')}"
-
-      affiliation_ids = Array(affiliation_identifier)
-      short_labels = affiliation_ids.map do |affil_id|
-        DepartmentsService.short_label(affil_id)
-      end
-      @affiliation_label.push(short_labels)
-    end
-
-    display_text
-  end
-
-  # split affiliations out
-  def split_affiliations(affiliations)
-    affiliations_list = []
-
-    Array(affiliations).reject { |a| a.blank? }.each do |aff|
-      Array(DepartmentsService.term(aff)).join(';').split(';').each do |value|
-        affiliations_list.push(value.squish!)
+  def add_affiliation(affiliation_relation, display_text)
+    affiliation_identifier = Array(affiliation_relation).first
+    term = DepartmentsService.term(affiliation_identifier)
+    if term.present?
+      display_text << "Affiliation: #{affiliation_identifier}"
+      term.split(';').each do |term_val|
+        @affiliation_label.push(term_val.strip)
       end
     end
-
-    affiliations_list.uniq
   end
 end

--- a/app/renderers/hyrax/renderers/person_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/person_attribute_renderer.rb
@@ -10,16 +10,10 @@ module Hyrax
 
         markup << %(<dt>#{label}</dt>\n<dd><ul class='tabular'>)
         attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
-        # conditional can be removed once all people objects have indexes
-        if values.first.match('index:')
-          sort_people_by_index(values).each do |value|
-            markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
-          end
-        else
-          Array(values).each do |value|
-            markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
-          end
+        sort_people_by_index(values).each do |value|
+          markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
         end
+
         markup << %(</ul></dd>)
         # Add 'itemprop' to default list of allowed attributes
         sanitize markup, attributes: %w(href src width height alt cite datetime title class name xml:lang abbr itemprop itemtype target)
@@ -30,26 +24,15 @@ module Hyrax
       def attribute_value_to_html(value)
         person = value.split('||')
         display_text = ''
-        # conditional can be removed once all people objects have indexes
-        if value.match('index:')
-          display_text << "<li><span#{html_attributes(microdata_value_attributes(field.to_s.chomp('_display')))}>#{person[1]}</span>"
-          if person.length > 2
-            display_text << '<ul>'
-            person[2..-1].each do |attr|
-              display_text << "<li>#{format_attribute(attr)}</li>"
-            end
-            display_text << '</ul>'
+        display_text << "<li><span#{html_attributes(microdata_value_attributes(field.to_s.chomp('_display')))}>#{person[1]}</span>"
+        if person.length > 2
+          display_text << '<ul>'
+          person[2..-1].each do |attr|
+            display_text << "<li>#{format_attribute(attr)}</li>"
           end
-        else
-          display_text << "<li><span#{html_attributes(microdata_value_attributes(field.to_s.chomp('_display')))}>#{person[0]}</span>"
-          if person.length > 1
-            display_text << '<ul>'
-            person[1..-1].each do |attr|
-              display_text << "<li>#{format_attribute(attr)}</li>"
-            end
-            display_text << '</ul>'
-          end
+          display_text << '</ul>'
         end
+
         display_text << '</li>'
       rescue ArgumentError
         value
@@ -60,6 +43,14 @@ module Hyrax
           text_pieces = text.split(' ')
           url = text_pieces[1].strip
           text = "#{text_pieces[0]} <a href='#{url}' target='_blank'>#{url}</a>"
+        elsif text =~ /Affiliation:/
+          # Get the full hierarchy of terms, with correct short labels, for the affiliation id
+          term = DepartmentsService.term(text.split(':').last.strip)
+          if term.present?
+            text = term.split(';').map do |term_val|
+              DepartmentsService.short_label(term_val.strip)
+            end.join(', ')
+          end
         end
 
         text

--- a/app/services/departments_service.rb
+++ b/app/services/departments_service.rb
@@ -6,7 +6,7 @@ module DepartmentsService
 
   def self.select_all_options
     authority.all.reject { |item| item['active'] == false }.map do |element|
-      [element[:id], element[:id]]
+      [element[:short_label], element[:id]]
     end
   end
 

--- a/config/authorities/departments.yml
+++ b/config/authorities/departments.yml
@@ -60,6 +60,10 @@ terms:
   term: Gillings School of Global Public Health; Carolina Global Breastfeeding Institute
   active: true
   short_label: Carolina Global Breastfeeding Institute
+- id: Carolina Health Informatics Program
+  term: Carolina Health Informatics Program
+  active: true
+  short_label: Carolina Health Informatics Program
 - id: Neurodevelopment Disorders Research Center
   term: School of Medicine; Neurodevelopment Disorders Research Center; Carolina Institute for Developmental Disabilities
   active: false
@@ -176,6 +180,10 @@ terms:
   term: School of Medicine; Center for Heart and Vascular Care
   active: true
   short_label: Center for Heart and Vascular Care
+- id: Center for Information, Technology, and Public Life
+  term: Center for Information, Technology, and Public Life
+  active: true
+  short_label: Center for Information, Technology, and Public Life
 - id: Center for Integrative Chemical Biology and Drug Discovery
   term: Eshelman School of Pharmacy; Center for Integrative Chemical Biology and Drug Discovery
   active: true
@@ -317,9 +325,9 @@ terms:
   active: true
   short_label: Curriculum in Russian and East European Studies
 - id: Curriculum in Toxicology
-  term: School of Medicine; Curriculum in Toxicology
+  term: School of Medicine; Curriculum in Toxicology and Environmental Medicine
   active: true
-  short_label: Curriculum in Toxicology
+  short_label: Curriculum in Toxicology and Environmental Medicine
 - id: CF/Pulmonary Research and Treatment Center
   term: School of Medicine; Cystic Fibrosis and Pulmonary Diseases Research and Treatment Center
   active: false
@@ -549,9 +557,9 @@ terms:
   active: true
   short_label: Department of Genetics
 - id: Department of Geography
-  term: College of Arts and Sciences; Department of Geography
+  term: College of Arts and Sciences; Department of Geography and Environment
   active: true
-  short_label: Department of Geography
+  short_label: Department of Geography and Environment
 - id: Department of Geological Sciences
   term: College of Arts and Sciences; Department of Geological Sciences
   active: true
@@ -908,6 +916,10 @@ terms:
   term: School of Medicine; Department of Allied Health Sciences; Division of Occupational Science and Occupational Therapy
   active: true
   short_label: Division of Occupational Science and Occupational Therapy
+- id: Division of Pediatric Dermatology
+  term: School of Medicine; Department of Dermatology; Division of Pediatric Dermatology
+  active: true
+  short_label: Division of Pediatric Dermatology
 - id: Division of Pharmaceutical Outcomes and Policy
   term: Eshelman School of Pharmacy; Division of Pharmaceutical Outcomes and Policy
   active: true
@@ -924,6 +936,14 @@ terms:
   term: School of Medicine; Department of Allied Health Sciences; Division of Physical Therapy
   active: true
   short_label: Division of Physical Therapy
+- id: Division of Plastic and Reconstructive Surgery
+  term: School of Medicine; Department of Surgery; Division of Plastic and Reconstructive Surgery
+  active: true
+  short_label: Division of Plastic and Reconstructive Surgery
+- id: Division of Practice Advancement and Clinical Education
+  term: Eshelman School of Pharmacy; Division of Practice Advancement and Clinical Education
+  active: true
+  short_label: Division of Practice Advancement and Clinical Education
 - id: Division of Pulmonary Diseases and Critical Care Medicine
   term: School of Medicine; Department of Medicine; Division of Pulmonary Diseases and Critical Care Medicine
   active: true
@@ -1372,10 +1392,18 @@ terms:
   term: School of Education; School Counseling Graduate Program
   active: true
   short_label: School Counseling Graduate Program
-- id: School of Dentistry
-  term: School of Dentistry
+- id: School of Civic Life and Leadership
+  term: School of Civic Life and Leadership
   active: true
-  short_label: School of Dentistry
+  short_label: School of Civic Life and Leadership
+- id: School of Data Science and Society
+  term: School of Data Science and Society
+  active: true
+  short_label: School of Data Science and Society
+- id: School of Dentistry
+  term: Adams School of Dentistry
+  active: true
+  short_label: Adams School of Dentistry
 - id: School of Education
   term: School of Education
   active: true
@@ -1548,6 +1576,22 @@ terms:
   term: School of Medicine; UNC/NCSU Joint Department of Biomedical Engineering
   active: true
   short_label: UNC/NCSU Joint Department of Biomedical Engineering
+- id: UNC Project-Liberia
+  term: School of Medicine; UNC Project-Liberia
+  active: true
+  short_label: UNC Project-Liberia
+- id: UNC Project-Nicaragua
+  term: School of Medicine; UNC Project-Nicaragua
+  active: true
+  short_label: UNC Project-Nicaragua
+- id: UNC Project-Vietnam
+  term: School of Medicine; UNC Project-Vietnam
+  active: true
+  short_label: UNC Project-Vietnam
+- id: UNC Project-Zambia
+  term: School of Medicine; UNC Project-Zambia
+  active: true
+  short_label: UNC Project-Zambia
 - id: University of North Carolina at Chapel Hill. Graduate School
   term: University of North Carolina at Chapel Hill. Graduate School
   active: true

--- a/config/authorities/departments.yml
+++ b/config/authorities/departments.yml
@@ -165,7 +165,7 @@ terms:
   active: false
   short_label: Heart and Vascular Center
 - id: Center for Esophageal Diseases and Swallowing
-  term: School of Medicine, Department of Medicine, Center for Esophageal Diseases and Swallowing
+  term: School of Medicine; Department of Medicine; Center for Esophageal Diseases and Swallowing
   active: true
   short_label: Center for Esophageal Diseases and Swallowing
 - id: Center for Faculty Excellence
@@ -201,7 +201,7 @@ terms:
   active: true
   short_label: Center for Nanotechnology in Drug Delivery
 - id: Center for Pain Research and Innovation
-  term: School of Dentistry, Center for Pain Research and Innovation
+  term: School of Dentistry; Center for Pain Research and Innovation
   active: true
   short_label: Center for Pain Research and Innovation
 - id: Center of Pharmacogenomics and Individualized Therapy
@@ -769,7 +769,7 @@ terms:
   active: true
   short_label: Department of Religious Studies
 - id: Department of Research Computing
-  term: Information Technology Services, Department of Research Computing
+  term: Information Technology Services; Department of Research Computing
   active: true
   short_label: Department of Research Computing
 - id: Department of Romance Languages
@@ -845,7 +845,7 @@ terms:
   active: true
   short_label: Division of Cardiology
 - id: Division of Cardiothoracic Surgery
-  term: School of Medicine, Department of Surgery, Division of Cardiothoracic Surgery
+  term: School of Medicine; Department of Surgery; Division of Cardiothoracic Surgery
   active: true
   short_label: Division of Cardiothoracic Surgery
 - id: Division of Chemical Biology and Medicinal Chemistry
@@ -1189,7 +1189,7 @@ terms:
   active: true
   short_label: Mass Communication Graduate Program
 - id: Marsico Lung Institute/UNC Cystic Fibrosis Center
-  term: School of Medicine, Marsico Lung Institute/UNC Cystic Fibrosis Center
+  term: School of Medicine; Marsico Lung Institute/UNC Cystic Fibrosis Center
   active: true
   short_label: Marsico Lung Institute/UNC Cystic Fibrosis Center
 - id: Materials Science Program
@@ -1205,7 +1205,7 @@ terms:
   active: false
   short_label: Mathematical Decision Sciences Program
 - id: Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center
-  term: College of Arts and Sciences, Department of Exercise and Sports Science, Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center
+  term: College of Arts and Sciences; Department of Exercise and Sports Science; Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center
   active: true
   short_label: Matthew Gfeller Sport-Related Traumatic Brain Injury Research Center
 - id: Michael Hooker Microscopy Facility
@@ -1217,7 +1217,7 @@ terms:
   active: true
   short_label: Molecular and Cellular Pathology Graduate Program
 - id: Moore Undergraduate Research Apprenticeship Program (MURAP)
-  term: Institute of African American Research, Moore Undergraduate Research Apprenticeship Program (MURAP)
+  term: Institute of African American Research; Moore Undergraduate Research Apprenticeship Program (MURAP)
   active: true
   short_label: Moore Undergraduate Research Apprenticeship Program (MURAP)
 - id: Musicology Graduate Program
@@ -1245,7 +1245,7 @@ terms:
   active: true
   short_label: Neuroscience Curriculum
 - id: NIMH Psychoactive Drug Screening Program
-  term: School of Medicine, Department of Pharmacology, NIMH Psychoactive Drug Screening Program
+  term: School of Medicine; Department of Pharmacology; NIMH Psychoactive Drug Screening Program
   active: true
   short_label: NIMH Psychoactive Drug Screening Program
 - id: North Carolina Institute for Public Health
@@ -1313,7 +1313,7 @@ terms:
   active: true
   short_label: Organic Chemistry Program
 - id: Partnerships in Aging Program
-  term: Office of the Provost, Partnerships in Aging Program
+  term: Office of the Provost; Partnerships in Aging Program
   active: true
   short_label: Partnerships in Aging Program
 - id: Pathobiology and Translational Science Graduate Program
@@ -1633,7 +1633,7 @@ terms:
   active: false
   short_label: Louis Round Wilson Library
 - id: UNC Global Women's Health
-  term: School of Medicine, Department of Obstetrics and Gynecology, UNC Global Women's Health
+  term: School of Medicine; Department of Obstetrics and Gynecology; UNC Global Women's Health
   active: true
   short_label: UNC Global Women's Health
 - id: UNC Medical Center
@@ -1641,11 +1641,11 @@ terms:
   active: true
   short_label: UNC Medical Center
 - id: UNC Project-China
-  term: School of Medicine, UNC Project-China
+  term: School of Medicine; UNC Project-China
   active: true
   short_label: UNC Project-China
 - id: UNC Project-Malawi
-  term: School of Medicine, UNC Project-Malawi
+  term: School of Medicine; UNC Project-Malawi
   active: true
   short_label: UNC Project-Malawi
 - id: University of North Carolina at Chapel Hill

--- a/spec/helpers/hyc_helper_spec.rb
+++ b/spec/helpers/hyc_helper_spec.rb
@@ -37,4 +37,28 @@ RSpec.describe HycHelper do
       end
     end
   end
+
+  describe '#format_affiliation_facet' do
+    before do
+      # Configure QA to use fixtures
+      qa_fixtures = { local_path: File.expand_path('spec/fixtures/authorities') }
+      allow(Qa::Authorities::Local).to receive(:config).and_return(qa_fixtures)
+    end
+
+    context 'with valid facet value' do
+      let(:facet_value) { 'Department of Chemistry' }
+
+      it 'returns the short label for the facet value' do
+        expect(helper.format_affiliation_facet(facet_value)).to eq 'Test short Department of Chemistry'
+      end
+    end
+
+    context 'with invalid facet value' do
+      let(:invalid_facet_value) { 'not-a-department' }
+
+      it 'returns the original facet value' do
+        expect(helper.format_affiliation_facet(invalid_facet_value)).to eq invalid_facet_value
+      end
+    end
+  end
 end

--- a/spec/indexers/hyc_indexer_spec.rb
+++ b/spec/indexers/hyc_indexer_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe HycIndexer, type: :indexer do
     let(:solr_affiliation_array_sim) { solr_doc.fetch('affiliation_label_sim') }
 
     let(:solr_expected_creator_array) do
-      ['index:1||creator||Affiliation: School of Medicine, Carolina Center for Genome Sciences',
-       'index:2||creator2||Affiliation: College of Arts and Sciences, Department of Chemistry']
+      ['index:1||creator||Affiliation: Carolina Center for Genome Sciences',
+       'index:2||creator2||Affiliation: Department of Chemistry']
     end
     let(:fedora_creator_array) { work_with_people.creators.map(&:attributes) }
     let(:fedora_creator_hash_one) { fedora_creator_array.find { |hash| hash['index'] == [1] } }
@@ -58,8 +58,8 @@ RSpec.describe HycIndexer, type: :indexer do
       end
 
       it 'maps the affiliations to the facet with the short_label' do
-        expect(solr_affiliation_array_tesim).to match_array(['Test short Carolina Center for Genome Sciences', 'Test short Department of Chemistry'])
-        expect(solr_affiliation_array_sim).to match_array(['Test short Carolina Center for Genome Sciences', 'Test short Department of Chemistry'])
+        expect(solr_affiliation_array_tesim).to match_array(["Carolina Center for Genome Sciences", "College of Arts and Sciences", "Department of Chemistry", "School of Medicine"])
+        expect(solr_affiliation_array_sim).to match_array(["Carolina Center for Genome Sciences", "College of Arts and Sciences", "Department of Chemistry", "School of Medicine"])
       end
 
       it 'stores the id in Fedora' do
@@ -69,7 +69,7 @@ RSpec.describe HycIndexer, type: :indexer do
 
     context 'with a work ingested with ProQuest' do
       let(:solr_expected_creator_array) do
-        ['index:1||creator||Affiliation: School of Medicine, Curriculum in Genetics and Molecular Biology',
+        ['index:1||creator||Affiliation: Curriculum in Genetics and Molecular Biology',
          'index:2||creator2']
       end
       let(:work_with_people) do
@@ -89,8 +89,8 @@ RSpec.describe HycIndexer, type: :indexer do
 
       it 'only indexes the controlled affiliation to Solr' do
         expect(solr_creator_array).to match_array(solr_expected_creator_array)
-        expect(solr_affiliation_array_tesim).to match_array(['Test short Genetics and Molecular Biology'])
-        expect(solr_affiliation_array_sim).to match_array(['Test short Genetics and Molecular Biology'])
+        expect(solr_affiliation_array_tesim).to match_array(["Curriculum in Genetics and Molecular Biology", "School of Medicine"])
+        expect(solr_affiliation_array_sim).to match_array(["Curriculum in Genetics and Molecular Biology", "School of Medicine"])
       end
     end
 
@@ -150,8 +150,8 @@ RSpec.describe HycIndexer, type: :indexer do
 
     context 'with two of the same affiliation' do
       let(:solr_expected_creator_array) do
-        ['index:1||creator||Affiliation: School of Medicine, Carolina Center for Genome Sciences||Other Affiliation: Matching string',
-         'index:2||creator2||Affiliation: School of Medicine, Carolina Center for Genome Sciences||Other Affiliation: Matching string']
+        ['index:1||creator||Affiliation: Carolina Center for Genome Sciences||Other Affiliation: Matching string',
+         'index:2||creator2||Affiliation: Carolina Center for Genome Sciences||Other Affiliation: Matching string']
       end
       let(:work_with_people) do
         Dissertation.new(title: ['New General Work with people'],
@@ -170,8 +170,8 @@ RSpec.describe HycIndexer, type: :indexer do
       end
 
       it 'indexes the affiliations for faceting together' do
-        expect(solr_affiliation_array_tesim).to match_array(['Test short Carolina Center for Genome Sciences'])
-        expect(solr_affiliation_array_sim).to match_array(['Test short Carolina Center for Genome Sciences'])
+        expect(solr_affiliation_array_tesim).to match_array(["Carolina Center for Genome Sciences", "School of Medicine"])
+        expect(solr_affiliation_array_sim).to match_array(["Carolina Center for Genome Sciences", "School of Medicine"])
       end
     end
 
@@ -300,14 +300,14 @@ RSpec.describe HycIndexer, type: :indexer do
   describe 'indexing people objects' do
     let(:creator_array) { solr_doc.fetch('creator_display_tesim') }
     let(:expected_creator_array) do
-      ['index:1||creator||ORCID: creator orcid||Affiliation: School of Medicine, Carolina Center for Genome Sciences||Other Affiliation: another affiliation',
-       'index:2||creator2||ORCID: creator2 orcid||Affiliation: College of Arts and Sciences, Department of Chemistry||Other Affiliation: another affiliation']
+      ['index:1||creator||ORCID: creator orcid||Affiliation: Carolina Center for Genome Sciences||Other Affiliation: another affiliation',
+       'index:2||creator2||ORCID: creator2 orcid||Affiliation: Department of Chemistry||Other Affiliation: another affiliation']
     end
 
     let(:reviewer_array) { solr_doc.fetch('reviewer_display_tesim') }
     let(:expected_reviewer_array) do
-      ['index:1||reviewer||ORCID: reviewer orcid||Affiliation: School of Medicine, Carolina Center for Genome Sciences||Other Affiliation: another affiliation',
-       'index:2||reviewer2||ORCID: reviewer2 orcid||Affiliation: College of Arts and Sciences, Department of Chemistry||Other Affiliation: another affiliation']
+      ['index:1||reviewer||ORCID: reviewer orcid||Affiliation: Carolina Center for Genome Sciences||Other Affiliation: another affiliation',
+       'index:2||reviewer2||ORCID: reviewer2 orcid||Affiliation: Department of Chemistry||Other Affiliation: another affiliation']
     end
     let(:solr_doc) { described_class.new(work_with_people).generate_solr_document }
 
@@ -372,8 +372,8 @@ RSpec.describe HycIndexer, type: :indexer do
 
     context 'with a mix of submitted and unsubmitted index values' do
       let(:expected_creator_array) do
-        ['index:2||creator||ORCID: creator orcid||Affiliation: School of Medicine, Carolina Center for Genome Sciences||Other Affiliation: another affiliation',
-         'index:1||creator2||ORCID: creator2 orcid||Affiliation: College of Arts and Sciences, Department of Chemistry||Other Affiliation: another affiliation',
+        ['index:2||creator||ORCID: creator orcid||Affiliation: Carolina Center for Genome Sciences||Other Affiliation: another affiliation',
+         'index:1||creator2||ORCID: creator2 orcid||Affiliation: Department of Chemistry||Other Affiliation: another affiliation',
          'index:3||creator3||ORCID: creator3 orcid||Affiliation: Department of Chemistry||Other Affiliation: another affiliation']
       end
 

--- a/spec/indexers/hyc_indexer_spec.rb
+++ b/spec/indexers/hyc_indexer_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe HycIndexer, type: :indexer do
       end
 
       it 'maps the affiliations to the facet with the short_label' do
-        expect(solr_affiliation_array_tesim).to match_array(["Carolina Center for Genome Sciences", "College of Arts and Sciences", "Department of Chemistry", "School of Medicine"])
-        expect(solr_affiliation_array_sim).to match_array(["Carolina Center for Genome Sciences", "College of Arts and Sciences", "Department of Chemistry", "School of Medicine"])
+        expect(solr_affiliation_array_tesim).to match_array(['Carolina Center for Genome Sciences', 'College of Arts and Sciences', 'Department of Chemistry', 'School of Medicine'])
+        expect(solr_affiliation_array_sim).to match_array(['Carolina Center for Genome Sciences', 'College of Arts and Sciences', 'Department of Chemistry', 'School of Medicine'])
       end
 
       it 'stores the id in Fedora' do
@@ -89,8 +89,8 @@ RSpec.describe HycIndexer, type: :indexer do
 
       it 'only indexes the controlled affiliation to Solr' do
         expect(solr_creator_array).to match_array(solr_expected_creator_array)
-        expect(solr_affiliation_array_tesim).to match_array(["Curriculum in Genetics and Molecular Biology", "School of Medicine"])
-        expect(solr_affiliation_array_sim).to match_array(["Curriculum in Genetics and Molecular Biology", "School of Medicine"])
+        expect(solr_affiliation_array_tesim).to match_array(['Curriculum in Genetics and Molecular Biology', 'School of Medicine'])
+        expect(solr_affiliation_array_sim).to match_array(['Curriculum in Genetics and Molecular Biology', 'School of Medicine'])
       end
     end
 
@@ -170,8 +170,8 @@ RSpec.describe HycIndexer, type: :indexer do
       end
 
       it 'indexes the affiliations for faceting together' do
-        expect(solr_affiliation_array_tesim).to match_array(["Carolina Center for Genome Sciences", "School of Medicine"])
-        expect(solr_affiliation_array_sim).to match_array(["Carolina Center for Genome Sciences", "School of Medicine"])
+        expect(solr_affiliation_array_tesim).to match_array(['Carolina Center for Genome Sciences', 'School of Medicine'])
+        expect(solr_affiliation_array_sim).to match_array(['Carolina Center for Genome Sciences', 'School of Medicine'])
       end
     end
 

--- a/spec/lib/active_fedora/rdf/indexing_service_spec.rb
+++ b/spec/lib/active_fedora/rdf/indexing_service_spec.rb
@@ -50,15 +50,15 @@ RSpec.describe ActiveFedora::RDF::IndexingService do
           date_created: '2022-01-01')
 
       end
-      let(:translator1_string) { 'index:1||translator_1||Affiliation: School of Medicine, Carolina Center for Genome Sciences' }
-      let(:translator2_string) { 'index:2||translator_2||Affiliation: College of Arts and Sciences, Department of Chemistry' }
+      let(:translator1_string) { 'index:1||translator_1||Affiliation: Carolina Center for Genome Sciences' }
+      let(:translator2_string) { 'index:2||translator_2||Affiliation: Department of Chemistry' }
       subject(:solr_doc) do
         indexer.generate_solr_document
       end
 
       it 'includes person attributes' do
         expect(solr_doc['translator_display_tesim']).to include(translator1_string, translator2_string)
-        expect(solr_doc['creator_display_tesim']).to eq ['index:1||creator_1||Affiliation: School of Medicine, Carolina Center for Genome Sciences']
+        expect(solr_doc['creator_display_tesim']).to eq ['index:1||creator_1||Affiliation: Carolina Center for Genome Sciences']
         expect(solr_doc['person_label_tesim']).to include('advisor_1', 'translator_2', 'translator_1', 'creator_1', 'contributor_1')
         expect(solr_doc['affiliation_label_tesim']).to include('Department of Chemistry', 'Carolina Center for Genome Sciences')
         expect(solr_doc['affiliation_label_sim']).to include('Department of Chemistry', 'Carolina Center for Genome Sciences')

--- a/spec/services/departments_service_spec.rb
+++ b/spec/services/departments_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::DepartmentsService do
     end
   end
 
-  describe '#label' do
+  describe '#term' do
     it 'resolves for ids of active terms' do
       expect(service.term('history')).to eq('History')
     end

--- a/spec/services/departments_service_spec.rb
+++ b/spec/services/departments_service_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe Hyrax::DepartmentsService do
 
   describe '#select_all_options' do
     it 'returns only active terms' do
-      expect(service.select_all_options).to include(['biology', 'biology'], ['chemistry', 'chemistry'],
-                                                    ['history', 'history'])
+      expect(service.select_all_options).to include(['Biology', 'biology'], ['Chemistry', 'chemistry'],
+                                                    ['History', 'history'],
+                                                    ['Test short Carolina Center for Genome Sciences', 'Carolina Center for Genome Sciences'])
     end
   end
 


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1997

* Added and adjusted department vocabulary
    * Fixed incorrect comma delimiters in term fields
* All solr fields will not store the id for affiliations, both in affiliation_label_tesim and in person objects.
    * Facet filtering by affiliation is by id now, rather than by display form
    * Affiliation values get looked up in the vocab and translated to short_labels before display, in facets and work pages
* If a department is part of a hierarchy (so it has multiple semi-colon delimited sections in the `term` field), then the affiliation_label_tesim field will now have an entry for each step of the hierarchy, rather than just the final step before.
    * This means that "School of Medicine" and other top level affiliations will be listed for specific subdepartments, and can be used to find everything by the "School of Medicine".
* Removed conditional logic to deal person objects not having "index:" fields, since they should all have that now (search prod affirmed this)