### PR TITLE
HYC-1968 - Reindexing error handling

### DIFF
--- a/app/services/departments_service.rb
+++ b/app/services/departments_service.rb
@@ -12,16 +12,19 @@ module DepartmentsService
 
   # The permanent identifier for the term, stored in Fedora. This identifier should not be changed.
   def self.identifier(term)
+    return nil if term.blank?
     authority.all.reject { |item| item['active'] == false }.find { |department| department['label'] == term }['id']
   rescue StandardError
+    Rails.logger.warn "DepartmentsService: cannot find identifier for '#{id}'"
     nil
   end
 
   # The full term associated with the identifier. This is currently used in the display of People objects
   def self.term(id)
+    return nil if id.blank?
     authority.find(id).fetch('term')
   rescue StandardError
-    Rails.logger.warn "DepartmentsService: cannot find '#{id}'"
+    Rails.logger.warn "DepartmentsService: cannot find term for '#{id}'"
     nil
   end
 
@@ -29,9 +32,10 @@ module DepartmentsService
   # values as the identifiers, but unlike the identifiers, these values *can* be changed without negative effects.
   # This values is indexed to solr for department faceting.
   def self.short_label(id)
+    return nil if id.blank?
     authority.find(id).fetch('short_label')
   rescue KeyError
-    Rails.logger.warn "DepartmentsService: cannot find '#{id}'"
+    Rails.logger.warn "DepartmentsService: cannot find short_label for '#{id}'"
     nil
   end
 

--- a/app/services/languages_service.rb
+++ b/app/services/languages_service.rb
@@ -10,6 +10,7 @@ module LanguagesService
   end
 
   def self.label(id)
+    return nil if id.blank?
     authority.find(Array.wrap(id).first).fetch('term')
   rescue StandardError
     Rails.logger.debug "LanguagesService: cannot find '#{id}'"
@@ -18,9 +19,10 @@ module LanguagesService
   end
 
   def self.iso639_1(id)
+    return nil if id.blank?
     authority.find(id).fetch('iso639_1')
   rescue KeyError
-    Rails.logger.warn "DepartmentsService: cannot find '#{id}'"
+    Rails.logger.warn "LanguageService: cannot find '#{id}'"
     nil
   end
 

--- a/app/services/tasks/solr_migration_service.rb
+++ b/app/services/tasks/solr_migration_service.rb
@@ -117,6 +117,10 @@ module Tasks
         rescue Ldp::Gone => e
           puts "Object with id #{id} is gone, skipping"
           Rails.logger.warn "Object with id #{id} is gone, skipping"
+        rescue Ldp::HttpError => e
+          puts "An error occurred when retrieving object with id #{id} from fedora, skipping"
+          Rails.logger.error "An error occurred when retrieving object with id #{id} from fedora, skipping"
+          Rails.logger.error [e.class.to_s, e.message, *e.backtrace].join($RS)
         rescue ActiveFedora::ObjectNotFoundError => e
           Rails.logger.warn "Object with id #{id} was not found, skipping: #{e.message}"
         rescue JSON::GeneratorError => e

--- a/spec/services/departments_service_spec.rb
+++ b/spec/services/departments_service_spec.rb
@@ -25,11 +25,19 @@ RSpec.describe Hyrax::DepartmentsService do
     it 'resolves for ids of inactive terms' do
       expect(service.term('example')).to eq('Some College; Example Department')
     end
+
+    it 'returns nil for blank input' do
+      expect(service.term('')).to be_nil
+    end
   end
 
   describe '#identifier' do
     it 'resolves for labels of active terms' do
       expect(service.identifier('History')).to eq('history')
+    end
+
+    it 'returns nil for blank input' do
+      expect(service.identifier('')).to be_nil
     end
   end
 
@@ -40,6 +48,10 @@ RSpec.describe Hyrax::DepartmentsService do
 
     it 'resolves for ids of inactive terms' do
       expect(service.short_label('example')).to eq('Example Department')
+    end
+
+    it 'returns nil for blank input' do
+      expect(service.short_label('')).to be_nil
     end
 
     it 'logs but does not raise error for non-existent terms' do

--- a/spec/services/languages_service_spec.rb
+++ b/spec/services/languages_service_spec.rb
@@ -21,5 +21,19 @@ RSpec.describe Hyrax::LanguagesService do
     it 'resolves for ids of terms' do
       expect(service.label('http://id.loc.gov/vocabulary/iso639-2/eng')).to eq('English')
     end
+
+    it 'returns nil for blank input' do
+      expect(service.label('')).to be_nil
+    end
+  end
+
+  describe '#iso639_1' do
+    it 'resolves for ids of terms' do
+      expect(service.iso639_1('http://id.loc.gov/vocabulary/iso639-2/eng')).to eq('en')
+    end
+
+    it 'returns nil for blank input' do
+      expect(service.iso639_1('')).to be_nil
+    end
   end
 end


### PR DESCRIPTION

* Handle Ldp:HttpError by logging it and then continuing with reindex
* Don't log vocab warning when a blank key is provided to services