### PR TITLE
HYC-2002 - Prevent nil workdata from being added for downloads

### DIFF
--- a/app/controllers/concerns/hyc/download_analytics_behavior.rb
+++ b/app/controllers/concerns/hyc/download_analytics_behavior.rb
@@ -65,9 +65,9 @@ module Hyc
 
         stat = HycDownloadStat.find_or_initialize_by(
           fileset_id: fileset_id,
-          work_id: work_data[:work_id],
-          admin_set_id: work_data[:admin_set_id],
-          work_type: work_data[:work_type],
+          work_id: work_data[:work_id] || 'Unknown',
+          admin_set_id: work_data[:admin_set_id] || 'Unknown',
+          work_type: work_data[:work_type] || 'Unknown',
           date: date.beginning_of_month
         )
         stat.download_count += 1

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 require Rails.root.join('app/overrides/controllers/hydra/controller/download_behavior_override.rb')
 require Rails.root.join('app/overrides/controllers/hyrax/downloads_controller_override.rb')
+require 'hyrax/analytics'
 
 RSpec.describe Hyrax::DownloadsController, type: :controller do
   routes { Hyrax::Engine.routes }
@@ -209,11 +210,11 @@ RSpec.describe Hyrax::DownloadsController, type: :controller do
     context 'fileset without a parent work' do
       before do
         dummy_work_data = {
-          work_id: 'Unknown',
-          work_type: 'Unknown',
-          title: 'Unknown',
-          admin_set_id: 'Unknown',
-          admin_set_name: 'Unknown'
+          work_id: nil,
+          work_type: nil,
+          title: nil,
+          admin_set_id: nil,
+          admin_set_name: nil
         }
         allow(WorkUtilsHelper).to receive(:fetch_work_data_by_fileset_id).and_return(dummy_work_data)
       end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2002

It seems like setting Unknown has moved around a bunch of times, but the analytics behavior didn't get informed of the last move?
https://github.com/UNC-Libraries/hy-c/commit/bf2925f84f45dc6ad30253321040bad056fe7f2d
https://github.com/UNC-Libraries/hy-c/commit/4c583d2b450a954a9205879d04b1c93054566b3f