### PR TITLE
HYC-1999 - Disable copy-pasted text styling in rich text fields

### DIFF
--- a/app/renderers/hyrax/renderers/formatted_text_renderer.rb
+++ b/app/renderers/hyrax/renderers/formatted_text_renderer.rb
@@ -23,6 +23,8 @@ module Hyrax
     # Same as attribute renderer override, but without escaping the value
       def li_value(value)
         field_value = find_language(value) || value
+        # Use get_sanitized_string instead of auto_link sanitization to preserve HTML tags (specifically underline)
+        get_sanitized_string(field_value)
         auto_link(field_value, sanitize: false)
       end
     end

--- a/app/renderers/hyrax/renderers/formatted_text_renderer.rb
+++ b/app/renderers/hyrax/renderers/formatted_text_renderer.rb
@@ -23,7 +23,7 @@ module Hyrax
     # Same as attribute renderer override, but without escaping the value
       def li_value(value)
         field_value = find_language(value) || value
-        auto_link((field_value))
+        auto_link(field_value, sanitize: false)
       end
     end
   end

--- a/app/services/hyrax/workflow/deposited_viewer_notification.rb
+++ b/app/services/hyrax/workflow/deposited_viewer_notification.rb
@@ -58,7 +58,9 @@ module Hyrax
         only_viewers = user_role_map.select { |user_id, role_counts| role_counts['view'] > 0 &&  role_counts['manage'] == 0 }
         viewer_ids = only_viewers.keys.map(&:to_i)
         # Fetch users directly from the database
-        ::User.where(id: viewer_ids).to_a + recipients['cc']
+        users = ::User.where(id: viewer_ids).to_a
+        # Add carbon copy recipients
+        users.concat(recipients['cc'] || [])
       end
     end
   end

--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -14,7 +14,8 @@ rich_text:
   toolbar:
     - "undo redo | bold italic underline | alignleft aligncenter alignright | link | numlist bullist outdent indent | blockquote | code"
   plugins:
-    - "link lists code"
+    - "link lists code paste"
+  invalid_styles: "color font-family"
   style_formats:
     - title: "Inline"
       items:


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-1999

- Update tinymce configuration to disable font family and color styles
- Autolink no longer sanitizes text in li_value (was removing underlines in methodology field)
- Duplicate user key caused issues running the development environment