### PR TITLE
HYC-2056 - Fix people without affiliations not displaying

### DIFF
--- a/app/renderers/hyrax/renderers/person_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/person_attribute_renderer.rb
@@ -34,7 +34,7 @@ module Hyrax
           end
           display_text << '</ul>'
         end
-
+        display_text
       rescue ArgumentError
         value
       end

--- a/spec/renderers/hyrax/renderers/person_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/person_attribute_renderer_spec.rb
@@ -52,5 +52,24 @@ RSpec.describe Hyrax::Renderers::PersonAttributeRenderer do
 
       it { expect(subject).to be_equivalent_to(expected) }
     end
+
+    context 'with creator with no affiliation' do
+      let(:field) { :creator_display }
+      let(:renderer) { described_class.new(field, ['index:1||lone, person||']) }
+      let(:tr_content) do
+        %(
+          <dt>Creator display</dt>
+          <dd>
+            <ul class="tabular">
+              <li itemprop="creator" itemtype="http://schema.org/Person" class="attribute attribute-creator_display">
+                <span>lone, person</span>
+              </li>
+            </ul>
+          </dd>
+        )
+      end
+
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
   end
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2056

* Add explicit return of display_text, otherwise nothing gets returned if there are no sub-attributes for a person