### PR TITLE
HYC-2009 - Get tinymce to work on abstract fields after the first one

### DIFF
--- a/app/assets/javascripts/hydra-editor/field_manager.es6
+++ b/app/assets/javascripts/hydra-editor/field_manager.es6
@@ -1,0 +1,219 @@
+// [hyc-override] https://github.com/samvera/hydra-editor/blob/v6.2.0/app/assets/javascripts/hydra-editor/field_manager.es6
+export class FieldManager {
+    constructor(element, options) {
+        this.element = $(element);
+
+        this.options = options;
+
+        this.options.label = this.getFieldLabel(this.element, options)
+
+        this.addSelector = '.add'
+        this.removeSelector = '.remove'
+
+        this.adder    = this.createAddHtml(this.options)
+        this.remover  = this.createRemoveHtml(this.options)
+
+        this.controls = $(options.controlsHtml);
+
+        this.inputTypeClass = options.inputTypeClass;
+        this.fieldWrapperClass = options.fieldWrapperClass;
+        this.warningClass = options.warningClass;
+        this.listClass = options.listClass;
+        // [hyc-override] - Capture TinyMCE configuration
+        this.tinyMCEConfig = TinyMCERails.configuration.rich_text;
+
+        this.init();
+    }
+
+    init() {
+        this._addInitialClasses();
+        this._addAriaLiveRegions()
+        this._appendControls();
+        this._attachEvents();
+        this._addCallbacks();
+    }
+
+    _addInitialClasses() {
+        this.element.addClass("managed");
+        $(this.fieldWrapperClass, this.element).addClass("input-group input-append");
+    }
+
+    _addAriaLiveRegions() {
+        $(this.element).find('.listing').attr('aria-live', 'polite')
+    }
+
+    // Add the "Add another" and "Remove" controls to the DOM
+    _appendControls() {
+        // We want to make these DOM additions idempotently, so exit if it's
+        // already set up.
+        if (!this._hasRemoveControl()) {
+            this._createRemoveWrapper()
+            this._createRemoveControl()
+        }
+
+        if (!this._hasAddControl()) {
+            this._createAddControl()
+        }
+    }
+
+    _createRemoveWrapper() {
+        $(this.fieldWrapperClass, this.element).append(this.controls);
+    }
+
+    _createRemoveControl() {
+        $(this.fieldWrapperClass + ' .field-controls', this.element).append(this.remover)
+    }
+
+    _createAddControl() {
+        this.element.find(this.listClass).after(this.adder)
+    }
+
+    _hasRemoveControl() {
+        return this.element.find(this.removeSelector).length > 0
+    }
+
+    _hasAddControl() {
+        return this.element.find(this.addSelector).length > 0
+    }
+
+    _attachEvents() {
+        this.element.on('click', this.removeSelector, (e) => this.removeFromList(e))
+        this.element.on('click', this.addSelector, (e) => this.addToList(e))
+    }
+
+    _addCallbacks() {
+        this.element.bind('managed_field:add', this.options.add);
+        this.element.bind('managed_field:remove', this.options.remove);
+    }
+
+    _manageFocus() {
+        $(this.element).find(this.listClass).children('li').last().find('.form-control').focus();
+    }
+
+    addToList( event ) {
+        event.preventDefault();
+        let $listing = $(event.target).closest(this.inputTypeClass).find(this.listClass)
+        let $activeField = $listing.children('li').last()
+
+        if (this.inputIsEmpty($activeField)) {
+            this.displayEmptyWarning();
+        } else {
+            this.clearEmptyWarning();
+            $listing.append(this._newField($activeField));
+        }
+
+        this._manageFocus()
+    }
+
+    inputIsEmpty($activeField) {
+        return $activeField.children('input.multi-text-field').val() === '';
+    }
+
+    _newField ($activeField) {
+        var $newField = this.createNewField($activeField);
+        return $newField;
+    }
+
+    // [hyc-override] - Update the field ID to be unique
+    _updateFieldId($field) {
+        let currentId = $field.attr('id');
+        let idParts = currentId.split('_');
+
+        if (idParts.length === 1) {
+            $field.attr('id', `${currentId}_1`)
+        } else {
+            let id = parseInt(idParts[idParts.length - 1])
+
+            if (isNaN(id)) {
+                $field.attr('id', `${currentId}_1`);
+                $field.attr('labelledby', `${currentId}_1`);
+            } else {
+                id += 1;
+                $field.attr('id', `${idParts[0]}_${idParts[1]}_${id}`);
+                $field.attr('labelledby', `${idParts[0]}_${idParts[1]}_${id}`);
+            }
+        }
+
+        return $field;
+    }
+
+    createNewField($activeField) {
+        let $newField = $activeField.clone();
+        // [hyc-override] - Remove TinyMCE editor before cloning, otherwise we are left with a dead copy of it
+        let isTinyMce = $newField.children(".tinymce").length > 0;
+        if (isTinyMce) {
+            $newField.children(".tox-tinymce").remove();
+        }
+        let $newChildren = this.createNewChildren($newField);
+        // [hyc-override] - Reinitialize TinyMCE editor on the new copy of the field
+        if (isTinyMce) {
+            const tinyMCEConfig = this.tinyMCEConfig;
+            setTimeout(function() {
+                $($newChildren[0]).show();
+                tinymce.init({
+                  ...tinyMCEConfig,
+                  selector: '#' + $newChildren[0].id
+                });
+            }, 100);
+        }
+        this.element.trigger("managed_field:add", $newChildren);
+        return $newField;
+    }
+
+    clearEmptyWarning() {
+        let $listing = $(this.listClass, this.element)
+        $listing.children(this.warningClass).remove();
+    }
+
+    displayEmptyWarning() {
+        let $listing = $(this.listClass, this.element)
+        var $warningMessage  = $("<div class=\'message has-warning\'>cannot add another with empty field</div>");
+        $listing.children(this.warningClass).remove();
+        $listing.append($warningMessage);
+    }
+
+    removeFromList( event ) {
+        event.preventDefault();
+        var $field = $(event.target).parents(this.fieldWrapperClass).remove();
+        this.element.trigger("managed_field:remove", $field);
+
+        this._manageFocus();
+    }
+
+    destroy() {
+        $(this.fieldWrapperClass, this.element).removeClass("input-append");
+        this.element.removeClass("managed");
+    }
+
+    getFieldLabel($element, options) {
+        var label = '';
+        var $label = $element.find("label").first();
+        if ($label.length && options.labelControls) {
+            var label = $label.data('label') || $.trim($label.contents().filter(function() { return this.nodeType === 3; }).text());
+            label = ' ' + label;
+        }
+
+        return label;
+    }
+
+    createAddHtml(options) {
+        var $addHtml  = $(options.addHtml);
+        $addHtml.find('.controls-add-text').html(options.addText + options.label);
+        return $addHtml;
+    }
+
+    createRemoveHtml(options) {
+        var $removeHtml = $(options.removeHtml);
+        $removeHtml.find('.controls-remove-text').html(options.removeText);
+        $removeHtml.find('.controls-field-name-text').html(options.label);
+        return $removeHtml;
+    }
+
+    createNewChildren(clone) {
+        let $newChildren = $(clone).children(this.inputTypeClass);
+        $newChildren.val('').removeAttr('required');
+        $newChildren.first().focus();
+        // [hyc-override] - Update the field ID to be unique
+        return this._updateFieldId($newChildren.first());
+    }
+}

--- a/app/inputs/multi_value_with_unique_id_input.rb
+++ b/app/inputs/multi_value_with_unique_id_input.rb
@@ -4,7 +4,9 @@ class MultiValueWithUniqueIdInput < MultiValueInput
     options = build_field_options(value, index)
 
     # Generate a unique ID using the field name and index
-    options[:id] = "#{input_dom_id}_#{index}"
+    if index > 0
+      options[:id] = "#{input_dom_id}_#{index}"
+    end
     # Add multi_value class since many parts of the UI rely on it
     options[:class] << 'multi_value'
 

--- a/app/inputs/multi_value_with_unique_id_input.rb
+++ b/app/inputs/multi_value_with_unique_id_input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class MultiValueWithUniqueIdInput < MultiValueInput
+  def build_field(value, index)
+    options = build_field_options(value, index)
+
+    # Generate a unique ID using the field name and index
+    options[:id] = "#{input_dom_id}_#{index}"
+    # Add multi_value class since many parts of the UI rely on it
+    options[:class] << 'multi_value'
+
+    if options.delete(:type) == 'textarea'.freeze
+      result = @builder.text_area(attribute_name, options)
+    else
+      result = @builder.text_field(attribute_name, options)
+    end
+    return result
+  end
+end

--- a/app/views/records/edit_fields/_abstract.html.erb
+++ b/app/views/records/edit_fields/_abstract.html.erb
@@ -1,5 +1,5 @@
 <% if f.object.multiple? key %>
-    <%= f.input :abstract, as: :multi_value, input_html: { rows: '14', type: 'textarea', class: 'tinymce'}, required: f.object.required?(key) %>
+    <%= f.input :abstract, as: :multi_value_with_unique_id, wrapper_html: { class: 'multi_value' }, input_html: { rows: '14', type: 'textarea', class: 'tinymce'}, required: f.object.required?(key) %>
 <% else %>
     <%= f.input :abstract, as: :text, input_html: { rows: '14', class: 'tinymce' }, required: f.object.required?(key) %>
 <% end %>

--- a/spec/app/inputs/multi_value_with_unique_id_input_spec.rb
+++ b/spec/app/inputs/multi_value_with_unique_id_input_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe MultiValueWithUniqueIdInput do
   describe '#build_field' do
     context 'when type is not textarea' do
       before do
-        allow(input).to receive(:build_field_options).and_return({ class: [], type: 'text' })
+        allow(input).to receive(:build_field_options).and_return({ class: [], type: 'text', id: input_dom_id })
         allow(builder).to receive(:text_field).and_return('<input type="text" />')
       end
 
       it 'generates a text field with unique ID' do
         expect(builder).to receive(:text_field).with(
           attribute_name,
-          { class: ['multi_value'] }
+          { class: ['multi_value'], id: input_dom_id }
         )
 
         result = input.build_field(value, 0)
@@ -46,7 +46,7 @@ RSpec.describe MultiValueWithUniqueIdInput do
 
     context 'when type is textarea' do
       before do
-        allow(input).to receive(:build_field_options).and_return({ class: [], type: 'textarea' })
+        allow(input).to receive(:build_field_options).and_return({ class: [], type: 'textarea', id: input_dom_id })
         allow(builder).to receive(:text_area).and_return('<textarea></textarea>')
       end
 

--- a/spec/app/inputs/multi_value_with_unique_id_input_spec.rb
+++ b/spec/app/inputs/multi_value_with_unique_id_input_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MultiValueWithUniqueIdInput do
+  let(:object) { double('object') }
+  let(:builder) { double('builder', object: object) }
+  let(:attribute_name) { 'description' }
+  let(:value) { 'test value' }
+  let(:input_dom_id) { 'description' }
+  let(:input) do
+    described_class.new(builder, attribute_name, nil, nil, {})
+  end
+
+  before do
+    allow(input).to receive(:attribute_name).and_return(attribute_name)
+    allow(input).to receive(:input_dom_id).and_return(input_dom_id)
+  end
+
+  describe '#build_field' do
+    context 'when type is not textarea' do
+      before do
+        allow(input).to receive(:build_field_options).and_return({ class: [], type: 'text' })
+        allow(builder).to receive(:text_field).and_return('<input type="text" />')
+      end
+
+      it 'generates a text field with unique ID' do
+        expect(builder).to receive(:text_field).with(
+          attribute_name,
+          { class: ['multi_value'], id: "#{input_dom_id}_0" }
+        )
+
+        result = input.build_field(value, 0)
+        expect(result).to eq('<input type="text" />')
+      end
+
+      it 'generates a text field with ID matching the index' do
+        expect(builder).to receive(:text_field).with(
+          attribute_name,
+          { class: ['multi_value'], id: "#{input_dom_id}_1" }
+        )
+
+        result = input.build_field(value, 1)
+        expect(result).to eq('<input type="text" />')
+      end
+    end
+
+    context 'when type is textarea' do
+      before do
+        allow(input).to receive(:build_field_options).and_return({ class: [], type: 'textarea' })
+        allow(builder).to receive(:text_area).and_return('<textarea></textarea>')
+      end
+
+      it 'generates a textarea with unique ID' do
+        expect(builder).to receive(:text_area).with(
+          attribute_name,
+          { class: ['multi_value'], id: "#{input_dom_id}_1" }
+        )
+
+        result = input.build_field(value, 1)
+        expect(result).to eq('<textarea></textarea>')
+      end
+    end
+  end
+end

--- a/spec/app/inputs/multi_value_with_unique_id_input_spec.rb
+++ b/spec/app/inputs/multi_value_with_unique_id_input_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MultiValueWithUniqueIdInput do
       it 'generates a text field with unique ID' do
         expect(builder).to receive(:text_field).with(
           attribute_name,
-          { class: ['multi_value'], id: "#{input_dom_id}_0" }
+          { class: ['multi_value'] }
         )
 
         result = input.build_field(value, 0)


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2009

* Overrides FieldManager in order to generate unique IDs for multivalue fields, and handles removing cloned tinymce components and then reinitializing it on new children
*  Assigns unique ids to multivalue fields at page load via new MultiValueWithUniqueIdInput input field type