### PR TITLE
Set turnstile_enabled to true on vm

### DIFF
--- a/config/local_env_sample.yml
+++ b/config/local_env_sample.yml
@@ -36,7 +36,8 @@ LOG_LEVEL: 'debug'
 HYRAX_DATABASE_PASSWORD: password
 INGEST_PROQUEST_PATH: /opt/data/ftp/proquest
 INGEST_SAGE_PATH: /opt/data/ftp/sage
-# Turnstile won't work on the VM, so just turn it off
-CF_TURNSTILE_ENABLED: 'false'
+# Turnstile won't work on the VM, but needs to be enabled for the tests to pass
+# It will never send an actual challenge as localhost requests are exempted
+CF_TURNSTILE_ENABLED: 'true'
 CF_TURNSTILE_SITE_KEY: ''
 CF_TURNSTILE_SECRET_KEY: ''


### PR DESCRIPTION
Set turnstile_enabled to true on vm. It will never get the challenge, but required for the tests to pass. Setting it in an `around` block in rspec doesn't seem to work.