### PR TITLE
Remove noindex tag from turnstile page

### DIFF
--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -1,6 +1,5 @@
 <% content_for(:head) do %>
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  <meta name="robots" content="noindex">
 <% end %>
 
 


### PR DESCRIPTION
Remove noindex tag from turnstile page, which can cause google some indexing confusion