### PR TITLE
HYC-2078 - Fix advanced search with unbalanced quotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 gem 'browser', '~> 5.3', '>= 5.3.1'
 gem 'active-fedora', '~> 14.0'
 gem 'base64', '0.1.0' # Downgrade from 0.2 so that it will match the version being used by passenger on the server
-gem 'blacklight', git: 'https://github.com/UNC-Libraries/blacklight.git', branch: 'unc-development'
+gem 'blacklight', '~> 7.40'
 gem 'blacklight_advanced_search', '~> 8.0.0.alpha2'
 gem 'blacklight_dynamic_sitemap', '~> 1.0'
 gem 'blacklight_oai_provider', '7.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,4 @@
 GIT
-  remote: https://github.com/UNC-Libraries/blacklight.git
-  revision: fb14870ec545dd3c86f87337047033bfeec533f0
-  branch: unc-development
-  specs:
-    blacklight (7.37.0)
-      deprecation
-      globalid
-      hashdiff
-      i18n (>= 1.7.0)
-      jbuilder (~> 2.7)
-      kaminari (>= 0.15)
-      ostruct (>= 0.3.2)
-      rails (>= 5.1, < 7.2)
-      view_component (>= 2.66, < 4)
-
-GIT
   remote: https://github.com/UNC-Libraries/hyrax.git
   revision: 40e18c4a0b685a96f3663fde36bc87395d29e890
   branch: unc-hyrax-4-development
@@ -206,6 +190,17 @@ GEM
       i18n
     bcrypt (3.1.20)
     bindex (0.8.1)
+    blacklight (7.40.0)
+      deprecation
+      globalid
+      hashdiff
+      i18n (>= 1.7.0)
+      jbuilder (~> 2.7)
+      kaminari (>= 0.15)
+      ostruct (>= 0.3.2)
+      rails (>= 6.1, < 7.3)
+      view_component (>= 2.74, < 4)
+      zeitwerk
     blacklight-access_controls (6.0.1)
       blacklight (> 6.0, < 8)
       cancancan (>= 1.8)
@@ -701,7 +696,7 @@ GEM
       rails (> 3.2.0)
     orm_adapter (0.5.0)
     os (1.1.4)
-    ostruct (0.6.0)
+    ostruct (0.6.1)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -1088,7 +1083,7 @@ PLATFORMS
 DEPENDENCIES
   active-fedora (~> 14.0)
   base64 (= 0.1.0)
-  blacklight!
+  blacklight (~> 7.40)
   blacklight_advanced_search (~> 8.0.0.alpha2)
   blacklight_dynamic_sitemap (~> 1.0)
   blacklight_oai_provider (= 7.0.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,6 @@ class ApplicationController < ActionController::Base
   rescue_from Faraday::TimeoutError, with: :render_408
   rescue_from ArgumentError, with: :render_400
   rescue_from URI::InvalidURIError, with: :render_400
-  rescue_from StandardError, with: :handle_standard_error
 
   protected
 
@@ -62,16 +61,6 @@ class ApplicationController < ActionController::Base
 
   def render_500
     render 'errors/internal_server_error', status: 500, formats: :html
-  end
-
-  def handle_standard_error(exception)
-    # Log the full exception with backtrace
-    Rails.logger.error "Unhandled exception: #{exception.class}: #{exception.message}"
-    Rails.logger.error "URL: #{request.method} #{request.url} | IP: #{request.remote_ip}"
-    Rails.logger.error exception.backtrace.join("\n") if exception.backtrace
-
-    # Render the 500 page
-    render_500
   end
 
   # Error caught in catalogController

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
   rescue_from Faraday::TimeoutError, with: :render_408
   rescue_from ArgumentError, with: :render_400
   rescue_from URI::InvalidURIError, with: :render_400
+  rescue_from StandardError, with: :handle_standard_error
 
   protected
 
@@ -61,6 +62,16 @@ class ApplicationController < ActionController::Base
 
   def render_500
     render 'errors/internal_server_error', status: 500, formats: :html
+  end
+
+  def handle_standard_error(exception)
+    # Log the full exception with backtrace
+    Rails.logger.error "Unhandled exception: #{exception.class}: #{exception.message}"
+    Rails.logger.error "URL: #{request.method} #{request.url} | IP: #{request.remote_ip}"
+    Rails.logger.error exception.backtrace.join("\n") if exception.backtrace
+
+    # Render the 500 page
+    render_500
   end
 
   # Error caught in catalogController

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,6 +82,8 @@ class ApplicationController < ActionController::Base
       exception_text.include?("Can't determine a Sort Order")
       render_400
     else
+      Rails.logger.error "RSolr exception caught: #{exception.class}: #{exception.message}"
+      Rails.logger.error exception.backtrace.join("\n") if exception.backtrace
       render_404
     end
   end

--- a/app/helpers/query_parser_helper.rb
+++ b/app/helpers/query_parser_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module QueryParserHelper
+  module_function
+  # Sanitizes a query clause by removing unbalanced quotes and parentheses to prevent parslet errors.
+  def sanitize_query(query)
+    query = remove_quotes(query) if unbalanced_quotes?(query)
+    query = remove_parentheses(query) if unbalanced_parentheses?(query)
+    query
+  end
+
+  def unbalanced_quotes?(query)
+    query.count('"').odd?
+  end
+
+  def remove_quotes(query)
+    query.delete('"')
+  end
+
+  def unbalanced_parentheses?(query)
+    query.count('(') != query.count(')')
+  end
+
+  def remove_parentheses(query)
+    query.gsub(/[()]/, '')
+  end
+end

--- a/app/middleware/decode_query_string.rb
+++ b/app/middleware/decode_query_string.rb
@@ -11,5 +11,9 @@ class DecodeQueryString
       env['QUERY_STRING'] = query_string
     end
     @app.call(env)
+  rescue => e
+    Rails.logger.error("#{e.class}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n")) if e.backtrace
+    raise  # Re-raise to let normal Rails error handling (e.g., rescue_from) occur
   end
 end

--- a/app/overrides/blacklight_advanced_search/advanced_query_parser_override.rb
+++ b/app/overrides/blacklight_advanced_search/advanced_query_parser_override.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# [hyc-override] https://github.com/projectblacklight/blacklight_advanced_search/blob/v8.0.0.alpha2/lib/blacklight_advanced_search/advanced_query_parser.rb
+BlacklightAdvancedSearch::QueryParser.module_eval do
+  # [hyc-override] removes unbalanced quotes and parentheses from the query
+  # borrowed from https://github.com/trln/trln_argon/blob/main/config/initializers/advanced_query_parser.rb
+  def process_query(config)
+    queries = keyword_queries.map do |clause|
+      field = clause[:field]
+      query = clause[:query]
+      begin
+        query = remove_quotes(query) if unbalanced_quotes?(query)
+        query = remove_parentheses(query) if unbalanced_parentheses?(query)
+        ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser])
+                            .to_query(local_param_hash(field, config))
+      rescue Parslet::ParseFailed => e
+        Rails.logger.warn { "failed to parse the advanced search query (#{query}): #{e.message}" }
+        next
+      end
+    end
+    queries.join(" #{keyword_op} ")
+  end
+
+  private
+
+  def unbalanced_quotes?(query)
+    query.count('"').odd?
+  end
+
+  def remove_quotes(query)
+    query.delete('"')
+  end
+
+  def unbalanced_parentheses?(query)
+    query.count('(') != query.count(')')
+  end
+
+  def remove_parentheses(query)
+    query.gsub(/[()]/, '')
+  end
+end

--- a/app/overrides/blacklight_advanced_search/advanced_query_parser_override.rb
+++ b/app/overrides/blacklight_advanced_search/advanced_query_parser_override.rb
@@ -1,40 +1,22 @@
 # frozen_string_literal: true
 # [hyc-override] https://github.com/projectblacklight/blacklight_advanced_search/blob/v8.0.0.alpha2/lib/blacklight_advanced_search/advanced_query_parser.rb
-BlacklightAdvancedSearch::QueryParser.module_eval do
+BlacklightAdvancedSearch::QueryParser.class_eval do
   # [hyc-override] removes unbalanced quotes and parentheses from the query
   # borrowed from https://github.com/trln/trln_argon/blob/main/config/initializers/advanced_query_parser.rb
   def process_query(config)
     queries = keyword_queries.map do |clause|
       field = clause[:field]
-      query = clause[:query]
+      query = QueryParserHelper.sanitize_query(clause[:query])
       begin
-        query = remove_quotes(query) if unbalanced_quotes?(query)
-        query = remove_parentheses(query) if unbalanced_parentheses?(query)
         ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser])
                             .to_query(local_param_hash(field, config))
       rescue Parslet::ParseFailed => e
         Rails.logger.warn { "failed to parse the advanced search query (#{query}): #{e.message}" }
         next
+      rescue StandardError => e
+        Rails.logger.error { "failed to update the advanced search query (#{query}): #{e.message}" }
       end
     end
     queries.join(" #{keyword_op} ")
-  end
-
-  private
-
-  def unbalanced_quotes?(query)
-    query.count('"').odd?
-  end
-
-  def remove_quotes(query)
-    query.delete('"')
-  end
-
-  def unbalanced_parentheses?(query)
-    query.count('(') != query.count(')')
-  end
-
-  def remove_parentheses(query)
-    query.gsub(/[()]/, '')
   end
 end

--- a/app/search_builders/hyc/catalog_search_builder.rb
+++ b/app/search_builders/hyc/catalog_search_builder.rb
@@ -25,7 +25,7 @@ module Hyc
     def retrieve_all_fields_query
       blacklight_params['clause']&.each do |_, entry|
         if entry['field'] == 'all_fields'
-          return entry['query']
+          return QueryParserHelper.sanitize_query(entry['query'])
         end
       end
       return nil

--- a/spec/blacklight_advanced_search/query_parser_spec.rb
+++ b/spec/blacklight_advanced_search/query_parser_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe BlacklightAdvancedSearch::QueryParser do
       let(:query1) { 'parse failure' }
 
       it 'logs an error' do
-        expect(ParsingNesting::Tree).to receive(:parse).and_raise(StandardError.new('standard error'))
-        expect(Rails.logger).to receive(:error)
+        expect(ParsingNesting::Tree).to receive(:parse).twice.and_raise(StandardError.new('standard error'))
+        expect(Rails.logger).to receive(:error).twice
 
         parser.process_query(config)
       end

--- a/spec/blacklight_advanced_search/query_parser_spec.rb
+++ b/spec/blacklight_advanced_search/query_parser_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe BlacklightAdvancedSearch::QueryParser do
+  let(:parser) { described_class.new(search_state, config) }
+  let(:search_state) { instance_double('Blacklight::SearchState') }
+  let(:clauses) do
+    {
+      '0' => { field: 'all_fields', query: query1 },
+      '1' => { field: 'title', query: query2 }
+    }
+  end
+  let(:query1) { 'test query 1' }
+  let(:query2) { 'test query 2' }
+  let(:op) { 'AND' }
+  let(:config) do
+    double('config', advanced_search: {
+      query_parser: 'dismax'
+    })
+  end
+
+  before do
+    allow(search_state).to receive(:clause_params).and_return(clauses)
+    allow(search_state).to receive_message_chain(:params, :[]).with(:op).and_return(op)
+    # Set up stubs for the methods not under test
+    allow(parser).to receive(:local_param_hash).and_return({ q: '{!dismax}' })
+  end
+
+  describe '#process_query' do
+    context 'with balanced quotes' do
+      let(:query1) { 'balanced "quotes"' }
+
+      it 'preserves the balanced quotes' do
+        result = parser.process_query(config)
+        expect(result).to eq('_query_:"{!dismax q={!dismax}}balanced \"quotes\"" AND _query_:"{!dismax q={!dismax}}test query 2"')
+      end
+    end
+
+    context 'with unbalanced quotes' do
+      let(:query1) { 'unbalanced "quote' }
+
+      it 'removes the unbalanced quotes' do
+        result = parser.process_query(config)
+        expect(result).to eq('_query_:"{!dismax q={!dismax}}unbalanced quote" AND _query_:"{!dismax q={!dismax}}test query 2"')
+      end
+    end
+
+    context 'when StandardError is raised' do
+      let(:query1) { 'parse failure' }
+
+      it 'logs an error' do
+        expect(ParsingNesting::Tree).to receive(:parse).and_raise(StandardError.new('standard error'))
+        expect(Rails.logger).to receive(:error)
+
+        parser.process_query(config)
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -62,20 +62,29 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     it 'renders a 400 response for NumberFormatException' do
-      number_exception = RSolr::Error::Http.new({ 'uri' => 'test' }, { code: 500, body: 'java.lang.NumberFormatException' })
+      number_exception = RSolr::Error::Http.new(
+        { 'uri' => 'test' },
+        { code: 500, body: String.new('java.lang.NumberFormatException') }
+      )
       get :index, params: { exception: number_exception }
       expect(response).to have_http_status(:bad_request)
     end
 
     it 'renders a 400 response for sort order exceptions' do
-      sort_exception = RSolr::Error::Http.new({ 'uri' => 'test' }, { code: 500, body: "Can't determine a Sort Order" })
+      sort_exception = RSolr::Error::Http.new(
+        { 'uri' => 'test' },
+        { code: 500, body: String.new("Can't determine a Sort Order") }
+      )
       get :index, params: { exception: sort_exception }
       expect(response).to have_http_status(:bad_request)
     end
 
     it 'renders a 404 response for other RSolr exceptions' do
       allow(Rails.logger).to receive(:error)
-      other_exception = RSolr::Error::Http.new({ 'uri' => 'test' }, { code: 500, body: 'Some other RSolr error' })
+      other_exception = RSolr::Error::Http.new(
+        { 'uri' => 'test' },
+        { code: 500, body: String.new('Some other RSolr error') }
+      )
       get :index, params: { exception: other_exception }
       expect(response).to have_http_status(:not_found)
       expect(Rails.logger).to have_received(:error).twice

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -55,39 +55,58 @@ RSpec.describe ApplicationController, type: :controller do
 
   describe '#render_rsolr_exceptions' do
     controller(ApplicationController) do
+      cattr_accessor :test_exception
+
       def index
-        @exception = params[:exception]
-        render_rsolr_exceptions(@exception)
+        render_rsolr_exceptions(self.class.test_exception)
       end
     end
 
-    it 'renders a 400 response for NumberFormatException' do
-      number_exception = RSolr::Error::Http.new(
-        { 'uri' => 'test' },
-        { code: 500, body: String.new('java.lang.NumberFormatException') }
-      )
-      get :index, params: { exception: number_exception }
-      expect(response).to have_http_status(:bad_request)
+    context 'when an RSolr exception is raised' do
+      before do
+        controller.class.test_exception = RSolr::Error::Http.new(
+          { uri: 'test' },
+          { code: 500, body: String.new('java.lang.NumberFormatException') }
+        )
+        controller.class.test_exception.set_backtrace(caller)
+      end
+
+      it 'renders a 400 response for NumberFormatException' do
+        get :index
+        expect(response).to have_http_status(:bad_request)
+      end
     end
 
-    it 'renders a 400 response for sort order exceptions' do
-      sort_exception = RSolr::Error::Http.new(
-        { 'uri' => 'test' },
-        { code: 500, body: String.new("Can't determine a Sort Order") }
-      )
-      get :index, params: { exception: sort_exception }
-      expect(response).to have_http_status(:bad_request)
+    context 'when a Sort Order exception is raised' do
+      before do
+        controller.class.test_exception = RSolr::Error::Http.new(
+          { uri: 'test' },
+          { code: 500, body: String.new("Can't determine a Sort Order") }
+        )
+        controller.class.test_exception.set_backtrace(caller)
+      end
+
+      it 'renders a 400 response for sort order exceptions' do
+        get :index
+        expect(response).to have_http_status(:bad_request)
+      end
     end
 
-    it 'renders a 404 response for other RSolr exceptions' do
-      allow(Rails.logger).to receive(:error)
-      other_exception = RSolr::Error::Http.new(
-        { 'uri' => 'test' },
-        { code: 500, body: String.new('Some other RSolr error') }
-      )
-      get :index, params: { exception: other_exception }
-      expect(response).to have_http_status(:not_found)
-      expect(Rails.logger).to have_received(:error).twice
+    context 'when any other RSolr exception is raised' do
+      before do
+        controller.class.test_exception = RSolr::Error::Http.new(
+          { uri: 'test' },
+          { code: 500, body: String.new('Some other RSolr error') }
+        )
+        controller.class.test_exception.set_backtrace(caller)
+      end
+
+      it 'renders a 404 response for other RSolr exceptions' do
+        allow(Rails.logger).to receive(:error)
+        get :index
+        expect(response).to have_http_status(:not_found)
+        expect(Rails.logger).to have_received(:error).twice
+      end
     end
   end
 end

--- a/spec/helpers/query_parser_helper_spec.rb
+++ b/spec/helpers/query_parser_helper_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe QueryParserHelper do
+  describe '.sanitize_query' do
+    it 'removes quotes when they are unbalanced' do
+      expect(QueryParserHelper.sanitize_query('unbalanced "quote')).to eq('unbalanced quote')
+    end
+
+    it 'keeps quotes when they are balanced' do
+      expect(QueryParserHelper.sanitize_query('balanced "quote"')).to eq('balanced "quote"')
+    end
+
+    it 'removes parentheses when they are unbalanced' do
+      expect(QueryParserHelper.sanitize_query('unbalanced (query')).to eq('unbalanced query')
+      expect(QueryParserHelper.sanitize_query('unbalanced query)')).to eq('unbalanced query')
+    end
+
+    it 'keeps parentheses when they are balanced' do
+      expect(QueryParserHelper.sanitize_query('balanced (query)')).to eq('balanced (query)')
+    end
+
+    it 'handles both unbalanced quotes and parentheses' do
+      expect(QueryParserHelper.sanitize_query('unbalanced "quote with (paren')).to eq('unbalanced quote with paren')
+    end
+  end
+end

--- a/spec/middleware/decode_query_string_spec.rb
+++ b/spec/middleware/decode_query_string_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DecodeQueryString do
       let(:error) { StandardError.new('Test error') }
 
       before do
-        allow_any_instance_of(DecodeQueryString).to receive(:call).and_raise(error)
+        allow(app).to receive(:call).and_raise(error)
         allow(Rails.logger).to receive(:error)
       end
 

--- a/spec/search_builders/hyc/catalog_search_builder_spec.rb
+++ b/spec/search_builders/hyc/catalog_search_builder_spec.rb
@@ -35,6 +35,21 @@ RSpec.describe Hyc::CatalogSearchBuilder do
         expect(solr_params[:q]).to eq ' _query_:"{!join from=id to=file_set_ids_ssim}{!dismax qf=all_text_timv}metalloprotease"'
       end
     end
+
+    context 'joining with unbalanced quote' do
+      let(:blacklight_params) do
+        {
+          search_field: 'advanced',
+          clause: { '0' => {field: 'all_fields', query: 'un"balanced' } }
+        }
+      end
+      subject { builder.join_works_from_files(solr_params) }
+
+      it 'removes the unbalanced quote' do
+        subject
+        expect(solr_params[:q]).to eq ' _query_:"{!join from=id to=file_set_ids_ssim}{!dismax qf=all_text_timv}unbalanced"'
+      end
+    end
   end
 
   class FakeSearchBuilderScope


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2078

* Cleanup unbalanced quotes and parenthesis when generating advanced search queries, otherwise we get Parslet errors for search terms like `hello"`
* Add better logging of unhandled exceptions, so we can see the full backtrace rather than cutting off at the middleware
* Update to blacklight 7.40 (was 7.37 via a fork)