### PR TITLE
HYC 2066 Follow Up 

### DIFF
--- a/app/helpers/work_utils_helper.rb
+++ b/app/helpers/work_utils_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module WorkUtilsHelper
   def self.fetch_work_data_by_alternate_identifier(identifier)
-    query = "identifier_tesim:\"#{identifier}\" AND has_model_ssim:(\"Article\")"
+    query = "identifier_tesim:\"#{identifier}\" NOT has_model_ssim:(\"FileSet\")"
     work_data = ActiveFedora::SolrService.get(query, rows: 1)['response']['docs'].first || {}
     Rails.logger.warn("No work found associated with alternate identifier: #{identifier}") if work_data.blank?
     admin_set_name = work_data['admin_set_tesim']&.first

--- a/app/helpers/work_utils_helper.rb
+++ b/app/helpers/work_utils_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module WorkUtilsHelper
   def self.fetch_work_data_by_alternate_identifier(identifier)
-    work_data = ActiveFedora::SolrService.get("identifier_tesim:\"#{identifier}\"", rows: 1)['response']['docs'].first || {}
+    query = "identifier_tesim:\"#{identifier}\" AND has_model_ssim:(\"Article\")"
+    work_data = ActiveFedora::SolrService.get(query, rows: 1)['response']['docs'].first || {}
     Rails.logger.warn("No work found associated with alternate identifier: #{identifier}") if work_data.blank?
     admin_set_name = work_data['admin_set_tesim']&.first
     admin_set_data = admin_set_name ? ActiveFedora::SolrService.get("title_tesim:#{admin_set_name} AND has_model_ssim:(\"AdminSet\")", { :rows => 1, 'df' => 'title_tesim'})['response']['docs'].first : {}

--- a/spec/helpers/hyrax/work_utils_helper_spec.rb
+++ b/spec/helpers/hyrax/work_utils_helper_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe WorkUtilsHelper, type: :module do
   describe '#fetch_work_data_by_alternate_identifier' do
     let (:mock_pmid) { '12345678' }
     it 'fetches the work data correctly' do
-      allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\"", rows: 1).and_return('response' => { 'docs' => mock_records[2] })
+      allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\" NOT has_model_ssim:(\"FileSet\")", rows: 1).and_return('response' => { 'docs' => mock_records[2] })
       allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name} AND has_model_ssim:(\"AdminSet\")",  {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => mock_admin_set })
       (0..3).each do |i|
         allow(ActiveFedora::SolrService).to receive(:get).with("id:#{fileset_ids[i]}", rows: 1).and_return('response' => { 'docs' => [{'title_tesim' => ["title_#{i}"]}] })
@@ -157,7 +157,7 @@ RSpec.describe WorkUtilsHelper, type: :module do
 
     it 'logs appropriate messages for missing values' do
         # Mock the solr response to simulate a work with missing values, if it somehow makes it past the initial nil check
-      allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\"", rows: 1).and_return('response' => { 'docs' => [] })
+      allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\" NOT has_model_ssim:(\"FileSet\")", rows: 1).and_return('response' => { 'docs' => [] })
       allow(Rails.logger).to receive(:warn)
       result = WorkUtilsHelper.fetch_work_data_by_alternate_identifier(mock_pmid)
       expect(Rails.logger).to have_received(:warn).with("No work found associated with alternate identifier: #{mock_pmid}")
@@ -166,7 +166,7 @@ RSpec.describe WorkUtilsHelper, type: :module do
     end
 
     it 'logs a message if a fileset cannot be found with the id' do
-      allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\"", rows: 1).and_return('response' => { 'docs' => mock_records[2] })
+      allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\" NOT has_model_ssim:(\"FileSet\")", rows: 1).and_return('response' => { 'docs' => mock_records[2] })
       allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name} AND has_model_ssim:(\"AdminSet\")",  {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => mock_admin_set })
       (0..2).each do |i|
         allow(ActiveFedora::SolrService).to receive(:get).with("id:#{fileset_ids[i]}", rows: 1).and_return('response' => { 'docs' => [{'title_tesim' => ["title_#{i}"]}] })
@@ -182,7 +182,7 @@ RSpec.describe WorkUtilsHelper, type: :module do
     context 'when admin set is not found' do
       it 'logs an appropriate message if the work doesnt have an admin set title' do
           # Using the mock record without an admin set title
-        allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\"", rows: 1).and_return('response' => { 'docs' => mock_records[1] })
+        allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\" NOT has_model_ssim:(\"FileSet\")", rows: 1).and_return('response' => { 'docs' => mock_records[1] })
         allow(Rails.logger).to receive(:warn)
         result = WorkUtilsHelper.fetch_work_data_by_alternate_identifier(mock_pmid)
         expect(Rails.logger).to have_received(:warn).with("Could not find an admin set, the work with id: #{mock_pmid} has no admin set name.")
@@ -191,7 +191,7 @@ RSpec.describe WorkUtilsHelper, type: :module do
 
       it 'logs an appropriate message if the query for an admin set returns nothing' do
         # Using the mock record with an admin set title
-        allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\"", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
+        allow(ActiveFedora::SolrService).to receive(:get).with("identifier_tesim:\"#{mock_pmid}\" NOT has_model_ssim:(\"FileSet\")", rows: 1).and_return('response' => { 'docs' => mock_records[0] })
         allow(ActiveFedora::SolrService).to receive(:get).with("title_tesim:#{admin_set_name} AND has_model_ssim:(\"AdminSet\")", {'df'=>'title_tesim', :rows=>1}).and_return('response' => { 'docs' => [{}] })
         allow(Rails.logger).to receive(:warn)
         result = WorkUtilsHelper.fetch_work_data_by_alternate_identifier(mock_pmid)

--- a/spec/services/tasks/ingest_helper_spec.rb
+++ b/spec/services/tasks/ingest_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# spec/helpers/tasks/ingest_helper_spec.rb
+require 'rails_helper'
+
+RSpec.describe Tasks::IngestHelper do
+  let(:helper) do
+    Class.new { include Tasks::IngestHelper }.new
+  end
+
+  let(:user) { FactoryBot.create(:admin) }
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:work) { Article.new(title: ['Test Work'], depositor: user.uid, admin_set: admin_set) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/sample_pdf.pdf') }
+  let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+
+  before do
+    allow(WorkUtilsHelper).to receive(:get_permissions_attributes).with(admin_set.id)
+      .and_return([{ access: 'read', type: 'group', name: 'public' }])
+
+    allow(Hyrax::VirusCheckerService).to receive(:file_has_virus?) { false }
+    allow(RegisterToLongleafJob).to receive(:perform_later).and_return(nil)
+    allow(CharacterizeJob).to receive(:perform_later)
+  end
+
+  describe '#attach_file_set_to_work' do
+    it 'attaches a FileSet and applies permissions' do
+      file_set = helper.attach_file_set_to_work(
+        work: work,
+        file_path: file_path,
+        user: user,
+        visibility: visibility
+      )
+
+      expect(work).to be_persisted
+      expect(file_set).to be_a(FileSet)
+      expect(file_set.read_groups).to include('public')
+    end
+  end
+end

--- a/spec/services/tasks/pubmed_ingest/pubmed_ingest_coordinator_service_spec.rb
+++ b/spec/services/tasks/pubmed_ingest/pubmed_ingest_coordinator_service_spec.rb
@@ -401,10 +401,10 @@ RSpec.describe Tasks::PubmedIngest::PubmedIngestCoordinatorService do
 
     it 'tries DOI first, then PMCID, then PMID' do
       expect(ActiveFedora::SolrService).to receive(:get)
-        .with('identifier_tesim:"10.1234/test"', anything).ordered
+        .with('identifier_tesim:"10.1234/test" NOT has_model_ssim:("FileSet")', anything).ordered
         .and_return({ 'response' => { 'docs' => [] } })
       expect(ActiveFedora::SolrService).to receive(:get)
-        .with('identifier_tesim:"PMC67890"', anything).ordered
+        .with('identifier_tesim:"PMC67890" NOT has_model_ssim:("FileSet")', anything).ordered
         .and_return({ 'response' => { 'docs' => [work_data] } })
 
       service.send(:find_best_work_match, alternate_ids)


### PR DESCRIPTION
Persist works before fileset attachment

[Bug](https://splunk.unc.edu/en-US/app/libraries/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20host%3D%22toronto.lib.unc.edu%22%20source%3D%22%2Flogs%2Fhyc%2Fproduction.log%22%20%22Error%20performing%20FileSetAttachedEventJob%22%20%22Job%20ID%3A%20fa903a7a-0981-4bd9-be69-eff47e990f07%22&earliest=%40d&latest=now&display.page.search.tab=events&display.general.type=events&sid=1750947921.10696_AB41F19C-07AA-4E0B-B3CD-26C769C8434C)