### PR TITLE
file_set_admin_set_option nil check

### DIFF
--- a/app/views/hyrax/file_sets/_admin_set_options.html.erb
+++ b/app/views/hyrax/file_sets/_admin_set_options.html.erb
@@ -1,0 +1,8 @@
+<!-- Including non-visible admin set dropdown to trigger VisibilityComponent JavaScript. -->
+<%# [hyc-override] Typecast @file_set_admin_set_option to an array to avoid issues with nil values %>
+<% if Flipflop.assign_admin_set? %>
+  <%= select_tag :admin_set_id,
+                options_for_select(@file_set_admin_set_option.to_a.map { |option| [option[0], option[1], option[2]] }),
+                include_blank: false,
+                class: 'form-control d-none' %>
+<% end %>


### PR DESCRIPTION
2025-08-11 04:22:09 -0400 - FATAL: [d293703f-934b-4786-8774-f24febead8fb]  
[d293703f-934b-4786-8774-f24febead8fb] ActionView::Template::Error (undefined method 'map' for nil:NilClass):

    1: <!-- Including non-visible admin set dropdown to trigger VisibilityComponent JavaScript. -->
    2: <% if Flipflop.assign_admin_set? %>
    3:   <%= select_tag :admin_set_id,
    4:                  options_for_select(@file_set_admin_set_option.map { |option| [option[0], option[1], option[2]] }),
    5:                  include_blank: false,
    6:                  class: 'form-control d-none' %>
    7: <% end %>

[d293703f-934b-4786-8774-f24febead8fb] app/middleware/decode_query_string.rb:13:in 'call
