### PR TITLE
HYC-2184 - Use s3 for getting PDF files for attaching to pubmed articles

### DIFF
--- a/app/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service.rb
+++ b/app/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'aws-sdk-s3'
 
 class Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService < Tasks::IngestHelperUtils::BaseFileAttachmentService
   PMC_S3_BUCKET = 'pmc-oa-opendata'
+  PMC_S3_BASE_URL = "https://#{PMC_S3_BUCKET}.s3.amazonaws.com"
 
   def initialize(config:, tracker:, log_file_path:, full_text_path:, metadata_ingest_result_path:)
     super(config: config, tracker: tracker, log_file_path: log_file_path, metadata_ingest_result_path: metadata_ingest_result_path)
@@ -41,13 +41,18 @@ class Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService < Tasks::
       end
 
       version_id = version_prefix.chomp('/')
-      pdf_key = "#{version_prefix}#{version_id}.pdf"
+      pdf_url = "#{PMC_S3_BASE_URL}/#{version_prefix}#{version_id}.pdf"
 
       filename = generate_filename_for_work(record.dig('ids', 'work_id'), pmcid)
       file_path = File.join(@full_text_path, filename)
 
-      LogUtilsHelper.double_log("Downloading s3://#{PMC_S3_BUCKET}/#{pdf_key}", :info, tag: 'S3')
-      s3_client.get_object(bucket: PMC_S3_BUCKET, key: pdf_key, response_target: file_path)
+      status = fetch_s3_file(pdf_url, local_file_path: file_path)
+
+      if status == 404
+        log_attachment_outcome(record, category: category_for_skipped_file_attachment(record),
+                               message: 'No PDF found in S3 for PMCID', file_name: 'NONE')
+        return
+      end
 
       file_set = attach_pdf_to_work_with_file_path!(record: record,
                                                     file_path: file_path,
@@ -59,9 +64,6 @@ class Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService < Tasks::
                   file_name: filename)
       end
 
-    rescue Aws::S3::Errors::NoSuchKey
-      log_attachment_outcome(record, category: category_for_skipped_file_attachment(record),
-                             message: 'No PDF found in S3 for PMCID', file_name: 'NONE')
     rescue => e
       retries += 1
       if retries <= RETRY_LIMIT
@@ -78,20 +80,24 @@ class Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService < Tasks::
   end
 
   def latest_version_prefix(pmcid)
-    resp = s3_client.list_objects_v2(
-      bucket: PMC_S3_BUCKET,
-      prefix: "#{pmcid}.",
-      delimiter: '/'
-    )
-    prefixes = resp.common_prefixes.map(&:prefix)
+    url = "#{PMC_S3_BASE_URL}/?list-type=2&prefix=#{pmcid}.&delimiter=/"
+    response = HTTParty.get(url, timeout: 10)
+    raise "S3 listing failed: #{response.code}" unless response.code == 200
+
+    doc = Nokogiri::XML(response.body)
+    doc.remove_namespaces!
+    prefixes = doc.xpath('//CommonPrefixes/Prefix').map(&:text)
     return nil if prefixes.empty?
+
     prefixes.sort.last
   end
 
-  def s3_client
-    @s3_client ||= Aws::S3::Client.new(
-      region: 'us-east-1',
-      credentials: Aws::AnonymousCredentials.new
-    )
+  def fetch_s3_file(url, local_file_path:)
+    LogUtilsHelper.double_log("Downloading #{url}", :info, tag: 'S3')
+    response = HTTParty.get(url, timeout: 60)
+    return response.code unless response.code == 200
+
+    File.binwrite(local_file_path, response.body)
+    response.code
   end
 end

--- a/app/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service.rb
+++ b/app/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'net/ftp'
-require 'zlib'
-require 'rubygems/package'
+require 'aws-sdk-s3'
 
 class Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService < Tasks::IngestHelperUtils::BaseFileAttachmentService
+  PMC_S3_BUCKET = 'pmc-oa-opendata'
+
   def initialize(config:, tracker:, log_file_path:, full_text_path:, metadata_ingest_result_path:)
     super(config: config, tracker: tracker, log_file_path: log_file_path, metadata_ingest_result_path: metadata_ingest_result_path)
     @full_text_path = full_text_path
@@ -30,138 +30,68 @@ class Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService < Tasks::
   def process_record(record)
     pmcid = record['ids']['pmcid']
     return unless pmcid.present?
-    url = "https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi?id=#{pmcid}"
+
     retries = 0
     begin
-      response = HTTParty.get(url, timeout: 10)
-      raise "Bad response: #{response.code}" unless response.code == 200
-
-      doc = Nokogiri::XML(response.body)
-      error_node = doc.at_xpath('//error')
-      if error_node
-        error_code = error_node['code']
-        Rails.logger.warn "Skipping PMCID #{pmcid} — Open Access API Error: #{error_code}"
-        log_attachment_outcome(record, category: :skipped_file_attachment, message: "Open Access API Error - #{error_code}", file_name: 'NONE')
+      version_prefix = latest_version_prefix(pmcid)
+      if version_prefix.nil?
+        log_attachment_outcome(record, category: category_for_skipped_file_attachment(record),
+                               message: 'No versions found in S3 for PMCID', file_name: 'NONE')
         return
       end
-      pdf_url = doc.at_xpath('//record/link[@format="pdf"]')&.[]('href')
-      tgz_url = doc.at_xpath('//record/link[@format="tgz"]')&.[]('href')
-      raise 'No PDF or TGZ link found' if pdf_url.blank? && tgz_url.blank?
 
-      if pdf_url.present?
-        uri = URI.parse(pdf_url)
-        filename = generate_filename_for_work(record.dig('ids', 'work_id'), pmcid)
-        file_path = File.join(@full_text_path, filename)
-        fetch_ftp_binary(uri, local_file_path: file_path)
-        file_set = attach_pdf_to_work_with_file_path!(record: record,
-                                                      file_path: file_path,
-                                                      depositor_onyen: config['depositor_onyen'])
-        if file_set
-          log_attachment_outcome(record,
-                    category: category_for_successful_attachment(record),
-                    message: 'PDF successfully attached.',
-                    file_name: filename)
-        end
-      elsif tgz_url.present?
-        tgz_path = File.join(@full_text_path, "#{pmcid}.tar.gz")
-        uri = URI.parse(tgz_url)
-        tgz_data = fetch_ftp_binary(uri, local_file_path: tgz_path)
-        process_and_attach_tgz_file(record, tgz_path)
+      version_id = version_prefix.chomp('/')
+      pdf_key = "#{version_prefix}#{version_id}.pdf"
+
+      filename = generate_filename_for_work(record.dig('ids', 'work_id'), pmcid)
+      file_path = File.join(@full_text_path, filename)
+
+      LogUtilsHelper.double_log("Downloading s3://#{PMC_S3_BUCKET}/#{pdf_key}", :info, tag: 'S3')
+      s3_client.get_object(bucket: PMC_S3_BUCKET, key: pdf_key, response_target: file_path)
+
+      file_set = attach_pdf_to_work_with_file_path!(record: record,
+                                                    file_path: file_path,
+                                                    depositor_onyen: config['depositor_onyen'])
+      if file_set
+        log_attachment_outcome(record,
+                  category: category_for_successful_attachment(record),
+                  message: 'PDF successfully attached.',
+                  file_name: filename)
       end
 
+    rescue Aws::S3::Errors::NoSuchKey
+      log_attachment_outcome(record, category: category_for_skipped_file_attachment(record),
+                             message: 'No PDF found in S3 for PMCID', file_name: 'NONE')
     rescue => e
-      # Do not retry if no PDF or TGZ link is found in the response
-      if e.message.include?('No PDF or TGZ link found')
-        log_attachment_outcome(record, category: category_for_skipped_file_attachment(record), message: 'No PDF or TGZ link found, skipping attachment', file_name: 'NONE')
+      retries += 1
+      if retries <= RETRY_LIMIT
+        sleep(1)
+        retry
       else
-        retries += 1
-        if retries <= RETRY_LIMIT
-          sleep(1)
-          retry
-        else
-          log_attachment_outcome(record, category: :failed, message: "File attachment failed -- #{e.message}", file_name: 'NONE')
-          LogUtilsHelper.double_log("Error processing record: #{e.message}. Request URL: #{url}", :error, tag: 'Attachment')
-          Rails.logger.error e.backtrace.join("\n")
-        end
+        log_attachment_outcome(record, category: :failed, message: "File attachment failed -- #{e.message}", file_name: 'NONE')
+        LogUtilsHelper.double_log("Error processing record: #{e.message}. PMCID: #{pmcid}", :error, tag: 'Attachment')
+        Rails.logger.error e.backtrace.join("\n")
       end
     ensure
       sleep(SLEEP_BETWEEN_REQUESTS)
     end
   end
 
-  def fetch_ftp_binary(uri, local_file_path:)
-    LogUtilsHelper.double_log("Fetching FTP file from #{uri}", :info, tag: 'FTP')
-    Net::FTP.open(uri.host) do |ftp|
-      ftp.login
-      ftp.passive = true
-      remote_path = uri.path
-      remote_path = "/#{remote_path}" unless remote_path.start_with?('/')
-      ftp.getbinaryfile(remote_path, local_file_path)
-    end
-    local_file_path
+  def latest_version_prefix(pmcid)
+    resp = s3_client.list_objects_v2(
+      bucket: PMC_S3_BUCKET,
+      prefix: "#{pmcid}.",
+      delimiter: '/'
+    )
+    prefixes = resp.common_prefixes.map(&:prefix)
+    return nil if prefixes.empty?
+    prefixes.sort.last
   end
 
-  def safe_gzip_reader(path)
-    content = File.binread(path)
-    gzip_start = content.index("\x1F\x8B".b)
-    raise 'No GZIP header found in file' unless gzip_start
-
-    str_io = StringIO.new(content[gzip_start..])
-    Zlib::GzipReader.new(str_io)
-  end
-
-  def process_and_attach_tgz_file(record, tgz_path)
-    pmcid = record.dig('ids', 'pmcid')
-    work_id = record.dig('ids', 'work_id')
-    return log_attachment_outcome(record, category: category_for_skipped_file_attachment(record), message: 'No article ID found to attach TGZ', file_name: 'NONE') if work_id.blank?
-
-    begin
-      work = Article.find(work_id)
-      depositor = ::User.find_by(uid: @config['depositor_onyen'])
-      raise 'No depositor found' unless depositor
-
-      pdf_count = 0
-
-      tgz_absolute_path = File.expand_path(tgz_path)
-
-      gz = safe_gzip_reader(tgz_absolute_path)
-      Gem::Package::TarReader.new(gz) do |tar|
-        tar.each do |entry|
-          next unless entry.file?
-          next unless entry.full_name.downcase.end_with?('.pdf')
-
-          pdf_binary = entry.read
-          LogUtilsHelper.double_log("Extracting PDF from TGZ: #{entry.full_name} (#{pdf_binary.bytesize} bytes)", :info, tag: 'TGZ Processing')
-
-          filename = generate_filename_for_work(work.id, pmcid)
-          file_path = File.join(@full_text_path, filename)
-          File.binwrite(file_path, pdf_binary)
-
-
-          # file_set = attach_df_to_work_with_file_path!(record, file_path, @config['depositor_onyen'])
-          file_set = attach_pdf_to_work_with_file_path!(record: record,
-                                                        file_path: file_path,
-                                                        depositor_onyen: @config['depositor_onyen'])
-          if file_set
-            log_attachment_outcome(record,
-                      category: :successfully_attached,
-                      message: 'PDF successfully attached from TGZ.',
-                      file_name: filename)
-            pdf_count += 1
-          end
-        end
-      end
-      gz.close
-
-      raise 'No PDF files found in TGZ archive' if pdf_count == 0
-
-      work.reload
-      work.update_index
-
-    rescue => e
-      log_attachment_outcome(record, category: :failed, message: "TGZ PDF processing failed: #{e.message}", file_name: 'NONE')
-      Rails.logger.error "TGZ PDF processing failed for #{pmcid}: #{e.message}"
-      Rails.logger.error e.backtrace.join("\n")
-    end
+  def s3_client
+    @s3_client ||= Aws::S3::Client.new(
+      region: 'us-east-1',
+      credentials: Aws::AnonymousCredentials.new
+    )
   end
 end

--- a/spec/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service_spec.rb
+++ b/spec/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service_spec.rb
@@ -156,63 +156,47 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
   end
 
   describe '#process_record' do
-    let(:oa_response_body) do
-      <<~XML
-        <?xml version="1.0"?>
-        <oa>
-          <record>
-            <link format="pdf" href="ftp://example.com/path/file.pdf"/>
-          </record>
-        </oa>
-      XML
-    end
-
-    let(:mock_response) { double('response', code: 200, body: oa_response_body) }
-    let(:mock_article) do
-      double(
-        'article',
-        id: 'work_123',
-        to_global_id: 'gid://hyrax/Article/work_123',
-        admin_set_id: 'admin_set_123',
-        title: ['Dummy Title'],
-        human_readable_type: 'Article',
-        reload: true,
-        update_index: true
-      )
+    let(:mock_s3_client) { double('s3_client') }
+    let(:mock_list_response) do
+      double('list_response', common_prefixes: [double('prefix', prefix: 'PMC123456.1/')])
     end
 
     before do
-      allow(HTTParty).to receive(:get).and_return(mock_response)
-      allow(service).to receive(:fetch_ftp_binary).and_return('pdf_binary_data')
+      allow(service).to receive(:s3_client).and_return(mock_s3_client)
+      allow(mock_s3_client).to receive(:list_objects_v2).and_return(mock_list_response)
+      allow(mock_s3_client).to receive(:get_object)
       allow(service).to receive(:attach_pdf_to_work_with_file_path!)
+      allow(service).to receive(:generate_filename_for_work).and_return('PMC123456_001.pdf')
       allow(service).to receive(:sleep)
-      allow(Article).to receive(:find).with('work_123').and_return(mock_article)
-      # RSpec::Mocks.space.proxy_for(service).reset
     end
 
     context 'when record has no PMCID' do
-      it 'returns early' do
-        expect(HTTParty).not_to receive(:get)
+      it 'returns early without calling S3' do
+        expect(mock_s3_client).not_to receive(:list_objects_v2)
         service.process_record(sample_record_without_pmcid)
       end
     end
 
-    context 'when PDF URL is found' do
+    context 'when PDF is found in S3' do
       before do
-        stub_const('Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::RETRY_LIMIT', 0)
-        allow(service).to receive(:generate_filename_for_work).and_return('PMC123456_001.pdf')
-        allow(service).to receive(:attach_pdf_to_work_with_file_path!).and_return([double('fileset'), 'PMC123456_001.pdf'])
-        allow(service).to receive(:log_attachment_outcome) # stub to observe
+        allow(service).to receive(:attach_pdf_to_work_with_file_path!)
+          .and_return([double('fileset'), 'PMC123456_001.pdf'])
+        allow(service).to receive(:log_attachment_outcome)
       end
 
-      it 'fetches and processes PDF' do
+      it 'lists S3 versions, downloads the PDF, and attaches it' do
         service.process_record(sample_record)
 
-        expect(HTTParty).to have_received(:get).with(
-          'https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi?id=PMC123456',
-          timeout: 10
+        expect(mock_s3_client).to have_received(:list_objects_v2).with(
+          bucket: Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::PMC_S3_BUCKET,
+          prefix: 'PMC123456.',
+          delimiter: '/'
         )
-        expect(service).to have_received(:fetch_ftp_binary)
+        expect(mock_s3_client).to have_received(:get_object).with(
+          bucket: Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::PMC_S3_BUCKET,
+          key: 'PMC123456.1/PMC123456.1.pdf',
+          response_target: anything
+        )
         expect(service).to have_received(:attach_pdf_to_work_with_file_path!)
       end
 
@@ -240,288 +224,74 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
       end
     end
 
-    context 'when TGZ URL is found' do
-      let(:oa_response_body) do
-        <<~XML
-          <?xml version="1.0"?>
-          <oa>
-            <record>
-              <link format="tgz" href="ftp://example.com/path/file.tgz"/>
-            </record>
-          </oa>
-        XML
+    context 'when no PDF is found in S3' do
+      before do
+        allow(mock_s3_client).to receive(:get_object)
+          .and_raise(Aws::S3::Errors::NoSuchKey.new(nil, 'The specified key does not exist.'))
+        allow(service).to receive(:log_attachment_outcome)
       end
 
-      it 'fetches and processes TGZ' do
-        expect(service).to receive(:fetch_ftp_binary).and_return('tgz_binary_data')
-        expect(service).to receive(:process_and_attach_tgz_file)
-
+      it 'logs successfully_ingested_metadata_only by default' do
         service.process_record(sample_record)
-      end
-    end
 
-    context 'when no PDF or TGZ link is found' do
-      let(:oa_response_body) do
-        <<~XML
-          <?xml version="1.0"?>
-          <oa>
-            <record>
-            </record>
-          </oa>
-        XML
-      end
-
-      it 'logs successful ingestion with no attachment' do
-        expect(service).to receive(:log_attachment_outcome).with(
+        expect(service).to have_received(:log_attachment_outcome).with(
           sample_record,
           category: :successfully_ingested_metadata_only,
-          message: 'No PDF or TGZ link found, skipping attachment',
+          message: 'No PDF found in S3 for PMCID',
           file_name: 'NONE'
         )
-
-        service.process_record(sample_record)
       end
 
       it 'logs skipped_file_attachment if record.category is skipped' do
         sample_record['category'] = 'skipped'
-        expect(service).to receive(:log_attachment_outcome).with(
+        service.process_record(sample_record)
+
+        expect(service).to have_received(:log_attachment_outcome).with(
           sample_record,
           category: :skipped_file_attachment,
-          message: 'No PDF or TGZ link found, skipping attachment',
+          message: 'No PDF found in S3 for PMCID',
           file_name: 'NONE'
         )
-        service.process_record(sample_record)
       end
     end
 
-    context 'when API request fails' do
-      let(:mock_response) { double('response', code: 500, body: '') }
+    context 'when no versions are found in S3' do
+      let(:empty_list_response) { double('empty_response', common_prefixes: []) }
+
+      before do
+        allow(mock_s3_client).to receive(:list_objects_v2).and_return(empty_list_response)
+        allow(service).to receive(:log_attachment_outcome)
+      end
+
+      it 'logs successfully_ingested_metadata_only by default' do
+        service.process_record(sample_record)
+
+        expect(service).to have_received(:log_attachment_outcome).with(
+          sample_record,
+          category: :successfully_ingested_metadata_only,
+          message: 'No versions found in S3 for PMCID',
+          file_name: 'NONE'
+        )
+      end
+    end
+
+    context 'when S3 request fails with a retryable error' do
+      before do
+        stub_const('Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::RETRY_LIMIT', 0)
+        allow(mock_s3_client).to receive(:list_objects_v2)
+          .and_raise(StandardError.new('Service unavailable'))
+        allow(service).to receive(:log_attachment_outcome)
+      end
 
       it 'retries and eventually logs failure' do
-        expect(service).to receive(:log_attachment_outcome).with(
-          sample_record,
-          category: :failed,
-          message: /File attachment failed -- Bad response: 500/,
-          file_name: 'NONE'
-        )
-
         service.process_record(sample_record)
-      end
-    end
 
-    context 'when Open Access API Error returns an error node' do
-      let(:oa_response_body) do
-        <<~XML
-          <?xml version="1.0"?>
-          <oa>
-            <error code="idDoesNotExist">identifier 'PMC99999999' does not exist</error>
-          </oa>
-        XML
-      end
-
-      it 'logs skipped_file_attachment with the error code as message' do
-        expect(service).to receive(:log_attachment_outcome).with(
-          sample_record,
-          category: :skipped_file_attachment,
-          message: 'Open Access API Error - idDoesNotExist',
-          file_name: 'NONE'
-        )
-
-        service.process_record(sample_record)
-      end
-    end
-  end
-
-  describe '#fetch_ftp_binary' do
-    let(:uri) { URI.parse('ftp://example.com/path/file.pdf') }
-    let(:mock_ftp) { double('ftp') }
-    let(:local_path) { '/tmp/test_fulltext/file.pdf' }
-
-    before do
-      allow(Net::FTP).to receive(:open).with('example.com').and_yield(mock_ftp)
-      allow(mock_ftp).to receive(:login)
-      allow(mock_ftp).to receive(:passive=)
-      allow(mock_ftp).to receive(:getbinaryfile)
-    end
-
-    it 'connects to FTP and downloads to the given path' do
-      result = service.fetch_ftp_binary(uri, local_file_path: local_path)
-
-      expect(Net::FTP).to have_received(:open).with('example.com')
-      expect(mock_ftp).to have_received(:getbinaryfile).with('/path/file.pdf', local_path)
-      expect(result).to eq(local_path)
-    end
-  end
-
-  describe '#safe_gzip_reader' do
-    before do
-      allow(File).to receive(:open).and_call_original
-    end
-
-    let(:temp_file) { Tempfile.new('test_gzip') }
-    let(:gzipped_content) do
-      # Create actual gzipped content
-      string_io = StringIO.new
-      gzip_writer = Zlib::GzipWriter.new(string_io)
-      gzip_writer.write('test content')
-      gzip_writer.close
-      string_io.string
-    end
-
-    before do
-      temp_file.binmode
-      temp_file.write('prefix_data')
-      temp_file.write(gzipped_content)
-      temp_file.close
-    end
-
-    after do
-      temp_file.unlink
-    end
-
-    it 'finds gzip header and creates reader' do
-      reader = service.safe_gzip_reader(temp_file.path)
-      expect(reader).to be_a(Zlib::GzipReader)
-      content = reader.read
-      expect(content).to eq('test content')
-      reader.close
-    end
-
-    context 'when no gzip header is found' do
-      let(:temp_file_no_gzip) { Tempfile.new('no_gzip') }
-
-      before do
-        temp_file_no_gzip.write('no gzip header here')
-        temp_file_no_gzip.close
-      end
-
-      after do
-        temp_file_no_gzip.unlink
-      end
-
-      it 'raises an error' do
-        expect {
-          service.safe_gzip_reader(temp_file_no_gzip.path)
-        }.to raise_error('No GZIP header found in file')
-      end
-    end
-  end
-
-  describe '#process_and_attach_tgz_file' do
-    let(:tgz_path) { '/full/path/PMC123456.tar.gz' }
-    let(:mock_user) { double('user', uid: 'admin') }
-    let(:mock_gz_reader) { double('gz_reader', close: true) }
-    let(:mock_tar_reader) { double('tar_reader') }
-    let(:mock_pdf_entry) { double('entry', file?: true, full_name: 'article.pdf', read: 'pdf_binary') }
-    let(:article) { double('article', id: 'work_123', reload: true, update_index: true) }
-
-    before do
-      allow(User).to receive(:find_by).with(uid: 'admin').and_return(mock_user)
-      allow(Article).to receive(:find).with('work_123').and_return(article)
-      allow(File).to receive(:expand_path).and_call_original
-      allow(File).to receive(:expand_path).with(tgz_path).and_return(tgz_path)
-      allow(service).to receive(:safe_gzip_reader).and_return(mock_gz_reader)
-      allow(Gem::Package::TarReader).to receive(:new).with(mock_gz_reader).and_yield(mock_tar_reader)
-      allow(service).to receive(:generate_filename_for_work).and_return('PMC123456_001.pdf')
-      allow(service).to receive(:attach_pdf_to_work_with_file_path!).and_return([double('fileset'), 'PMC123456_001.pdf'])
-      allow(File).to receive(:exist?).with(tgz_path).and_return(true)
-    end
-
-    context 'when work ID is present' do
-      before do
-        allow(mock_tar_reader).to receive(:each).and_yield(mock_pdf_entry)
-        allow(File).to receive(:binwrite)
-          .with(%r{/tmp/test_fulltext/PMC123456_001\.pdf}, 'pdf_binary')
-          .and_return(11)
-      end
-
-      it 'processes TGZ file and attaches PDFs' do
-        expect(service).to receive(:log_attachment_outcome).with(
-          sample_record,
-          category: :successfully_attached,
-          message: 'PDF successfully attached from TGZ.',
-          file_name: 'PMC123456_001.pdf'
-        )
-
-        service.process_and_attach_tgz_file(sample_record, tgz_path)
-
-        expect(article).to have_received(:reload)
-        expect(article).to have_received(:update_index)
-      end
-    end
-
-    context 'when TGZ contains a nested PDF file' do
-      let(:nested_pdf_entry) { double('entry', file?: true, full_name: 'nested/article.pdf', read: 'pdf_binary') }
-
-      before do
-        allow(mock_tar_reader).to receive(:each).and_yield(nested_pdf_entry)
-        allow(File).to receive(:binwrite)
-          .with(%r{/tmp/test_fulltext/PMC123456_001\.pdf}, 'pdf_binary')
-          .and_return(11)
-      end
-
-      it 'still attaches the PDF' do
-        expect(service).to receive(:log_attachment_outcome).with(
-          sample_record,
-          category: :successfully_attached,
-          message: 'PDF successfully attached from TGZ.',
-          file_name: 'PMC123456_001.pdf'
-        )
-
-        service.process_and_attach_tgz_file(sample_record, tgz_path)
-      end
-    end
-
-    context 'when work ID is blank' do
-      let(:record_without_work_id) do
-        { 'ids' => { 'pmcid' => 'PMC123456' } }
-      end
-
-      it 'logs metadata only message and returns early' do
-        expect(service).to receive(:log_attachment_outcome).with(
-          record_without_work_id,
-          category: :successfully_ingested_metadata_only,
-          message: 'No article ID found to attach TGZ',
-          file_name: 'NONE'
-        )
-
-        service.process_and_attach_tgz_file(record_without_work_id, tgz_path)
-      end
-    end
-
-    context 'when no PDF files found in TGZ' do
-      let(:mock_non_pdf_entry) { double('entry', file?: true, full_name: 'data.xml', read: 'xml_content') }
-
-      before do
-        allow(mock_tar_reader).to receive(:each).and_yield(mock_non_pdf_entry)
-      end
-
-      it 'logs failure message' do
-        expect(service).to receive(:log_attachment_outcome).with(
+        expect(service).to have_received(:log_attachment_outcome).with(
           sample_record,
           category: :failed,
-          message: /No PDF files found in TGZ archive/,
+          message: 'File attachment failed -- Service unavailable',
           file_name: 'NONE'
         )
-
-        service.process_and_attach_tgz_file(sample_record, tgz_path)
-      end
-    end
-
-    context 'when processing fails' do
-      before do
-        allow(Article).to receive(:find).and_raise(ActiveFedora::ObjectNotFoundError.new("Couldn't find Article with 'id'=work_123"))
-      end
-
-      it 'logs failure and error details' do
-        expect(service).to receive(:log_attachment_outcome).with(
-          sample_record,
-          category: :failed,
-          message: "TGZ PDF processing failed: Couldn't find Article with 'id'=work_123",
-          file_name: 'NONE'
-        )
-
-        service.process_and_attach_tgz_file(sample_record, tgz_path)
       end
     end
   end

--- a/spec/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service_spec.rb
+++ b/spec/services/tasks/pubmed_ingest/recurring/utilities/file_attachment_service_spec.rb
@@ -156,46 +156,31 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
   end
 
   describe '#process_record' do
-    let(:mock_s3_client) { double('s3_client') }
-    let(:mock_list_response) do
-      double('list_response', common_prefixes: [double('prefix', prefix: 'PMC123456.1/')])
-    end
-
     before do
-      allow(service).to receive(:s3_client).and_return(mock_s3_client)
-      allow(mock_s3_client).to receive(:list_objects_v2).and_return(mock_list_response)
-      allow(mock_s3_client).to receive(:get_object)
-      allow(service).to receive(:attach_pdf_to_work_with_file_path!)
+      allow(service).to receive(:latest_version_prefix).and_return('PMC123456.1/')
+      allow(service).to receive(:fetch_s3_file).and_return(200)
       allow(service).to receive(:generate_filename_for_work).and_return('PMC123456_001.pdf')
+      allow(service).to receive(:attach_pdf_to_work_with_file_path!)
+        .and_return([double('fileset'), 'PMC123456_001.pdf'])
+      allow(service).to receive(:log_attachment_outcome)
       allow(service).to receive(:sleep)
     end
 
     context 'when record has no PMCID' do
-      it 'returns early without calling S3' do
-        expect(mock_s3_client).not_to receive(:list_objects_v2)
+      it 'returns early without fetching from S3' do
+        expect(service).not_to receive(:latest_version_prefix)
         service.process_record(sample_record_without_pmcid)
       end
     end
 
     context 'when PDF is found in S3' do
-      before do
-        allow(service).to receive(:attach_pdf_to_work_with_file_path!)
-          .and_return([double('fileset'), 'PMC123456_001.pdf'])
-        allow(service).to receive(:log_attachment_outcome)
-      end
-
-      it 'lists S3 versions, downloads the PDF, and attaches it' do
+      it 'fetches the latest version, downloads the PDF, and attaches it' do
         service.process_record(sample_record)
 
-        expect(mock_s3_client).to have_received(:list_objects_v2).with(
-          bucket: Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::PMC_S3_BUCKET,
-          prefix: 'PMC123456.',
-          delimiter: '/'
-        )
-        expect(mock_s3_client).to have_received(:get_object).with(
-          bucket: Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::PMC_S3_BUCKET,
-          key: 'PMC123456.1/PMC123456.1.pdf',
-          response_target: anything
+        expect(service).to have_received(:latest_version_prefix).with('PMC123456')
+        expect(service).to have_received(:fetch_s3_file).with(
+          'https://pmc-oa-opendata.s3.amazonaws.com/PMC123456.1/PMC123456.1.pdf',
+          local_file_path: anything
         )
         expect(service).to have_received(:attach_pdf_to_work_with_file_path!)
       end
@@ -224,12 +209,8 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
       end
     end
 
-    context 'when no PDF is found in S3' do
-      before do
-        allow(mock_s3_client).to receive(:get_object)
-          .and_raise(Aws::S3::Errors::NoSuchKey.new(nil, 'The specified key does not exist.'))
-        allow(service).to receive(:log_attachment_outcome)
-      end
+    context 'when no PDF is found in S3 (404)' do
+      before { allow(service).to receive(:fetch_s3_file).and_return(404) }
 
       it 'logs successfully_ingested_metadata_only by default' do
         service.process_record(sample_record)
@@ -256,12 +237,7 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
     end
 
     context 'when no versions are found in S3' do
-      let(:empty_list_response) { double('empty_response', common_prefixes: []) }
-
-      before do
-        allow(mock_s3_client).to receive(:list_objects_v2).and_return(empty_list_response)
-        allow(service).to receive(:log_attachment_outcome)
-      end
+      before { allow(service).to receive(:latest_version_prefix).and_return(nil) }
 
       it 'logs successfully_ingested_metadata_only by default' do
         service.process_record(sample_record)
@@ -275,12 +251,10 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
       end
     end
 
-    context 'when S3 request fails with a retryable error' do
+    context 'when a retryable error occurs' do
       before do
         stub_const('Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService::RETRY_LIMIT', 0)
-        allow(mock_s3_client).to receive(:list_objects_v2)
-          .and_raise(StandardError.new('Service unavailable'))
-        allow(service).to receive(:log_attachment_outcome)
+        allow(service).to receive(:latest_version_prefix).and_raise(StandardError.new('Service unavailable'))
       end
 
       it 'retries and eventually logs failure' do
@@ -293,6 +267,83 @@ RSpec.describe Tasks::PubmedIngest::Recurring::Utilities::FileAttachmentService 
           file_name: 'NONE'
         )
       end
+    end
+  end
+
+  describe '#latest_version_prefix' do
+    let(:list_xml) do
+      <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <CommonPrefixes><Prefix>PMC123456.1/</Prefix></CommonPrefixes>
+          <CommonPrefixes><Prefix>PMC123456.2/</Prefix></CommonPrefixes>
+        </ListBucketResult>
+      XML
+    end
+
+    before do
+      allow(HTTParty).to receive(:get)
+        .with(a_string_including('PMC123456.'), anything)
+        .and_return(double('response', code: 200, body: list_xml))
+    end
+
+    it 'returns the latest (sorted) version prefix' do
+      expect(service.latest_version_prefix('PMC123456')).to eq('PMC123456.2/')
+    end
+
+    context 'when no versions exist' do
+      let(:empty_xml) do
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          </ListBucketResult>
+        XML
+      end
+
+      before do
+        allow(HTTParty).to receive(:get)
+          .and_return(double('response', code: 200, body: empty_xml))
+      end
+
+      it 'returns nil' do
+        expect(service.latest_version_prefix('PMC123456')).to be_nil
+      end
+    end
+
+    context 'when the S3 listing request fails' do
+      before do
+        allow(HTTParty).to receive(:get)
+          .and_return(double('response', code: 500, body: ''))
+      end
+
+      it 'raises an error' do
+        expect { service.latest_version_prefix('PMC123456') }.to raise_error(/S3 listing failed/)
+      end
+    end
+  end
+
+  describe '#fetch_s3_file' do
+    let(:url) { 'https://pmc-oa-opendata.s3.amazonaws.com/PMC123456.1/PMC123456.1.pdf' }
+    let(:local_path) { '/tmp/test_fulltext/PMC123456_001.pdf' }
+
+    before { allow(File).to receive(:binwrite) }
+
+    it 'writes the body to disk and returns 200 on success' do
+      allow(HTTParty).to receive(:get).and_return(double('response', code: 200, body: 'pdf_content'))
+
+      result = service.fetch_s3_file(url, local_file_path: local_path)
+
+      expect(result).to eq(200)
+      expect(File).to have_received(:binwrite).with(local_path, 'pdf_content')
+    end
+
+    it 'returns 404 without writing a file when not found' do
+      allow(HTTParty).to receive(:get).and_return(double('response', code: 404, body: ''))
+
+      result = service.fetch_s3_file(url, local_file_path: local_path)
+
+      expect(result).to eq(404)
+      expect(File).not_to have_received(:binwrite)
     end
   end
 end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2184

* Use s3 for getting PDF files for attaching to pubmed articles. Removes TGZ behaviors since their FAQ states that those files will no longer be available.