### PR TITLE
HYC-2216 - Work menu fixes

### DIFF
--- a/app/assets/stylesheets/unc_custom.css.scss
+++ b/app/assets/stylesheets/unc_custom.css.scss
@@ -160,6 +160,13 @@ span.institution_name {
   }
 }
 
+// Match the dashboard action menu font size on work-show related file dropdowns.
+.related-files {
+  .dropdown-item {
+    font-size: 16px;
+  }
+}
+
 #unc-search {
   background-color: $carolina-blue;
   height: 45%;

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -30,11 +30,6 @@
     <% end %>
 
     <%# [hyc-override] Remove the option to feature on profile page, as we don't use profiles %>
-    <%# <%= display_trophy_link(current_user, document.id, role: 'menuitem') do |text| %> %>
-    <%#   <li class="dropdown-item" tabindex="-1"> %>
-    <%#     <%= text %> %>
-    <%#   </li> %>
-    <%# <% end %> %>
 
     <% if can? :transfer, document.id %>
       <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', role: 'menuitem',


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2216
https://unclibrary.atlassian.net/browse/HYC-2217

* Remove the commented out trophy menu entry, which was dropping extra characters into the menu
* Reduce font size of file actions dropdown menu, which got bigger in hyrax 5