### PR TITLE
HYC-2220 - Improve dashboard/work page performance

### DIFF
--- a/app/overrides/controllers/hyrax/my/works_controller_override.rb
+++ b/app/overrides/controllers/hyrax/my/works_controller_override.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# https://github.com/samvera/hyrax/blob/hyrax-v5.2.0/app/controllers/hyrax/my/works_controller.rb
+# [hyc-override] https://github.com/samvera/hyrax/blob/hyrax-v5.2.0/app/controllers/hyrax/my/works_controller.rb
 
 Hyrax::My::WorksController.class_eval do
   private
@@ -11,7 +11,7 @@ Hyrax::My::WorksController.class_eval do
     )
     return [] if source_ids.blank?
 
-    # Avoid Wings `find_many_by_ids`, which resolves each admin set via Fedora one id at a time.
+    # [hyc-override] Avoid Wings `find_many_by_ids`, which resolves each admin set via Fedora one id at a time.
     admin_sets_list = Hyrax::SolrQueryService.new
                         .with_ids(ids: source_ids)
                         .with_field_pairs(

--- a/app/overrides/controllers/hyrax/my/works_controller_override.rb
+++ b/app/overrides/controllers/hyrax/my/works_controller_override.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# https://github.com/samvera/hyrax/blob/hyrax-v5.2.0/app/controllers/hyrax/my/works_controller.rb
+
+Hyrax::My::WorksController.class_eval do
+  private
+
+  def admin_sets_for_select
+    source_ids = Hyrax::Collections::PermissionsService.source_ids_for_deposit(
+      ability: current_ability,
+      source_type: 'admin_set'
+    )
+    return [] if source_ids.blank?
+
+    # Avoid Wings `find_many_by_ids`, which resolves each admin set via Fedora one id at a time.
+    admin_sets_list = Hyrax::SolrQueryService.new
+                        .with_ids(ids: source_ids)
+                        .with_field_pairs(
+                          field_pairs: {
+                            has_model_ssim: Hyrax::ModelRegistry.admin_set_rdf_representations.join(',')
+                          },
+                          type: 'terms'
+                        )
+                        .solr_documents(rows: source_ids.length, fl: 'id,title_tesim')
+                        .map do |doc|
+      [Array(doc['title_tesim']).first.to_s, doc['id']]
+    end
+
+    admin_sets_list.sort do |a, b|
+      if Hyrax::AdminSetCreateService.default_admin_set?(id: a[1])
+        -1
+      elsif Hyrax::AdminSetCreateService.default_admin_set?(id: b[1])
+        1
+      else
+        a[0] <=> b[0]
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/my/works_controller_spec.rb
+++ b/spec/controllers/hyrax/my/works_controller_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('app/overrides/controllers/hyrax/my/works_controller_override.rb')
+
+RSpec.describe Hyrax::My::WorksController, type: :controller do
+  let(:ability) { instance_double(Ability) }
+  let(:query_service) { instance_double('query_service') }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(Hyrax).to receive(:query_service).and_return(query_service)
+  end
+
+  describe '#admin_sets_for_select' do
+    context 'when depositable admin sets are available' do
+      let(:source_ids) { ['z-admin-set', Hyrax::AdminSetCreateService::DEFAULT_ID, 'a-admin-set'] }
+      let(:solr_query_service) { instance_double(Hyrax::SolrQueryService) }
+      let(:solr_documents) do
+        [
+          { 'id' => 'z-admin-set', 'title_tesim' => ['Zeta Admin Set'] },
+          { 'id' => Hyrax::AdminSetCreateService::DEFAULT_ID, 'title_tesim' => ['Default Admin Set'] },
+          { 'id' => 'a-admin-set', 'title_tesim' => ['Alpha Admin Set'] }
+        ]
+      end
+
+      before do
+        allow(Hyrax::Collections::PermissionsService)
+          .to receive(:source_ids_for_deposit)
+          .with(ability: ability, source_type: 'admin_set')
+          .and_return(source_ids)
+
+        allow(Hyrax::AdminSetCreateService)
+          .to receive(:default_admin_set?) do |id:|
+            id == Hyrax::AdminSetCreateService::DEFAULT_ID
+          end
+
+        allow(Hyrax::SolrQueryService).to receive(:new).and_return(solr_query_service)
+        allow(solr_query_service).to receive(:with_ids).with(ids: source_ids).and_return(solr_query_service)
+        allow(solr_query_service)
+          .to receive(:with_field_pairs)
+          .with(
+            field_pairs: {
+              has_model_ssim: Hyrax::ModelRegistry.admin_set_rdf_representations.join(',')
+            },
+            type: 'terms'
+          )
+          .and_return(solr_query_service)
+        allow(solr_query_service)
+          .to receive(:solr_documents)
+          .with(rows: source_ids.length, fl: 'id,title_tesim')
+          .and_return(solr_documents)
+      end
+
+      it 'builds the select options from Solr without loading admin sets through the query service' do
+        expect(query_service).not_to receive(:find_many_by_ids)
+
+        expect(controller.send(:admin_sets_for_select)).to eq(
+          [
+            ['Default Admin Set', Hyrax::AdminSetCreateService::DEFAULT_ID],
+            ['Alpha Admin Set', 'a-admin-set'],
+            ['Zeta Admin Set', 'z-admin-set']
+          ]
+        )
+      end
+    end
+
+    context 'when there are no depositable admin sets' do
+      before do
+        allow(Hyrax::Collections::PermissionsService)
+          .to receive(:source_ids_for_deposit)
+          .with(ability: ability, source_type: 'admin_set')
+          .and_return([])
+      end
+
+      it 'returns an empty list without querying Solr' do
+        expect(Hyrax::SolrQueryService).not_to receive(:new)
+        expect(query_service).not_to receive(:find_many_by_ids)
+
+        expect(controller.send(:admin_sets_for_select)).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2220

* Gets works dashboard back to a normal loading time (1-2 seconds), it was taking around 25 seconds to load because it was pulling the full fedora record for every admin set in the repo one by one when the page was requested, in order to populate the facet filter list of admin sets (it still works, it just pulls exclusively from solr now)