### PR TITLE
HYC-227 - Duplicate predicate warnings

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,15 +10,7 @@ class Article < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -10,10 +10,6 @@ class Artwork < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -8,7 +8,9 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
-      property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
+      property :alternative_title, predicate: ::RDF::Vocab::DC.alternative do |index|
+        index.as :stored_searchable
+      end
 
       property :label, predicate: ActiveFedora::RDF::Fcrepo::Model.downloadFilename, multiple: false
 
@@ -27,7 +29,9 @@ module Hyrax
       end
       property :contributor, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#Contributor')
       property :description, predicate: ::RDF::Vocab::DC11.description, multiple: false
-      property :abstract, predicate: ::RDF::Vocab::DC.abstract
+      property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
+        index.as :stored_searchable
+      end
       # predicate changed
       property :keyword, predicate: ::RDF::Vocab::SCHEMA.keywords
       # predicate changed

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -10,10 +10,6 @@ class DataSet < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/dissertation.rb
+++ b/app/models/dissertation.rb
@@ -10,19 +10,11 @@ class Dissertation < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end
 
   property :advisors, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ths'), class_name: 'Person' do |index|
-    index.as :stored_searchable
-  end
-
-  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/general.rb
+++ b/app/models/general.rb
@@ -10,10 +10,6 @@ class General < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :academic_concentration, predicate: ::RDF::URI('http://vivoweb.org/ontology/core#majorField') do |index|
     index.as :stored_searchable
   end
@@ -23,10 +19,6 @@ class General < ActiveFedora::Base
   end
 
   property :advisors, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ths'), class_name: 'Person' do |index|
-    index.as :stored_searchable
-  end
-
-  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/honors_thesis.rb
+++ b/app/models/honors_thesis.rb
@@ -10,10 +10,6 @@ class HonorsThesis < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :academic_concentration, predicate: ::RDF::URI('http://vivoweb.org/ontology/core#majorField') do |index|
     index.as :stored_searchable
   end
@@ -23,10 +19,6 @@ class HonorsThesis < ActiveFedora::Base
   end
 
   property :advisors, predicate: ::RDF::URI('http://id.loc.gov/vocabulary/relators/ths'), class_name: 'Person' do |index|
-    index.as :stored_searchable
-  end
-
-  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -10,15 +10,7 @@ class Journal < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/masters_paper.rb
+++ b/app/models/masters_paper.rb
@@ -10,10 +10,6 @@ class MastersPaper < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :academic_concentration, predicate: ::RDF::URI('http://vivoweb.org/ontology/core#majorField') do |index|
     index.as :stored_searchable
   end

--- a/app/models/multimed.rb
+++ b/app/models/multimed.rb
@@ -10,10 +10,6 @@ class Multimed < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/scholarly_work.rb
+++ b/app/models/scholarly_work.rb
@@ -10,10 +10,6 @@ class ScholarlyWork < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
-    index.as :stored_searchable
-  end
-
   property :admin_note, predicate: ::RDF::URI('http://cdr.unc.edu/definitions/model#AdminNote'), multiple: false do |index|
     index.as :stored_searchable
   end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2227

Remove abstract and alternative_title from model classes, and make the basic_metadata definition of them include stored_searchable to match how they were defined almost everywhere