### PR TITLE
HYC-2249 - Pooled Solr Repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'concurrent-ruby', '1.3.4'
 gem 'devise', '~> 4.8.0'
 gem 'devise-guests', '~> 0.8.1'
 gem 'edtf-humanize', '~> 2.1'
+gem 'faraday-net_http_persistent', '~> 2.3'
+gem 'faraday-retry'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'execjs', '2.10.2'
 gem 'httparty', '~>0.21.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,11 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    faraday-net_http_persistent (2.3.1)
+      faraday (~> 2.5)
+      net-http-persistent (>= 4.0.4, < 5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
     ffaker (2.24.0)
@@ -1191,6 +1196,8 @@ DEPENDENCIES
   equivalent-xml (~> 0.6)
   execjs (= 2.10.2)
   factory_bot_rails (~> 6.2.0)
+  faraday-net_http_persistent (~> 2.3)
+  faraday-retry
   fcrepo_wrapper (~> 0.9.0)
   ffaker
   google-analytics-data!

--- a/app/repositories/hyc/pooled_solr_repository.rb
+++ b/app/repositories/hyc/pooled_solr_repository.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'faraday/net_http_persistent'
+require 'faraday/retry'
+
+module Hyc
+  class PooledSolrRepository < Blacklight::Solr::Repository
+    def build_connection
+      opts = connection_config.symbolize_keys
+      url = opts.fetch(:url)
+      faraday = Faraday.new(
+          url: url,
+          request: {
+            open_timeout: opts.fetch(:open_timeout, 2).to_f,
+            timeout: opts.fetch(:timeout, 10).to_f
+          }
+        ) do |conn|
+            conn.request :retry, max: 2, interval: 0.05, interval_randomness: 0.5,
+                        backoff_factor: 2, exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
+            conn.response :raise_error
+            conn.adapter :net_http_persistent
+        end
+      RSolr::Client.new(
+        faraday,
+        url: url
+      )
+    end
+  end
+end

--- a/app/repositories/hyc/pooled_solr_repository.rb
+++ b/app/repositories/hyc/pooled_solr_repository.rb
@@ -27,7 +27,9 @@ module Hyc
             conn.request :retry, max: 2, interval: 0.05, interval_randomness: 0.5,
                         backoff_factor: 2, exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
             conn.response :raise_error
-            conn.adapter :net_http_persistent
+            conn.adapter :net_http_persistent do |http|
+              http.retry_change_requests = true
+            end
         end
       RSolr::Client.new(
         faraday,

--- a/app/repositories/hyc/pooled_solr_repository.rb
+++ b/app/repositories/hyc/pooled_solr_repository.rb
@@ -24,17 +24,17 @@ module Hyc
             timeout: opts.fetch(:timeout, 10).to_f
           }
         ) do |conn|
-            conn.request :retry,
-                        max: 2,
-                        interval: 0.05,
-                        interval_randomness: 0.5,
-                        backoff_factor: 2,
-                        retry_if: lambda { |env, _exception|
-                          env.method == :post && !env.url.path.end_with?('/update')
-                        },
-                        exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
-            conn.response :raise_error
-            conn.adapter :net_http_persistent
+          conn.request :retry,
+                      max: 2,
+                      interval: 0.05,
+                      interval_randomness: 0.5,
+                      backoff_factor: 2,
+                      retry_if: lambda { |env, _exception|
+                        env.method == :post && !env.url.path.end_with?('/update')
+                      },
+                      exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
+          conn.response :raise_error
+          conn.adapter :net_http_persistent
         end
       RSolr::Client.new(
         faraday,

--- a/app/repositories/hyc/pooled_solr_repository.rb
+++ b/app/repositories/hyc/pooled_solr_repository.rb
@@ -6,6 +6,15 @@ require 'faraday/retry'
 module Hyc
   class PooledSolrRepository < Blacklight::Solr::Repository
     def build_connection
+      # Reuse a connection object across requests within the same passenger/puma worker
+      self.class.shared_connection(connection_config)
+    end
+
+    def self.shared_connection(connection_config)
+      @shared_connection ||= build_raw_connection(connection_config)
+    end
+
+    def self.build_raw_connection(connection_config)
       opts = connection_config.symbolize_keys
       url = opts.fetch(:url)
       faraday = Faraday.new(

--- a/app/repositories/hyc/pooled_solr_repository.rb
+++ b/app/repositories/hyc/pooled_solr_repository.rb
@@ -24,12 +24,17 @@ module Hyc
             timeout: opts.fetch(:timeout, 10).to_f
           }
         ) do |conn|
-            conn.request :retry, max: 2, interval: 0.05, interval_randomness: 0.5,
-                        backoff_factor: 2, exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
+            conn.request :retry,
+                        max: 2,
+                        interval: 0.05,
+                        interval_randomness: 0.5,
+                        backoff_factor: 2,
+                        retry_if: lambda { |env, _exception|
+                          env.method == :post && !env.url.path.end_with?('/update')
+                        },
+                        exceptions: [Faraday::ConnectionFailed, Faraday::TimeoutError]
             conn.response :raise_error
-            conn.adapter :net_http_persistent do |http|
-              http.retry_change_requests = true
-            end
+            conn.adapter :net_http_persistent
         end
       RSolr::Client.new(
         faraday,

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -2,7 +2,7 @@ development:
   adapter: Hyc::PooledSolrRepository
   url: <%= ENV['SOLR_DEV_URL'] %>
 test: &test
-  adapter: Solr
+  adapter: solr
   url: <%= ENV['SOLR_TEST_URL'] %>
 production:
   adapter: Hyc::PooledSolrRepository

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,9 +1,11 @@
 development:
-  adapter: solr
+  adapter: Hyc::PooledSolrRepository
   url: <%= ENV['SOLR_DEV_URL'] %>
 test: &test
-  adapter: solr
+  adapter: Solr
   url: <%= ENV['SOLR_TEST_URL'] %>
 production:
-  adapter: solr
+  adapter: Hyc::PooledSolrRepository
   url: <%= ENV['SOLR_PRODUCTION_URL'] %>
+  open_timeout: <%= ENV.fetch('SOLR_OPEN_TIMEOUT', 2) %>
+  timeout: <%= ENV.fetch('SOLR_TIMEOUT', 5) %>

--- a/spec/repositories/hyc/pooled_solr_repository_spec.rb
+++ b/spec/repositories/hyc/pooled_solr_repository_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 require Rails.root.join('app/repositories/hyc/pooled_solr_repository.rb')
 

--- a/spec/repositories/hyc/pooled_solr_repository_spec.rb
+++ b/spec/repositories/hyc/pooled_solr_repository_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+require Rails.root.join('app/repositories/hyc/pooled_solr_repository.rb')
+
+RSpec.describe Hyc::PooledSolrRepository do
+  subject(:repository) { described_class.new(CatalogController.blacklight_config) }
+
+  let(:doc_id) { "pooled-solr-repository-spec-#{SecureRandom.hex(6)}" }
+  let(:doc_title) { 'Pooled Solr Repository Spec Document' }
+
+  before do
+    described_class.instance_variable_set(:@shared_connection, nil)
+    repository.connection.delete_by_query("id:#{doc_id}")
+    repository.connection.commit
+  end
+
+  after do
+    repository.connection.delete_by_query("id:#{doc_id}")
+    repository.connection.commit
+    described_class.instance_variable_set(:@shared_connection, nil)
+  end
+
+  describe '#search' do
+    it 'returns a successful response from Solr' do
+      repository.connection.add([{ id: doc_id, title_tesim: [doc_title] }])
+      repository.connection.commit
+
+      response = repository.search(q: "id:#{doc_id}")
+
+      expect(response.documents.count).to eq 1
+      expect(response.documents.first.id).to eq doc_id
+      expect(response.documents.first['title_tesim']).to eq [doc_title]
+    end
+
+    it 'raises an invalid request error for bad lucene syntax' do
+      expect do
+        repository.search(q: 'title_tesim:(', defType: 'lucene')
+      end.to raise_error(Blacklight::Exceptions::InvalidRequest)
+    end
+  end
+end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2249

* Sets up a pooled solr repository to enable connection reuse within the same passenger worker, to cut down on overhead from every request opening a new connection. This isn't truly pooling, its more like connection reuse, since a true pool likely isn't going to be shared across passenger workers anyway.
* 