### PR TITLE
HYC-2225 - UnknownFormat log spam

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,17 +77,11 @@ class CatalogController < ApplicationController
   end
 
   def facet
-    begin
-      facet_field_name = params[:id]
-      targeted_facet_list = ['affiliation_label_sim']
-      super
-      # Only calculate total unique facets for facets in the target list
-      @total_unique_facets =  targeted_facet_list.include?(facet_field_name) ? facet_total_count(facet_field_name) : 0
-    rescue StandardError => e
-      # Capture any errors that occur and log them
-      Rails.logger.error("Error during facet action: #{e.message}")
-      Rails.logger.error(e.backtrace.join("\n"))
-    end
+    facet_field_name = params[:id]
+    targeted_facet_list = ['affiliation_label_sim']
+    super
+    # Only calculate total unique facets for facets in the target list
+    @total_unique_facets =  targeted_facet_list.include?(facet_field_name) ? facet_total_count(facet_field_name) : 0
   end
 
   configure_blacklight do |config|

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -95,6 +95,12 @@ RSpec.describe CatalogController, type: :controller do
 
       expect(response).to have_http_status(:bad_request)
     end
+
+    it 'returns not found for unsupported facet formats' do
+      get :facet, params: { id: CatalogController.blacklight_config.facet_fields.keys.first, format: 'php' }
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'search page limits' do


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2225

Remove rescue from facet method which was logging verbose errors and preventing the server from responding with a 4xx for invalid formats