### PR TITLE
HYC-2226 - Fix catalog search build issues

### DIFF
--- a/app/search_builders/hyc/catalog_search_builder.rb
+++ b/app/search_builders/hyc/catalog_search_builder.rb
@@ -26,12 +26,13 @@ module Hyc
 
       # Sanitize the query term from JSON (handles unbalanced quotes)
       query_term = QueryParserHelper.sanitize_query(query_term)
+      escaped_query_term = escape_local_param_query(query_term)
 
       # Build metadata query using edismax
-      metadata_query = "_query_:\"{!edismax qf='#{qf}' pf='#{pf}'}#{query_term}\""
+      metadata_query = "_query_:\"{!edismax qf='#{qf}' pf='#{pf}'}#{escaped_query_term}\""
 
       # Build combined query that includes both metadata search (from JSON query) and file text search
-      combined_query = "(#{metadata_query}) OR (#{all_fields_query(all_fields_value)})"
+      combined_query = "(#{metadata_query}) OR (#{all_fields_query(escaped_query_term)})"
       solr_parameters.delete(:json)
       # Use lucene defType to allow for the OR operator in the combined query
       solr_parameters[:defType] = 'lucene'
@@ -62,6 +63,10 @@ module Hyc
 
     def join_work_to_file
       "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}"
+    end
+
+    def escape_local_param_query(query)
+      query.gsub(/([\\"])/, '\\\\\1')
     end
   end
 end

--- a/app/search_builders/hyc/catalog_search_builder.rb
+++ b/app/search_builders/hyc/catalog_search_builder.rb
@@ -11,38 +11,28 @@ module Hyc
     # This should always be the last processor in this processor chain.
     # Adds full text searching for :all_fields
     def join_works_from_files(solr_parameters)
-      all_fields_value = retrieve_all_fields_query
-      return if all_fields_value.blank?
+      return if retrieve_all_fields_query.blank?
 
-      # JSON query and q parameters are AND-ed together by solr, so we need to remove the JSON query and replace it with a custom combined query to achieve the desired OR behavior
-      # Retrieve the JSON query for metadata search
-      json_query = solr_parameters.dig(:json, :query, :bool, :must, 0)
-      return if json_query.nil? || json_query[:edismax].nil?
+      bool_query = solr_parameters.dig(:json, :query, :bool)
+      return if bool_query.blank?
 
-      # Extract the metadata search parameters
-      qf = json_query[:edismax][:qf]
-      pf = json_query[:edismax][:pf]
-      query_term = json_query[:edismax][:query]
+      # Preserve the surrounding advanced-search bool structure and only rewrite
+      # the all_fields clause into: metadata match OR joined file-text match.
+      %i[must should must_not].each do |operator|
+        next unless bool_query[operator].is_a?(Array)
 
-      # Sanitize the query term from JSON (handles unbalanced quotes)
-      query_term = QueryParserHelper.sanitize_query(query_term)
-      escaped_query_term = escape_local_param_query(query_term)
-
-      # Build metadata query using edismax
-      metadata_query = "_query_:\"{!edismax qf='#{qf}' pf='#{pf}'}#{escaped_query_term}\""
-
-      # Build combined query that includes both metadata search (from JSON query) and file text search
-      combined_query = "(#{metadata_query}) OR (#{all_fields_query(escaped_query_term)})"
-      solr_parameters.delete(:json)
-      # Use lucene defType to allow for the OR operator in the combined query
-      solr_parameters[:defType] = 'lucene'
-      solr_parameters[:q] = combined_query
+        bool_query[operator].map! do |clause|
+          all_fields_json_clause?(clause) ? build_all_fields_bool_clause(clause) : clause
+        end
+      end
     end
 
     def retrieve_all_fields_query
+      clauses = blacklight_params['clause'] || blacklight_params[:clause]
+
       # Advanced search uses clause params
-      if blacklight_params['clause'].present?
-        blacklight_params['clause']&.each do |_, entry|
+      if clauses.present?
+        clauses.each do |_, entry|
           if entry['field'] == 'all_fields'
             return QueryParserHelper.sanitize_query(entry['query'])
           end
@@ -50,15 +40,18 @@ module Hyc
       end
 
       # Basic search uses q param directly when search_field is all_fields
-      if blacklight_params[:search_field] == 'all_fields' && blacklight_params[:q].present?
-        return QueryParserHelper.sanitize_query(blacklight_params[:q])
+      search_field = blacklight_params[:search_field] || blacklight_params['search_field']
+      query = blacklight_params[:q] || blacklight_params['q']
+
+      if search_field == 'all_fields' && query.present?
+        return QueryParserHelper.sanitize_query(query)
       end
 
-      return nil
+      nil
     end
 
     def all_fields_query(all_fields_value)
-      " _query_:\"#{join_work_to_file}{!dismax qf=all_text_timv}#{all_fields_value}\""
+      "_query_:\"#{join_work_to_file}{!dismax qf=all_text_timv}#{all_fields_value}\""
     end
 
     def join_work_to_file
@@ -67,6 +60,40 @@ module Hyc
 
     def escape_local_param_query(query)
       query.gsub(/([\\"])/, '\\\\\1')
+    end
+
+    def build_all_fields_bool_clause(clause)
+      edismax = clause[:edismax] || clause['edismax']
+      query = QueryParserHelper.sanitize_query(edismax[:query] || edismax['query'])
+
+      {
+        bool: {
+          should: [
+            {
+              edismax: {
+                qf: edismax[:qf] || edismax['qf'],
+                pf: edismax[:pf] || edismax['pf'],
+                query: query
+              }
+            },
+            all_fields_query(escape_local_param_query(query))
+          ]
+        }
+      }
+    end
+
+    def all_fields_json_clause?(clause)
+      edismax = clause[:edismax] || clause['edismax']
+      return false unless edismax
+
+      qf = edismax[:qf] || edismax['qf']
+      pf = edismax[:pf] || edismax['pf']
+
+      qf == all_fields_edismax[:qf] && pf == all_fields_edismax[:pf]
+    end
+
+    def all_fields_edismax
+      @all_fields_edismax ||= CatalogController.blacklight_config.search_fields['all_fields'].clause_params[:edismax]
     end
   end
 end

--- a/app/search_builders/hyc/catalog_search_builder.rb
+++ b/app/search_builders/hyc/catalog_search_builder.rb
@@ -7,9 +7,11 @@ module Hyc
       :join_works_from_files
     ]
 
-    # join from file id to work relationship solrized file_set_ids_ssim for full text searching in advanced search
-    # This should always be the last processor in this processor chain.
     # Adds full text searching for :all_fields
+    # Rewrites only the advanced-search all_fields clause so it matches either
+    # work metadata or joined file full text, while leaving sibling clauses in
+    # Blacklight's bool query untouched.
+    # This should always be the last processor in this processor chain.
     def join_works_from_files(solr_parameters)
       return if retrieve_all_fields_query.blank?
 
@@ -27,6 +29,8 @@ module Hyc
       end
     end
 
+    # We only need to run the rewrite when the request actually includes an
+    # all_fields search, either from advanced search clauses or a basic search.
     def retrieve_all_fields_query
       clauses = blacklight_params['clause'] || blacklight_params[:clause]
 
@@ -62,6 +66,8 @@ module Hyc
       query.gsub(/([\\"])/, '\\\\\1')
     end
 
+    # Keeps the outer bool operator from Blacklight intact, but expands the
+    # all_fields clause itself into: metadata match OR joined file-text match.
     def build_all_fields_bool_clause(clause)
       edismax = clause[:edismax] || clause['edismax']
       query = QueryParserHelper.sanitize_query(edismax[:query] || edismax['query'])
@@ -71,17 +77,23 @@ module Hyc
           should: [
             {
               edismax: {
+                # Preserve Blacklight's configured metadata fields for the
+                # original all_fields clause.
                 qf: edismax[:qf] || edismax['qf'],
                 pf: edismax[:pf] || edismax['pf'],
                 query: query
               }
             },
+            # The file-text side of the OR is still expressed as a local-param
+            # query string because it relies on a Solr join.
             all_fields_query(escape_local_param_query(query))
           ]
         }
       }
     end
 
+    # Identify the JSON clause Blacklight built for all_fields by matching the
+    # configured edismax fields, rather than assuming a fixed clause position.
     def all_fields_json_clause?(clause)
       edismax = clause[:edismax] || clause['edismax']
       return false unless edismax
@@ -92,6 +104,8 @@ module Hyc
       qf == all_fields_edismax[:qf] && pf == all_fields_edismax[:pf]
     end
 
+    # Memoize the configured all_fields edismax so clause matching stays tied to
+    # the controller config without repeating the lookup.
     def all_fields_edismax
       @all_fields_edismax ||= CatalogController.blacklight_config.search_fields['all_fields'].clause_params[:edismax]
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -126,5 +126,16 @@ RSpec.describe CatalogController, type: :controller do
 
       expect(response).to have_http_status(:success)
     end
+
+    it 'allows advanced searches when all_fields is not the first clause' do
+      get :index, params: {
+        clause: {
+          '0' => { field: 'creator', query: 'Smith' },
+          '1' => { field: 'all_fields', query: 'thesis' }
+        }
+      }
+
+      expect(response).to have_http_status(:success)
+    end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -120,5 +120,11 @@ RSpec.describe CatalogController, type: :controller do
 
       expect(response).to have_http_status(:bad_request)
     end
+
+    it 'allows quoted all_fields searches' do
+      get :index, params: { q: '"Doctor of Nursing Practice"', search_field: 'all_fields' }
+
+      expect(response).to have_http_status(:success)
+    end
   end
 end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -1,14 +1,75 @@
 # frozen_string_literal: true
 require 'rails_helper'
+require Rails.root.join('spec/support/full_text.rb')
 require Rails.root.join('spec/support/oai_sample_solr_documents.rb')
 include Warden::Test::Helpers
 
 RSpec.describe 'Advanced search', type: :feature, js: false do
   let(:solr) { Blacklight.default_index.connection }
+  let(:smith_work) do
+    FULL_TEXT_WORK.merge(
+      'id' => 'smith-thesis-work',
+      'title_tesim' => ['Smith thesis target'],
+      'title_sort_ssi' => 'smith thesis target',
+      'file_set_ids_ssim' => ['smith-thesis-file-set'],
+      'member_ids_ssim' => ['smith-thesis-file-set'],
+      'creator_tesim' => ['smith'],
+      'creator_sim' => ['smith'],
+      'creator_label_tesim' => ['smith'],
+      'creator_label_sim' => ['smith']
+    )
+  end
+
+  let(:smith_file_set) do
+    FULL_TEXT_FILE_SET.merge(
+      'id' => 'smith-thesis-file-set',
+      'title_tesim' => ['smith-thesis.pdf'],
+      'label_tesim' => ['smith-thesis.pdf'],
+      'label_ssi' => 'smith-thesis.pdf',
+      'all_text_timv' => ['thesis']
+    )
+  end
+
+  let(:jones_work) do
+    FULL_TEXT_WORK.merge(
+      'id' => 'jones-thesis-work',
+      'title_tesim' => ['Jones thesis decoy'],
+      'title_sort_ssi' => 'jones thesis decoy',
+      'file_set_ids_ssim' => ['jones-thesis-file-set'],
+      'member_ids_ssim' => ['jones-thesis-file-set'],
+      'creator_tesim' => ['jones'],
+      'creator_sim' => ['jones'],
+      'creator_label_tesim' => ['jones'],
+      'creator_label_sim' => ['jones']
+    )
+  end
+
+  let(:jones_file_set) do
+    FULL_TEXT_FILE_SET.merge(
+      'id' => 'jones-thesis-file-set',
+      'title_tesim' => ['jones-thesis.pdf'],
+      'label_tesim' => ['jones-thesis.pdf'],
+      'label_ssi' => 'jones-thesis.pdf',
+      'all_text_timv' => ['thesis']
+    )
+  end
 
   before do
     solr.delete_by_query('*:*') # delete everything in Solr
-    solr.add([SLEEPY_HOLLOW, MYSTERIOUS_AFFAIR, BEOWULF, LEVIATHAN, GREAT_EXPECTATIONS, ILIAD, MISERABLES, MOBY_DICK])
+    solr.add([
+               SLEEPY_HOLLOW,
+               MYSTERIOUS_AFFAIR,
+               BEOWULF,
+               LEVIATHAN,
+               GREAT_EXPECTATIONS,
+               ILIAD,
+               MISERABLES,
+               MOBY_DICK,
+               smith_work,
+               smith_file_set,
+               jones_work,
+               jones_file_set
+             ])
     solr.commit
   end
 
@@ -37,4 +98,19 @@ RSpec.describe 'Advanced search', type: :feature, js: false do
     expect(find('#range_date_issued_isim_begin').value).to eq('1990')
     expect(find('#range_date_issued_isim_end').value).to eq('2020')
   end
+
+  it 'uses the creator clause to narrow all fields results' do
+    visit search_catalog_path(
+      op: 'must',
+      clause: {
+        '0' => { field: 'all_fields', query: 'thesis' },
+        '1' => { field: 'creator', query: 'smith' }
+      }
+    )
+
+    expect(page).to have_current_path(/\/catalog\?/)
+    expect(page).to have_content('Smith thesis target')
+    expect(page).not_to have_content('Jones thesis decoy')
+  end
+
 end

--- a/spec/search_builders/hyc/catalog_search_builder_spec.rb
+++ b/spec/search_builders/hyc/catalog_search_builder_spec.rb
@@ -6,99 +6,88 @@ RSpec.describe Hyc::CatalogSearchBuilder do
   let(:context) { FakeSearchBuilderScope.new }
   let(:builder) { described_class.new(context).with(blacklight_params) }
   let(:solr_params) { Blacklight::Solr::Request.new }
+  let(:all_fields_edismax) { CatalogController.blacklight_config.search_fields['all_fields'].clause_params[:edismax] }
 
-  context 'with a user query from the regular search' do
-    let(:blacklight_params) { { q: user_query, search_field: 'all_fields' } }
-    let(:user_query) { 'find me' }
+  describe '#join_works_from_files' do
+    subject(:join_works_from_files) { builder.join_works_from_files(solr_params) }
 
-    subject { builder.show_works_or_works_that_contain_files(solr_params) }
+    context 'with a quoted all_fields basic search' do
+      let(:blacklight_params) { { q: '"Doctor of Nursing Practice"', search_field: 'all_fields' } }
 
-    context 'with a user query' do
-      it 'creates a valid solr join for works and files' do
-        subject
-        expect(solr_params[:user_query]).to eq user_query
-        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=member_ids_ssim}{!lucene q.op=AND}has_model_ssim:*FileSet{!dismax v=$user_query}"'
-      end
-    end
-
-    context 'joining with file_sets' do
-      let(:blacklight_params) do
-        {
-          search_field: 'advanced',
-          clause: { '0' => {field: 'all_fields', query: 'metalloprotease' } }
-        }
-      end
-
-      # Mock the JSON query that Blacklight would create
       before do
         solr_params[:json] = {
           query: {
             bool: {
               must: [{
-                edismax: {
-                  qf: 'title_tesim creator_label_tesim',
-                  pf: 'title_tesim',
-                  query: 'metalloprotease'
-                }
+                edismax: all_fields_edismax.merge(query: '"Doctor of Nursing Practice"')
               }]
             }
           }
         }
       end
 
-      subject { builder.join_works_from_files(solr_params) }
+      it 'replaces the all_fields clause with a nested OR query and preserves quoted phrases' do
+        join_works_from_files
 
-      it 'combines metadata and file text search with OR' do
-        subject
-        expect(solr_params[:q]).to eq '(_query_:"{!edismax qf=\'title_tesim creator_label_tesim\' pf=\'title_tesim\'}metalloprotease") OR ( _query_:"{!join from=id to=file_set_ids_ssim}{!dismax qf=all_text_timv}metalloprotease")'
+        clause = solr_params.dig(:json, :query, :bool, :must, 0)
+
+        expect(solr_params[:q]).to be_nil
+        expect(solr_params[:defType]).to be_nil
+        expect(clause.dig(:bool, :should, 0, :edismax, :query)).to eq '"Doctor of Nursing Practice"'
+        expect(clause.dig(:bool, :should, 1)).to include('\\"Doctor of Nursing Practice\\"')
       end
     end
 
-    context 'joining with unbalanced quote' do
+    context 'with an advanced search where all_fields is not the first clause' do
       let(:blacklight_params) do
         {
           search_field: 'advanced',
-          clause: { '0' => {field: 'all_fields', query: 'un"balanced' } }
+          clause: {
+            '0' => { field: 'creator', query: 'Smith' },
+            '1' => { field: 'all_fields', query: 'thesis' }
+          }
         }
       end
 
-      # Mock the JSON query that Blacklight would create
       before do
         solr_params[:json] = {
           query: {
             bool: {
-              must: [{
-                edismax: {
-                  qf: 'title_tesim creator_label_tesim',
-                  pf: 'title_tesim',
-                  query: 'un"balanced'
+              must: [
+                {
+                  edismax: {
+                    qf: 'creator_label_tesim',
+                    pf: 'creator_label_tesim',
+                    query: 'Smith'
+                  }
+                },
+                {
+                  edismax: all_fields_edismax.merge(query: 'thesis')
                 }
-              }]
+              ]
             }
           }
         }
       end
 
-      subject { builder.join_works_from_files(solr_params) }
+      it 'preserves the other advanced clauses and rewrites only the all_fields clause' do
+        join_works_from_files
 
-      it 'removes the unbalanced quote' do
-        subject
-        # Should not contain the unbalanced quote anywhere
-        expect(solr_params[:q]).not_to include('"balanced')
+        must_clauses = solr_params.dig(:json, :query, :bool, :must)
 
-        # Should contain the sanitized version (no quote)
-        expect(solr_params[:q]).to include('unbalanced')
-
-        # Verify it still has the OR structure
-        expect(solr_params[:q]).to include(') OR (')
+        expect(must_clauses.first.dig('edismax', 'query')).to eq('Smith')
+        expect(must_clauses.first.dig('edismax', 'qf')).to eq('creator_label_tesim')
+        expect(must_clauses.first.dig('edismax', 'pf')).to eq('creator_label_tesim')
+        expect(must_clauses.second.dig(:bool, :should, 0, :edismax, :query)).to eq('thesis')
+        expect(must_clauses.second.dig(:bool, :should, 1)).to include('thesis')
       end
     end
 
-    context 'joining with a quoted phrase' do
+    context 'with an advanced search using an unbalanced quote' do
       let(:blacklight_params) do
         {
           search_field: 'advanced',
-          clause: { '0' => { field: 'all_fields', query: '"Doctor of Nursing Practice"' } }
+          clause: { '0' => { field: 'all_fields', query: 'un"balanced' } }
         }
       end
 
@@ -107,23 +96,20 @@ RSpec.describe Hyc::CatalogSearchBuilder do
           query: {
             bool: {
               must: [{
-                edismax: {
-                  qf: 'title_tesim creator_label_tesim',
-                  pf: 'title_tesim',
-                  query: '"Doctor of Nursing Practice"'
-                }
+                edismax: all_fields_edismax.merge(query: 'un"balanced')
               }]
             }
           }
         }
       end
 
-      subject { builder.join_works_from_files(solr_params) }
+      it 'sanitizes the query before building the nested OR clause' do
+        join_works_from_files
 
-      it 'escapes embedded quotes so the combined local-param query stays valid' do
-        subject
+        clause = solr_params.dig(:json, :query, :bool, :must, 0)
 
-        expect(solr_params[:q]).to include('\\"Doctor of Nursing Practice\\"')
+        expect(clause.dig(:bool, :should, 0, :edismax, :query)).to eq('unbalanced')
+        expect(clause.dig(:bool, :should, 1)).to include('unbalanced')
       end
     end
   end

--- a/spec/search_builders/hyc/catalog_search_builder_spec.rb
+++ b/spec/search_builders/hyc/catalog_search_builder_spec.rb
@@ -93,6 +93,39 @@ RSpec.describe Hyc::CatalogSearchBuilder do
         expect(solr_params[:q]).to include(') OR (')
       end
     end
+
+    context 'joining with a quoted phrase' do
+      let(:blacklight_params) do
+        {
+          search_field: 'advanced',
+          clause: { '0' => { field: 'all_fields', query: '"Doctor of Nursing Practice"' } }
+        }
+      end
+
+      before do
+        solr_params[:json] = {
+          query: {
+            bool: {
+              must: [{
+                edismax: {
+                  qf: 'title_tesim creator_label_tesim',
+                  pf: 'title_tesim',
+                  query: '"Doctor of Nursing Practice"'
+                }
+              }]
+            }
+          }
+        }
+      end
+
+      subject { builder.join_works_from_files(solr_params) }
+
+      it 'escapes embedded quotes so the combined local-param query stays valid' do
+        subject
+
+        expect(solr_params[:q]).to include('\\"Doctor of Nursing Practice\\"')
+      end
+    end
   end
 
   class FakeSearchBuilderScope


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2226

* Escape nested quotes and backslashes in queries which were breaking lucene syntax when there were parameters after a quoted query
* Fix issues with full text searching that were causing advanced search fields to be ignored when all_fields was specified