### PR TITLE
HYC-2249 - Persistent Solr Connections

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,6 +85,9 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    # Use our repository class, since setting it in blacklight.yml does not cause it to be used for queries
+    config.repository_class = Hyc::PooledSolrRepository
+
     # Advanced search configuration
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
     config.advanced_search[:url_key] ||= 'advanced'

--- a/app/repositories/hyc/pooled_solr_repository.rb
+++ b/app/repositories/hyc/pooled_solr_repository.rb
@@ -11,7 +11,12 @@ module Hyc
     end
 
     def self.shared_connection(connection_config)
-      @shared_connection ||= build_raw_connection(connection_config)
+      # Ensure that each passenger processor gets its own connection rather than attempting to share
+      if @shared_connection.nil? || @shared_connection_pid != Process.pid
+        @shared_connection = build_raw_connection(connection_config)
+        @shared_connection_pid = Process.pid
+      end
+      @shared_connection
     end
 
     def self.build_raw_connection(connection_config)
@@ -25,7 +30,7 @@ module Hyc
           }
         ) do |conn|
           conn.request :retry,
-                      max: 2,
+                      max: 1,
                       interval: 0.05,
                       interval_randomness: 0.5,
                       backoff_factor: 2,

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,11 +1,11 @@
 development:
-  adapter: Hyc::PooledSolrRepository
+  adapter: solr
   url: <%= ENV['SOLR_DEV_URL'] %>
 test: &test
   adapter: solr
   url: <%= ENV['SOLR_TEST_URL'] %>
 production:
-  adapter: Hyc::PooledSolrRepository
+  adapter: solr
   url: <%= ENV['SOLR_PRODUCTION_URL'] %>
   open_timeout: <%= ENV.fetch('SOLR_OPEN_TIMEOUT', 2) %>
   timeout: <%= ENV.fetch('SOLR_TIMEOUT', 5) %>

--- a/config/initializers/active_fedora_solr_connection.rb
+++ b/config/initializers/active_fedora_solr_connection.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'faraday/net_http_persistent'
+
+Rails.application.config.after_initialize do
+  ActiveFedora.solr_config[:adapter] = :net_http_persistent
+  ActiveFedora.solr_config[:open_timeout] ||= ENV.fetch('SOLR_OPEN_TIMEOUT', 2).to_i
+  ActiveFedora.solr_config[:timeout] ||= ENV.fetch('SOLR_TIMEOUT', 5).to_i
+
+  # ActiveFedora caches a SolrService per thread, so clear any boot-time instance
+  # and let later calls rebuild it with the updated connection options.
+  ActiveFedora::SolrService.reset!
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe CatalogController, type: :controller do
       expect(blacklight_config.per_page).to eq([10, 20])
       expect(blacklight_config.default_per_page).to eq(10)
     end
+
+    it 'uses the pooled Solr repository for catalog searches' do
+      expect(blacklight_config.repository_class).to eq(Hyc::PooledSolrRepository)
+      expect(controller.send(:search_service).repository).to be_a(Hyc::PooledSolrRepository)
+    end
   end
 
   describe 'search result size parameter limits' do

--- a/spec/initializers/active_fedora_solr_connection_spec.rb
+++ b/spec/initializers/active_fedora_solr_connection_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ActiveFedora Solr connection initializer' do
+  around do |example|
+    ActiveFedora::SolrService.reset!
+    example.run
+    ActiveFedora::SolrService.reset!
+  end
+
+  it 'adds the persistent adapter and timeout options to ActiveFedora solr config' do
+    expect(ActiveFedora.solr_config).to include(
+      adapter: :net_http_persistent,
+      open_timeout: 2,
+      timeout: 5
+    )
+  end
+
+  it 'builds new SolrService instances with the persistent adapter settings' do
+    expect(ActiveFedora::SolrService.instance.options).to include(
+      adapter: :net_http_persistent,
+      open_timeout: 2,
+      timeout: 5
+    )
+  end
+end


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2249

* Explicitly use PooledSolrRepository in catalog controller so its actually used for requests, rather than being initialized and ignored.
    * Revert blacklight.yml
* Update ActiveFedora::SolrService to use persistent connections, since it accounts for about half the solr requests.