### PR TITLE
HYC-2251 - Reset advanced search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ build_log.txt
 /node_modules
 
 .github/copilot-instructions.md
+agents.md

--- a/app/components/blacklight/advanced_search_form_component.html.erb
+++ b/app/components/blacklight/advanced_search_form_component.html.erb
@@ -1,0 +1,58 @@
+<%# [hyc-override] https://github.com/projectblacklight/blacklight/blob/v7.41.0/app/components/blacklight/advanced_search_form_component.html.erb %>
+<% if constraints? %>
+  <div class="constraints well search_history">
+    <h4><%= t 'blacklight.advanced_search.form.search_context' %></h4>
+    <% constraints.each do |constraint| %>
+      <%= constraint %>
+    <% end %>
+  </div>
+<% end %>
+
+<%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(@params) %>
+
+  <div class="input-criteria">
+    <div class="query-criteria mb-4">
+      <h2 class="query-criteria-heading h3 mb-4">
+        <%= t('blacklight.advanced_search.form.query_criteria_heading_html', select_menu: default_operator_menu) %>
+      </h2>
+
+      <div id="advanced_search">
+        <% search_field_controls.each do |control| %>
+          <%= control %>
+        <% end %>
+      </div>
+    </div>
+
+    <% if search_filter_controls? %>
+      <div class="limit-criteria mb-4">
+        <h2 class="limit-criteria-heading h3"><%= t('blacklight.advanced_search.form.limit_criteria_heading_html') %></h2>
+
+        <div id="advanced_search_facets" class="limit_input row">
+          <div class="advanced-facet-limits panel-group col-md-9 offset-md-3">
+            <% search_filter_controls.each do |control| %>
+              <%= control %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <% if sort_fields_select %>
+    <div class="form-group row mb-4">
+      <%= content_tag :h2, t('blacklight.advanced_search.form.sort_label'), id: 'advanced-search-sort-label', class: 'col-md-3 text-md-right' %>
+      <div class="col-md-9">
+        <%= sort_fields_select %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="form-group row">
+    <div class="submit-buttons col-md-9 offset-md-3">
+      <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: 'advanced-search-submit' %>
+      <%# [hyc-override] Replace the reset button with a link to a blank form %>
+      <%= link_to t('blacklight.advanced_search.form.start_over_html'), helpers.search_action_path(action: 'advanced_search'), class: 'btn btn-link advanced-search-start-over' %>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -113,4 +113,17 @@ RSpec.describe 'Advanced search', type: :feature, js: false do
     expect(page).not_to have_content('Jones thesis decoy')
   end
 
+  it 'can start over from a prepopulated advanced search' do
+    visit '/catalog/advanced'
+    fill_in('All Fields', with: "smith")
+    click_button('Search')
+    click_link('Advanced search', match: :first)
+
+    expect(find_field('All Fields').value).to eq("smith")
+
+    click_link('Start over')
+
+    expect(page).to have_current_path(%r{/catalog/advanced(?:\?locale=en)?})
+    expect(find_field('All Fields').value).to be_blank
+  end
 end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -115,11 +115,11 @@ RSpec.describe 'Advanced search', type: :feature, js: false do
 
   it 'can start over from a prepopulated advanced search' do
     visit '/catalog/advanced'
-    fill_in('All Fields', with: "smith")
+    fill_in('All Fields', with: 'smith')
     click_button('Search')
     click_link('Advanced search', match: :first)
 
-    expect(find_field('All Fields').value).to eq("smith")
+    expect(find_field('All Fields').value).to eq('smith')
 
     click_link('Start over')
 


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/HYC-2251

* Override advanced search form in order to replace reset button with a link, which actually clears the form rather than resetting it to the values set at page load.